### PR TITLE
Local MLX serving: env-tunable concurrency, eval-harness overrides, memory-safe hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Hotkeys: `e/g/f/p` filter by tier, `1-5` filter by theme, `s` filter by sender, 
 2. **Safe defaults**: Unknown sender type → SERVICE (body goes to cloud, safe for non-person). Unknown email label → LOW_PRIORITY (archived, not deleted).
 3. **MLX degradation**: If local MLX is down, person emails are skipped (retried next cycle). Privacy invariant preserved.
 4. **No web server**: Pure asyncio daemon. Health check via file timestamp + Docker HEALTHCHECK.
-5. **Sequential processing**: Emails processed one at a time per poll cycle.
+5. **Bounded-concurrency processing**: Threads in a poll cycle are processed concurrently, bounded by the `cloud_parallel`/`local_parallel` semaphores. `local_parallel` defaults to 4 (env override: `LOCAL_PARALLEL`); modern MLX servers batch the concurrent local requests, so concurrency mostly costs KV cache, not weight memory. Keep it ≤ 8.
 
 ## Labels (must be pre-created in Gmail)
 
@@ -106,6 +106,8 @@ Hotkeys: `e/g/f/p` filter by tier, `1-5` filter by theme, `s` filter by sender, 
 - `MLX_MODEL` — Local LLM model name (shared with email-agent, referenced in config.toml as `{env.MLX_MODEL}`)
 - `MLX_API_KEY` — Local LLM API key (empty for real MLX, set for public API stand-ins like Novita.ai)
 - `NEWSLETTER_ONLY` — When `1`/`true`/`yes`, daemon runs newsletter classification pipeline instead of email labeling
+- `LOCAL_PARALLEL` — Override `local_parallel` (max concurrent local MLX requests; default 4, keep ≤ 8)
+- `MAX_EMAILS_PER_CYCLE` — Override `max_emails_per_cycle` (max threads per poll cycle; default 10)
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Hotkeys: `e/g/f/p` filter by tier, `1-5` filter by theme, `s` filter by sender, 
 - `MLX_MODEL` — Local LLM model name (shared with email-agent, referenced in config.toml as `{env.MLX_MODEL}`)
 - `MLX_API_KEY` — Local LLM API key (empty for real MLX, set for public API stand-ins like Novita.ai)
 - `NEWSLETTER_ONLY` — When `1`/`true`/`yes`, daemon runs newsletter classification pipeline instead of email labeling
-- `LOCAL_PARALLEL` — Override `local_parallel` (max concurrent local MLX requests; default 4, keep ≤ 8)
+- `LOCAL_PARALLEL` — Override `local_parallel` (max concurrent local MLX requests; default 1, keep ≤ 8)
 - `MAX_EMAILS_PER_CYCLE` — Override `max_emails_per_cycle` (max threads per poll cycle; default 10)
 
 ## Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Hotkeys: `e/g/f/p` filter by tier, `1-5` filter by theme, `s` filter by sender, 
 2. **Safe defaults**: Unknown sender type → SERVICE (body goes to cloud, safe for non-person). Unknown email label → LOW_PRIORITY (archived, not deleted).
 3. **MLX degradation**: If local MLX is down, person emails are skipped (retried next cycle). Privacy invariant preserved.
 4. **No web server**: Pure asyncio daemon. Health check via file timestamp + Docker HEALTHCHECK.
-5. **Bounded-concurrency processing**: Threads in a poll cycle are processed concurrently, bounded by the `cloud_parallel`/`local_parallel` semaphores. `local_parallel` defaults to 4 (env override: `LOCAL_PARALLEL`); modern MLX servers batch the concurrent local requests, so concurrency mostly costs KV cache, not weight memory. Keep it ≤ 8.
+5. **Bounded-concurrency processing**: Threads in a poll cycle are processed concurrently, bounded by the `cloud_parallel`/`local_parallel` semaphores. `local_parallel` defaults to **1** (env override: `LOCAL_PARALLEL`): each concurrent local request needs its own KV cache, and long transcripts make those multi-GB, so concurrent requests can exceed the GPU's Metal working set and OOM-crash the local server. Raise it only after confirming the model + N KV caches fit; keep ≤ 8. See README-technical "Local Model Serving & Memory".
 
 ## Labels (must be pre-created in Gmail)
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -72,6 +72,7 @@ gmail_query = "in:inbox -label:agent/processed"  # Gmail search query
 max_thread_chars = 16000       # Cap on transcript chars sent to the classifier
 cloud_parallel = 2             # Max concurrent cloud LLM requests
 local_parallel = 1             # Max concurrent local MLX requests (override: LOCAL_PARALLEL)
+fetch_parallel = 4             # Max concurrent Gmail thread fetches (get_thread)
 healthcheck_file = "/tmp/healthcheck"            # Healthcheck timestamp path
 ```
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -53,6 +53,8 @@ email-labeler/
 | `VIP_SENDERS` | No | — | Comma-separated email addresses of VIP senders. VIP threads skip the sender classification LLM call. |
 | `EMAIL_LABELER_API_KEY` | No | — | Fallback API key for the api-proxy server, used when `PROXY_API_KEY` is not set. |
 | `NEWSLETTER_ONLY` | No | — | Set to `1`, `true`, or `yes` to skip non-newsletter threads. Useful for testing newsletter classification in isolation. |
+| `LOCAL_PARALLEL` | No | `4` (from `config.toml`) | Max concurrent local MLX requests, overriding `local_parallel` in `config.toml`. Modern MLX servers batch these (shared weights), so concurrency mostly costs KV cache. Keep ≤ 8 — mlx-lm has a KV-cache cross-contamination bug at 16+. |
+| `MAX_EMAILS_PER_CYCLE` | No | `10` (from `config.toml`) | Max threads processed per poll cycle, overriding `max_emails_per_cycle` in `config.toml`. Raise temporarily to drain a large backlog faster. |
 
 Note: The cloud LLM **model name** is configured in `config.toml` under `[llm.cloud]`, not in `.env`. The local LLM **model name** is set via the `MLX_MODEL` environment variable (shared with email-agent) and referenced in `config.toml` as `{env.MLX_MODEL}`. This keeps secrets (keys, URLs) in `.env` while operational parameters (temperature, prompts) stay in version-controlled `config.toml`.
 
@@ -65,10 +67,20 @@ All operational parameters are in `config.toml`. The daemon reads this file on s
 ```toml
 [daemon]
 poll_interval_seconds = 60     # How often to poll Gmail
-max_emails_per_cycle = 10      # Max emails to process per poll
+max_emails_per_cycle = 10      # Max threads per poll (override: MAX_EMAILS_PER_CYCLE)
 gmail_query = "in:inbox -label:agent/processed"  # Gmail search query
+cloud_parallel = 2             # Max concurrent cloud LLM requests
+local_parallel = 4             # Max concurrent local MLX requests (override: LOCAL_PARALLEL)
 healthcheck_file = "/tmp/healthcheck"            # Healthcheck timestamp path
 ```
+
+Threads found in a poll cycle are processed concurrently, bounded by the
+`cloud_parallel` and `local_parallel` semaphores. `local_parallel` defaults to 4
+because modern MLX servers (mlx-lm 0.30.4+, LM Studio 0.4.2+) batch concurrent
+requests — weights are loaded once and shared, so only the per-request KV cache
+grows. Keep it ≤ 8 to avoid mlx-lm's KV-cache cross-contamination bug at 16+
+concurrent requests. Both `local_parallel` and `max_emails_per_cycle` can be
+overridden per run via the `LOCAL_PARALLEL` and `MAX_EMAILS_PER_CYCLE` env vars.
 
 ### LLM settings
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -53,7 +53,7 @@ email-labeler/
 | `VIP_SENDERS` | No | — | Comma-separated email addresses of VIP senders. VIP threads skip the sender classification LLM call. |
 | `EMAIL_LABELER_API_KEY` | No | — | Fallback API key for the api-proxy server, used when `PROXY_API_KEY` is not set. |
 | `NEWSLETTER_ONLY` | No | — | Set to `1`, `true`, or `yes` to skip non-newsletter threads. Useful for testing newsletter classification in isolation. |
-| `LOCAL_PARALLEL` | No | `4` (from `config.toml`) | Max concurrent local MLX requests, overriding `local_parallel` in `config.toml`. Modern MLX servers batch these (shared weights), so concurrency mostly costs KV cache. Keep ≤ 8 — mlx-lm has a KV-cache cross-contamination bug at 16+. |
+| `LOCAL_PARALLEL` | No | `1` (from `config.toml`) | Max concurrent local MLX requests, overriding `local_parallel` in `config.toml`. Modern MLX servers batch these (shared weights), so concurrency mostly costs KV cache. Keep ≤ 8 — mlx-lm has a KV-cache cross-contamination bug at 16+. |
 | `MAX_EMAILS_PER_CYCLE` | No | `10` (from `config.toml`) | Max threads processed per poll cycle, overriding `max_emails_per_cycle` in `config.toml`. Raise temporarily to drain a large backlog faster. |
 
 Note: The cloud LLM **model name** is configured in `config.toml` under `[llm.cloud]`, not in `.env`. The local LLM **model name** is set via the `MLX_MODEL` environment variable (shared with email-agent) and referenced in `config.toml` as `{env.MLX_MODEL}`. This keeps secrets (keys, URLs) in `.env` while operational parameters (temperature, prompts) stay in version-controlled `config.toml`.

--- a/README-technical.md
+++ b/README-technical.md
@@ -112,7 +112,7 @@ timeout = 60
 model = "{env.MLX_MODEL}"              # set MLX_MODEL in .env (shared with email-agent)
 max_tokens = 8096
 temperature = 0.2
-timeout = 120       # Local LLM gets more time (runs on consumer hardware)
+timeout = 180       # Local LLM gets more time (runs on consumer hardware)
 ```
 
 ### Extra request body fields

--- a/README-technical.md
+++ b/README-technical.md
@@ -69,18 +69,30 @@ All operational parameters are in `config.toml`. The daemon reads this file on s
 poll_interval_seconds = 60     # How often to poll Gmail
 max_emails_per_cycle = 10      # Max threads per poll (override: MAX_EMAILS_PER_CYCLE)
 gmail_query = "in:inbox -label:agent/processed"  # Gmail search query
+max_thread_chars = 16000       # Cap on transcript chars sent to the classifier
 cloud_parallel = 2             # Max concurrent cloud LLM requests
-local_parallel = 4             # Max concurrent local MLX requests (override: LOCAL_PARALLEL)
+local_parallel = 1             # Max concurrent local MLX requests (override: LOCAL_PARALLEL)
 healthcheck_file = "/tmp/healthcheck"            # Healthcheck timestamp path
 ```
 
 Threads found in a poll cycle are processed concurrently, bounded by the
-`cloud_parallel` and `local_parallel` semaphores. `local_parallel` defaults to 4
-because modern MLX servers (mlx-lm 0.30.4+, LM Studio 0.4.2+) batch concurrent
-requests — weights are loaded once and shared, so only the per-request KV cache
-grows. Keep it ≤ 8 to avoid mlx-lm's KV-cache cross-contamination bug at 16+
-concurrent requests. Both `local_parallel` and `max_emails_per_cycle` can be
-overridden per run via the `LOCAL_PARALLEL` and `MAX_EMAILS_PER_CYCLE` env vars.
+`cloud_parallel` and `local_parallel` semaphores. **`local_parallel` defaults to 1**:
+modern MLX servers do batch concurrent requests (weights loaded once, shared), but
+each concurrent request still needs its own KV cache, and long email transcripts
+make those caches multi-GB. On a memory-constrained Mac, a few concurrent
+long-transcript requests can exceed the GPU's Metal working set (~75% of unified
+memory) and OOM-crash the server. Raise `local_parallel` (via `LOCAL_PARALLEL`)
+only once you've confirmed the model plus N concurrent KV caches fit the GPU
+working set — tune the serving side too (`--prompt-cache-size`, and on macOS
+`sudo sysctl iogpu.wired_limit_mb=...`). Keep it ≤ 8 regardless (mlx-lm KV-cache
+cross-contamination bug at 16+). See [Local Model Serving & Memory](#local-model-serving--memory).
+
+`max_thread_chars` caps the transcript fed to the classifier. It's deliberately
+modest: the local model prefills the entire transcript before answering, so a
+50k-char thread can take minutes and exceed the local request timeout — which, on
+a stateless daemon, means the thread errors and is retried every cycle forever.
+`max_emails_per_cycle`, `local_parallel`, and (via config) the LLM `timeout` are
+the levers that keep a single huge thread from stalling the loop.
 
 ### LLM settings
 
@@ -137,6 +149,45 @@ The `[prompts.sender_classification]` and `[prompts.email_classification]` secti
 ### Label configuration
 
 All label names and their inbox/archive actions are defined in `config.toml` under `[labels]` and `[labels.actions]`. Newsletter labels live under `[newsletter.labels]`.
+
+## Local Model Serving & Memory
+
+Person-email bodies are classified by a local MLX model (`MLX_URL`), typically
+`mlx_lm.server`. On a memory-constrained Mac this is the most failure-prone part
+of the stack, and the failures are non-obvious, so they're documented here.
+
+### Starting the server
+
+```bash
+mlx_lm.server --model <mlx-model> --host 0.0.0.0 --port 8080 --temp 0 \
+  --decode-concurrency 8 --prompt-cache-size 2
+```
+
+- `--host 0.0.0.0` — required to reach the server from another machine (e.g. over Tailscale). The default `127.0.0.1` accepts only localhost; a remote connection to a localhost-bound server is **reset**, surfacing in the daemon as a connection error.
+- The request's `model` field must match the loaded `--model`, or mlx_lm.server returns `404 Not Found`. So `MLX_MODEL` must name the served model.
+- `--prompt-cache-size N` bounds how many past request KV caches are retained for reuse. The default (10) accumulates several GB of KV across distinct emails (which share no prefix) and can exhaust GPU memory; **2 is recommended** for this workload.
+- `--decode-concurrency` sizes the continuous-batching slots; it only matters when the daemon sends concurrent requests (`local_parallel` > 1).
+
+### The GPU memory ceiling (why it OOM-crashes)
+
+Apple Silicon caps the GPU's Metal working set at roughly **75% of unified memory** (~48 GB on a 64 GB Mac). Model weights + every live KV cache + prefill activation buffers must fit under that ceiling, not the full RAM. Exceeding it aborts the server:
+
+```
+[METAL] Command buffer execution failed: Insufficient Memory
+  (kIOGPUCommandBufferCallbackErrorOutOfMemory)  ... SIGABRT
+```
+
+A 27B model at 8-bit is ~34 GB, leaving only ~14 GB of headroom. Long transcripts have multi-GB KV caches, so a few concurrent long-transcript requests (or a large retained prompt cache) blow the ceiling. Mitigations, in order of preference:
+
+1. **Free system RAM** — leaked/idle processes shrink what the GPU can wire.
+2. **`local_parallel = 1`** (the default) — one live KV cache at a time.
+3. **`--prompt-cache-size 2`** — stop the retained cache piling up.
+4. **`max_thread_chars`** — cap prefill size (also bounds latency).
+5. **Raise the ceiling**: `sudo sysctl iogpu.wired_limit_mb=53248` (~52 GB on a 64 GB Mac; resets on reboot; don't starve macOS).
+
+### Prefill latency and the request timeout
+
+The model prefills the whole transcript before emitting a label, at ~100–200 tokens/sec on consumer hardware. A 50k-char (~17k-token) thread can take minutes — longer than `[llm.local] timeout` (default 180s) — so the client times out and the thread errors. On the stateless daemon that thread would otherwise be retried every cycle forever; **`max_thread_chars`** (cap the input) and the **`FailureTracker`** (give up after repeated failures, see `daemon.py`) are the two guards.
 
 ## Health Checking
 

--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,10 @@ cloud_parallel = 2
 # --prompt-cache-size, and/or raise iogpu.wired_limit_mb); keep it <= 8
 # (mlx-lm has a KV-cache cross-contamination bug at 16+ concurrent requests).
 local_parallel = 1
+# Max concurrent Gmail thread fetches (get_thread). Bounds the proxy-read burst
+# when max_emails_per_cycle is large; the cloud/local semaphores gate only the
+# downstream classify calls, not the fetch.
+fetch_parallel = 4
 healthcheck_file = "/tmp/healthcheck"
 
 [labels]

--- a/config.toml
+++ b/config.toml
@@ -2,14 +2,22 @@
 poll_interval_seconds = 60
 max_emails_per_cycle = 10       # Override per-run with the MAX_EMAILS_PER_CYCLE env var
 gmail_query = "in:inbox -label:agent/processed"
-max_thread_chars = 50000
+# Max characters of thread transcript sent to the classifier. Kept modest
+# because the local model prefills the WHOLE transcript before answering:
+# tens-of-thousands-of-char threads take minutes to prefill on consumer
+# hardware and can blow the local request timeout. Oldest messages are dropped
+# first when a thread exceeds this (see format_thread_transcript).
+max_thread_chars = 16000
 cloud_parallel = 2
-# Max concurrent local MLX requests. Modern MLX servers (mlx-lm 0.30.4+,
-# LM Studio 0.4.2+) batch these: weights are loaded once and shared across
-# requests, so only the per-request KV cache grows. Keep <= 8 — mlx-lm has a
-# KV-cache cross-contamination bug at 16+ concurrent requests. Override
-# per-run with the LOCAL_PARALLEL env var (e.g. to bump it for a backlog drain).
-local_parallel = 4
+# Max concurrent local MLX requests. Defaults to 1: each concurrent request
+# adds a full KV cache on top of the model weights, and long email transcripts
+# make those caches multi-GB. Concurrent long-transcript requests can exceed
+# the GPU's Metal working set (~75% of unified memory) and OOM-crash the
+# server. Raise it via the LOCAL_PARALLEL env var ONLY if the model plus N
+# concurrent KV caches fit the GPU working set (tune the server's
+# --prompt-cache-size, and/or raise iogpu.wired_limit_mb); keep it <= 8
+# (mlx-lm has a KV-cache cross-contamination bug at 16+ concurrent requests).
+local_parallel = 1
 healthcheck_file = "/tmp/healthcheck"
 
 [labels]

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,15 @@
 [daemon]
 poll_interval_seconds = 60
-max_emails_per_cycle = 10
+max_emails_per_cycle = 10       # Override per-run with the MAX_EMAILS_PER_CYCLE env var
 gmail_query = "in:inbox -label:agent/processed"
 max_thread_chars = 50000
 cloud_parallel = 2
-local_parallel = 1
+# Max concurrent local MLX requests. Modern MLX servers (mlx-lm 0.30.4+,
+# LM Studio 0.4.2+) batch these: weights are loaded once and shared across
+# requests, so only the per-request KV cache grows. Keep <= 8 — mlx-lm has a
+# KV-cache cross-contamination bug at 16+ concurrent requests. Override
+# per-run with the LOCAL_PARALLEL env var (e.g. to bump it for a backlog drain).
+local_parallel = 4
 healthcheck_file = "/tmp/healthcheck"
 
 [labels]

--- a/daemon.py
+++ b/daemon.py
@@ -41,6 +41,11 @@ logging.basicConfig(
 )
 log = logging.getLogger("email-labeler")
 
+# Default cap on transcript chars sent to the classifier when config.toml omits
+# max_thread_chars. Shared with the eval harness (evals/run_eval.py) so the two
+# never drift — an eval must truncate transcripts exactly as production does.
+DEFAULT_MAX_THREAD_CHARS = 16000
+
 
 def load_config() -> dict:
     """Load configuration from config.toml.
@@ -555,7 +560,7 @@ async def run_daemon() -> None:
             if threads:
                 log.info("Grouped into %d thread(s)", len(threads))
 
-            max_thread_chars = daemon_config.get("max_thread_chars", 16000)
+            max_thread_chars = daemon_config.get("max_thread_chars", DEFAULT_MAX_THREAD_CHARS)
             thread_items = list(threads.items())
             results = await asyncio.gather(
                 *(

--- a/daemon.py
+++ b/daemon.py
@@ -432,6 +432,29 @@ async def process_single_thread(
         return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager)
 
 
+def summarize_cycle(
+    thread_items: list[tuple[str, list[str]]],
+    results: list,
+    failure_tracker: FailureTracker,
+) -> tuple[int, list[str]]:
+    """Tally a poll cycle's outcomes and update the failure tracker.
+
+    A thread is "handled" when process_single_thread returned True (classified,
+    skipped at max priority, or given up — all return True); its failure count is
+    cleared. Drains the per-cycle give-up list and prunes counts for threads no
+    longer pending. Returns (handled_count, given_up_thread_ids); given_up is a
+    subset of the handled count (a give-up also returns True).
+    """
+    processed = 0
+    for (tid, _msg_ids), result in zip(thread_items, results):
+        if result is True:
+            processed += 1
+            failure_tracker.clear(tid)  # success/give-up resets the failure count
+    given_up = failure_tracker.take_given_up()
+    failure_tracker.prune(tid for tid, _msg_ids in thread_items)
+    return processed, given_up
+
+
 async def run_daemon() -> None:
     """Main polling loop."""
     config = load_config()
@@ -584,19 +607,11 @@ async def run_daemon() -> None:
                 ),
                 return_exceptions=True,
             )
-            processed = 0
-            for (tid, _msg_ids), result in zip(thread_items, results):
-                if result is True:
-                    processed += 1
-                    failure_tracker.clear(tid)  # success/give-up resets the failure count
-
-            given_up = failure_tracker.take_given_up()
-            # Keep the failure map bounded: drop counts for threads no longer pending.
-            failure_tracker.prune(threads)
+            processed, given_up = summarize_cycle(thread_items, results, failure_tracker)
             if threads:
                 if given_up:
                     log.info(
-                        "Processed %d/%d threads (%d abandoned after repeated failures: %s)",
+                        "Processed %d/%d threads (%d of them abandoned after repeated failures: %s)",
                         processed, len(threads), len(given_up), given_up,
                     )
                 else:

--- a/daemon.py
+++ b/daemon.py
@@ -95,6 +95,7 @@ class FailureTracker:
     def __init__(self, max_failures: int = 5):
         self.max_failures = max_failures
         self._counts: dict[str, int] = {}
+        self._given_up: list[str] = []  # threads abandoned since the last take_given_up()
 
     def record_failure(self, thread_id: str) -> None:
         self._counts[thread_id] = self._counts.get(thread_id, 0) + 1
@@ -104,6 +105,17 @@ class FailureTracker:
 
     def clear(self, thread_id: str) -> None:
         self._counts.pop(thread_id, None)
+
+    def record_give_up(self, thread_id: str) -> None:
+        """Record that a thread was abandoned (marked processed without a label),
+        so the per-cycle summary can report give-ups distinctly from classifications."""
+        self._given_up.append(thread_id)
+
+    def take_given_up(self) -> list[str]:
+        """Return the thread ids given up since the last call, resetting the list."""
+        out = self._given_up
+        self._given_up = []
+        return out
 
 
 async def _give_up_if_stuck(
@@ -132,6 +144,7 @@ async def _give_up_if_stuck(
     except Exception:
         log.exception("Could not mark stuck thread %s processed", thread_id)
         return False
+    failure_tracker.record_give_up(thread_id)
     failure_tracker.clear(thread_id)
     return True
 
@@ -559,8 +572,15 @@ async def run_daemon() -> None:
                     processed += 1
                     failure_tracker.clear(tid)  # success/give-up resets the failure count
 
+            given_up = failure_tracker.take_given_up()
             if threads:
-                log.info("Processed %d/%d threads", processed, len(threads))
+                if given_up:
+                    log.info(
+                        "Processed %d/%d threads (%d abandoned after repeated failures: %s)",
+                        processed, len(threads), len(given_up), given_up,
+                    )
+                else:
+                    log.info("Processed %d/%d threads", processed, len(threads))
 
             # Update healthcheck
             healthcheck_file.write_text(str(asyncio.get_event_loop().time()))

--- a/daemon.py
+++ b/daemon.py
@@ -157,7 +157,8 @@ async def _give_up_if_stuck(
         log.exception("Could not mark stuck thread %s processed", thread_id)
         return False
     failure_tracker.record_give_up(thread_id)
-    failure_tracker.clear(thread_id)
+    # Note: the poll loop clears the failure count on every True result (which a
+    # give-up returns), so the count is reset there — no need to clear it here too.
     return True
 
 

--- a/daemon.py
+++ b/daemon.py
@@ -53,6 +53,24 @@ def load_config() -> dict:
     return substitute_env_vars(config)
 
 
+def resolve_int_env(env_var: str, default: int) -> int:
+    """Return an int from *env_var* if set and valid, otherwise *default*.
+
+    Lets operators override numeric daemon settings (e.g. concurrency) per run
+    without editing config.toml. {env.VAR} substitution only works for string
+    config values, so numeric overrides are read here instead. An unparseable
+    value falls back to the default with a warning rather than crashing.
+    """
+    raw = os.environ.get(env_var, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        log.warning("Invalid %s=%r (expected an integer); using %d", env_var, raw, default)
+        return default
+
+
 def format_thread_transcript(messages: list[dict], max_chars: int) -> str:
     """Format Gmail messages into a chronological thread transcript.
 
@@ -356,8 +374,15 @@ async def run_daemon() -> None:
         log.info("Newsletter-only mode: non-newsletter threads will be skipped")
 
     cloud_sem = asyncio.Semaphore(daemon_config.get("cloud_parallel", 2))
-    local_sem = asyncio.Semaphore(daemon_config.get("local_parallel", 1))
+    local_parallel = resolve_int_env("LOCAL_PARALLEL", daemon_config.get("local_parallel", 4))
+    local_sem = asyncio.Semaphore(local_parallel)
     log.info("Concurrency limits: cloud=%d, local=%d", cloud_sem._value, local_sem._value)
+    if local_parallel > 8:
+        log.warning(
+            "local_parallel=%d exceeds 8 — some MLX servers exhibit KV-cache "
+            "cross-contamination at high concurrency (mlx-lm at 16+)",
+            local_parallel,
+        )
 
     # Wait for api-proxy to become available, then verify labels
     startup_backoff = 5
@@ -382,7 +407,7 @@ async def run_daemon() -> None:
     log.info("All labels verified. Starting poll loop.")
 
     poll_interval = daemon_config["poll_interval_seconds"]
-    max_emails = daemon_config["max_emails_per_cycle"]
+    max_emails = resolve_int_env("MAX_EMAILS_PER_CYCLE", daemon_config["max_emails_per_cycle"])
     gmail_query = daemon_config["gmail_query"]
     if newsletter_only and newsletter_recipient:
         gmail_query += f" to:{newsletter_recipient}"

--- a/daemon.py
+++ b/daemon.py
@@ -11,6 +11,7 @@ import logging
 import os
 import sys
 import tomllib
+from contextlib import nullcontext
 from pathlib import Path
 
 import httpx
@@ -188,6 +189,7 @@ async def process_single_thread(
     newsletter_output_file: str = "",
     newsletter_only: bool = False,
     failure_tracker: "FailureTracker | None" = None,
+    fetch_sem: asyncio.Semaphore | None = None,
 ) -> bool:
     """Process a single thread through the classification pipeline.
 
@@ -225,8 +227,11 @@ async def process_single_thread(
     # give-up exists to break never converges).
     ids_to_mark = msg_ids
     try:
-        # Fetch full thread (all messages in one API call)
-        thread_data = await proxy_client.get_thread(thread_id)
+        # Fetch full thread (all messages in one API call). Bounded by fetch_sem so
+        # a large max_emails_per_cycle can't burst one concurrent proxy read per
+        # thread (the cloud/local semaphores gate only the classify calls).
+        async with (fetch_sem or nullcontext()):
+            thread_data = await proxy_client.get_thread(thread_id)
         messages = thread_data.get("messages", [])
         if not messages:
             log.warning("Thread %s has no messages, skipping", thread_id)
@@ -459,7 +464,11 @@ async def run_daemon() -> None:
     cloud_sem = asyncio.Semaphore(daemon_config.get("cloud_parallel", 2))
     local_parallel = resolve_int_env("LOCAL_PARALLEL", daemon_config.get("local_parallel", 1))
     local_sem = asyncio.Semaphore(local_parallel)
-    log.info("Concurrency limits: cloud=%d, local=%d", cloud_sem._value, local_sem._value)
+    fetch_sem = asyncio.Semaphore(daemon_config.get("fetch_parallel", 4))
+    log.info(
+        "Concurrency limits: cloud=%d, local=%d, fetch=%d",
+        cloud_sem._value, local_sem._value, fetch_sem._value,
+    )
     if local_parallel > 8:
         log.warning(
             "local_parallel=%d exceeds 8 — some MLX servers exhibit KV-cache "
@@ -538,6 +547,7 @@ async def run_daemon() -> None:
                         newsletter_output_file=newsletter_output_file,
                         newsletter_only=newsletter_only,
                         failure_tracker=failure_tracker,
+                        fetch_sem=fetch_sem,
                     )
                     for tid, msg_ids in thread_items
                 ),

--- a/daemon.py
+++ b/daemon.py
@@ -106,6 +106,18 @@ class FailureTracker:
     def clear(self, thread_id: str) -> None:
         self._counts.pop(thread_id, None)
 
+    def prune(self, active_thread_ids) -> None:
+        """Drop failure counts for threads no longer pending.
+
+        A thread that fails a few times (below the give-up threshold) and then
+        disappears from the query — read, archived, or relabeled externally —
+        would otherwise leak its count for the daemon's lifetime. Pruning each
+        cycle to the still-pending set keeps the map bounded; a consecutively
+        failing thread reappears every cycle, so it is never pruned.
+        """
+        active = set(active_thread_ids)
+        self._counts = {tid: n for tid, n in self._counts.items() if tid in active}
+
     def record_give_up(self, thread_id: str) -> None:
         """Record that a thread was abandoned (marked processed without a label),
         so the per-cycle summary can report give-ups distinctly from classifications."""
@@ -573,6 +585,8 @@ async def run_daemon() -> None:
                     failure_tracker.clear(tid)  # success/give-up resets the failure count
 
             given_up = failure_tracker.take_given_up()
+            # Keep the failure map bounded: drop counts for threads no longer pending.
+            failure_tracker.prune(threads)
             if threads:
                 if given_up:
                     log.info(

--- a/daemon.py
+++ b/daemon.py
@@ -71,6 +71,60 @@ def resolve_int_env(env_var: str, default: int) -> int:
         return default
 
 
+class FailureTracker:
+    """Counts consecutive thread-specific failures to break infinite retry loops.
+
+    Only genuine processing failures are recorded — never transient
+    unavailability (a ConnectError when an LLM endpoint is down) — so an outage
+    doesn't cause threads to be given up. In-memory and session-scoped: counts
+    reset on daemon restart, so a thread that failed for a since-resolved reason
+    gets another chance after a restart.
+    """
+
+    def __init__(self, max_failures: int = 5):
+        self.max_failures = max_failures
+        self._counts: dict[str, int] = {}
+
+    def record_failure(self, thread_id: str) -> None:
+        self._counts[thread_id] = self._counts.get(thread_id, 0) + 1
+
+    def should_give_up(self, thread_id: str) -> bool:
+        return self._counts.get(thread_id, 0) >= self.max_failures
+
+    def clear(self, thread_id: str) -> None:
+        self._counts.pop(thread_id, None)
+
+
+async def _give_up_if_stuck(
+    thread_id: str,
+    msg_ids: list[str],
+    failure_tracker: "FailureTracker | None",
+    label_manager: LabelManager,
+) -> bool:
+    """Record a thread-specific failure; if it has failed too many times, mark it
+    processed so it stops being retried every cycle.
+
+    Returns True if the thread was given up (marked processed → handled), or False
+    if it should simply be retried next cycle.
+    """
+    if failure_tracker is None:
+        return False
+    failure_tracker.record_failure(thread_id)
+    if not failure_tracker.should_give_up(thread_id):
+        return False
+    log.error(
+        "Thread %s failed %d+ times — marking processed to break the retry loop",
+        thread_id, failure_tracker.max_failures,
+    )
+    try:
+        await label_manager.mark_processed(msg_ids)
+    except Exception:
+        log.exception("Could not mark stuck thread %s processed", thread_id)
+        return False
+    failure_tracker.clear(thread_id)
+    return True
+
+
 def format_thread_transcript(messages: list[dict], max_chars: int) -> str:
     """Format Gmail messages into a chronological thread transcript.
 
@@ -123,6 +177,7 @@ async def process_single_thread(
     newsletter_recipient: str = "",
     newsletter_output_file: str = "",
     newsletter_only: bool = False,
+    failure_tracker: "FailureTracker | None" = None,
 ) -> bool:
     """Process a single thread through the classification pipeline.
 
@@ -300,17 +355,19 @@ async def process_single_thread(
         return True
 
     except httpx.ConnectError as exc:
+        # Endpoint unreachable (e.g. local MLX down) — transient. Don't count it
+        # toward give-up; just retry next cycle (preserves graceful degradation).
         log.warning("Connection error processing thread %s: %s", thread_id, exc)
         return False
     except TimeoutError as exc:
         log.error("Timeout processing thread %s: %s", thread_id, exc)
-        return False
+        return await _give_up_if_stuck(thread_id, msg_ids, failure_tracker, label_manager)
     except RuntimeError as exc:
         log.error("Thread %s: %s", thread_id, exc)
-        return False
+        return await _give_up_if_stuck(thread_id, msg_ids, failure_tracker, label_manager)
     except Exception:
         log.exception("Error processing thread %s", thread_id)
-        return False
+        return await _give_up_if_stuck(thread_id, msg_ids, failure_tracker, label_manager)
 
 
 async def run_daemon() -> None:
@@ -374,7 +431,7 @@ async def run_daemon() -> None:
         log.info("Newsletter-only mode: non-newsletter threads will be skipped")
 
     cloud_sem = asyncio.Semaphore(daemon_config.get("cloud_parallel", 2))
-    local_parallel = resolve_int_env("LOCAL_PARALLEL", daemon_config.get("local_parallel", 4))
+    local_parallel = resolve_int_env("LOCAL_PARALLEL", daemon_config.get("local_parallel", 1))
     local_sem = asyncio.Semaphore(local_parallel)
     log.info("Concurrency limits: cloud=%d, local=%d", cloud_sem._value, local_sem._value)
     if local_parallel > 8:
@@ -383,6 +440,11 @@ async def run_daemon() -> None:
             "cross-contamination at high concurrency (mlx-lm at 16+)",
             local_parallel,
         )
+
+    # Breaks infinite retry loops: a thread that keeps failing for a
+    # thread-specific reason (not a transient outage) is marked processed after
+    # a few attempts. Session-scoped — counts reset on restart.
+    failure_tracker = FailureTracker()
 
     # Wait for api-proxy to become available, then verify labels
     startup_backoff = 5
@@ -432,7 +494,8 @@ async def run_daemon() -> None:
             if threads:
                 log.info("Grouped into %d thread(s)", len(threads))
 
-            max_thread_chars = daemon_config.get("max_thread_chars", 50000)
+            max_thread_chars = daemon_config.get("max_thread_chars", 16000)
+            thread_items = list(threads.items())
             results = await asyncio.gather(
                 *(
                     process_single_thread(
@@ -448,12 +511,17 @@ async def run_daemon() -> None:
                         newsletter_recipient=newsletter_recipient,
                         newsletter_output_file=newsletter_output_file,
                         newsletter_only=newsletter_only,
+                        failure_tracker=failure_tracker,
                     )
-                    for tid, msg_ids in threads.items()
+                    for tid, msg_ids in thread_items
                 ),
                 return_exceptions=True,
             )
-            processed = sum(r for r in results if r is True)
+            processed = 0
+            for (tid, _msg_ids), result in zip(thread_items, results):
+                if result is True:
+                    processed += 1
+                    failure_tracker.clear(tid)  # success/give-up resets the failure count
 
             if threads:
                 log.info("Processed %d/%d threads", processed, len(threads))

--- a/daemon.py
+++ b/daemon.py
@@ -20,7 +20,7 @@ from classifier import EmailClassifier, EmailLabel, SenderType, ThreadMetadata
 from config_utils import substitute_env_vars
 from gmail_utils import decode_body, get_header
 from labeler import LabelManager, _get_priority
-from llm_client import LLMClient
+from llm_client import LLMClient, LLMUnavailableError
 from newsletter import NewsletterClassifier, NewsletterTier, is_newsletter, write_assessment
 from proxy_client import GmailProxyClient
 
@@ -53,22 +53,32 @@ def load_config() -> dict:
     return substitute_env_vars(config)
 
 
-def resolve_int_env(env_var: str, default: int) -> int:
+def resolve_int_env(env_var: str, default: int, minimum: int = 1) -> int:
     """Return an int from *env_var* if set and valid, otherwise *default*.
 
     Lets operators override numeric daemon settings (e.g. concurrency) per run
     without editing config.toml. {env.VAR} substitution only works for string
-    config values, so numeric overrides are read here instead. An unparseable
-    value falls back to the default with a warning rather than crashing.
+    config values, so numeric overrides are read here instead.
+
+    A value that is unparseable OR below *minimum* falls back to the default with
+    a warning rather than crashing. The lower bound matters: these values feed
+    asyncio.Semaphore() and Gmail maxResults, where 0 deadlocks the poll loop and
+    a negative crashes the daemon at startup.
     """
     raw = os.environ.get(env_var, "").strip()
     if not raw:
         return default
     try:
-        return int(raw)
+        value = int(raw)
     except ValueError:
         log.warning("Invalid %s=%r (expected an integer); using %d", env_var, raw, default)
         return default
+    if value < minimum:
+        log.warning(
+            "%s=%d is below the minimum of %d; using %d", env_var, value, minimum, default
+        )
+        return default
+    return value
 
 
 class FailureTracker:
@@ -208,6 +218,12 @@ async def process_single_thread(
         True if the thread was successfully classified and labeled,
         False if skipped or errored.
     """
+    # Messages to mark processed if we give up. Starts as the query stubs (all we
+    # know before fetching); upgraded to the full message list once the thread is
+    # fetched, so a give-up marks every message and the thread stops re-matching
+    # the query (otherwise unmarked siblings re-surface it and the retry loop the
+    # give-up exists to break never converges).
+    ids_to_mark = msg_ids
     try:
         # Fetch full thread (all messages in one API call)
         thread_data = await proxy_client.get_thread(thread_id)
@@ -223,6 +239,7 @@ async def process_single_thread(
         if newsletter_classifier and newsletter_recipient:
             if is_newsletter(messages, newsletter_recipient):
                 all_msg_ids = [msg["id"] for msg in messages]
+                ids_to_mark = all_msg_ids
                 first_headers = messages[0]["payload"]["headers"]
                 subject = get_header(first_headers, "Subject")
                 sender = get_header(first_headers, "From")
@@ -286,6 +303,7 @@ async def process_single_thread(
 
         # Collect all message IDs (thread may have more messages than query returned)
         all_msg_ids = [msg["id"] for msg in messages]
+        ids_to_mark = all_msg_ids
 
         # Extract unique senders (preserve order)
         senders = []
@@ -354,20 +372,28 @@ async def process_single_thread(
         log.debug("Thread %s CoT — label: %s", thread_id, result.label_cot)
         return True
 
+    except LLMUnavailableError as exc:
+        # LLM endpoint unreachable or dropped mid-request (server down, connect
+        # timeout, reset) — transient. Don't count it toward give-up; just retry
+        # next cycle (preserves graceful degradation of the privacy invariant).
+        log.warning("LLM unavailable processing thread %s: %s", thread_id, exc)
+        return False
     except httpx.ConnectError as exc:
-        # Endpoint unreachable (e.g. local MLX down) — transient. Don't count it
-        # toward give-up; just retry next cycle (preserves graceful degradation).
+        # Proxy/endpoint unreachable — transient. Retry next cycle, don't give up.
         log.warning("Connection error processing thread %s: %s", thread_id, exc)
         return False
     except TimeoutError as exc:
+        # Request-specific slowness (e.g. a transcript too large to prefill within
+        # the timeout) — eligible for give-up so one huge thread can't be retried
+        # forever. (Connect/pool timeouts are LLMUnavailableError, handled above.)
         log.error("Timeout processing thread %s: %s", thread_id, exc)
-        return await _give_up_if_stuck(thread_id, msg_ids, failure_tracker, label_manager)
+        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager)
     except RuntimeError as exc:
         log.error("Thread %s: %s", thread_id, exc)
-        return await _give_up_if_stuck(thread_id, msg_ids, failure_tracker, label_manager)
+        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager)
     except Exception:
         log.exception("Error processing thread %s", thread_id)
-        return await _give_up_if_stuck(thread_id, msg_ids, failure_tracker, label_manager)
+        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager)
 
 
 async def run_daemon() -> None:

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -49,6 +49,8 @@ Complete CLI flag references, cache internals, and chain-of-thought capture deta
 | `--local-temperature` | Override local LLM temperature (alias: `--local-temp`) |
 | `--cloud-max-tokens` | Override cloud LLM max tokens from config |
 | `--local-max-tokens` | Override local LLM max tokens from config |
+| `--cloud-timeout` | Override cloud LLM request timeout in seconds (for slow prefills on long inputs) |
+| `--local-timeout` | Override local LLM request timeout in seconds (for slow prefills on long inputs) |
 | `--cloud-extra-body` | JSON object merged into every cloud LLM request body (e.g. `'{"top_p": 0.9}'`) |
 | `--local-extra-body` | JSON object merged into every local LLM request body (e.g. `'{"chat_template_kwargs": {"enable_thinking": false}}'`) |
 | `--cloud-no-think` | Disable thinking for the cloud LLM (shortcut for `--cloud-extra-body '{"chat_template_kwargs": {"enable_thinking": false}}'`) |

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -49,6 +49,33 @@ Complete CLI flag references, cache internals, and chain-of-thought capture deta
 | `--local-temperature` | Override local LLM temperature (alias: `--local-temp`) |
 | `--cloud-max-tokens` | Override cloud LLM max tokens from config |
 | `--local-max-tokens` | Override local LLM max tokens from config |
+| `--cloud-extra-body` | JSON object merged into every cloud LLM request body (e.g. `'{"top_p": 0.9}'`) |
+| `--local-extra-body` | JSON object merged into every local LLM request body (e.g. `'{"chat_template_kwargs": {"enable_thinking": false}}'`) |
+| `--cloud-no-think` | Disable thinking for the cloud LLM (shortcut for `--cloud-extra-body '{"chat_template_kwargs": {"enable_thinking": false}}'`) |
+| `--local-no-think` | Disable thinking for the local LLM (shortcut for `--local-extra-body '{"chat_template_kwargs": {"enable_thinking": false}}'`) |
+
+#### A/B testing thinking on vs. off
+
+The local model (person-body label classification) is a reasoning model by
+default. To measure the accuracy impact of disabling thinking before changing
+`config.toml`, run two evaluations and compare:
+
+```bash
+# Baseline (thinking on, from config) — person threads only
+uv run python -m evals.run_eval --stages stage2_only --sender-type person --tag think-on
+
+# Thinking off
+uv run python -m evals.run_eval --stages stage2_only --sender-type person \
+    --local-no-think --tag think-off
+
+uv run python -m evals.report --compare evals/results/<think-on>.jsonl evals/results/<think-off>.jsonl
+```
+
+Because `extra_body` is part of the cache key, the two runs are cached
+independently — no `--no-cache` needed. The exact disable payload is
+server-specific; `--local-no-think` uses the `chat_template_kwargs` form
+(Qwen3 / LM Studio). If your server expects a top-level flag instead, pass it
+explicitly, e.g. `--local-extra-body '{"enable_thinking": false}'`.
 
 ### report
 

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -24,7 +24,7 @@ import httpx
 
 from classifier import EmailClassifier, SenderType, ThreadMetadata
 from config_utils import substitute_env_vars
-from daemon import format_thread_transcript
+from daemon import DEFAULT_MAX_THREAD_CHARS, format_thread_transcript
 from evals import format_network_error
 from evals.llm_cache import CachedLLMClient
 from evals.schemas import GoldenThread, PredictionResult, RunMeta, ThinkingEntry
@@ -39,6 +39,15 @@ def resolve_parallelism(cli_value: int | None, config: dict) -> int:
     if cli_value is not None:
         return cli_value
     return config.get("daemon", {}).get("cloud_parallel", 1)
+
+
+def resolve_max_thread_chars(config: dict) -> int:
+    """Transcript char cap: config value if present, else the shared daemon default.
+
+    Uses DEFAULT_MAX_THREAD_CHARS (imported from daemon) so an eval run truncates
+    transcripts exactly as production does, even for a config that omits the key.
+    """
+    return config.get("daemon", {}).get("max_thread_chars", DEFAULT_MAX_THREAD_CHARS)
 
 
 def resolve_extra_body(base: dict | None, no_think: bool, override_json: str | None) -> dict | None:
@@ -399,7 +408,7 @@ async def main(args: argparse.Namespace) -> None:
 
     classifier = EmailClassifier(cloud_llm=cloud_llm, local_llm=local_llm, config=config)
 
-    max_thread_chars = config.get("daemon", {}).get("max_thread_chars", 50000)
+    max_thread_chars = resolve_max_thread_chars(config)
 
     # Run evaluation — flush cache even if something fails after evaluation
     try:

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -72,6 +72,25 @@ def resolve_extra_body(base: dict | None, no_think: bool, override_json: str | N
     return result or None
 
 
+def apply_config_overrides(config: dict, args: argparse.Namespace) -> None:
+    """Apply CLI model/temperature/max_tokens/timeout overrides onto *config* in place.
+
+    A CLI value of None means "not provided" and leaves the config value intact.
+    0 / 0.0 are valid overrides (e.g. temperature 0), so the guard is `is not None`,
+    not truthiness.
+    """
+    overrides = {
+        "cloud": {"model": args.cloud_model, "temperature": args.cloud_temperature,
+                  "max_tokens": args.cloud_max_tokens, "timeout": args.cloud_timeout},
+        "local": {"model": args.local_model, "temperature": args.local_temperature,
+                  "max_tokens": args.local_max_tokens, "timeout": args.local_timeout},
+    }
+    for section, fields in overrides.items():
+        for key, value in fields.items():
+            if value is not None:
+                config["llm"][section][key] = value
+
+
 def load_golden_set(path: Path, reviewed_only: bool = False) -> list[GoldenThread]:
     """Load golden set from JSONL."""
     threads = []
@@ -309,16 +328,7 @@ async def main(args: argparse.Namespace) -> None:
     args.parallelism = resolve_parallelism(args.parallelism, config)
 
     # Apply CLI overrides to config (CLI always wins over config file)
-    _overrides = {
-        "cloud": {"model": args.cloud_model, "temperature": args.cloud_temperature,
-                  "max_tokens": args.cloud_max_tokens},
-        "local": {"model": args.local_model, "temperature": args.local_temperature,
-                  "max_tokens": args.local_max_tokens},
-    }
-    for section, fields in _overrides.items():
-        for key, value in fields.items():
-            if value is not None:
-                config["llm"][section][key] = value
+    apply_config_overrides(config, args)
 
     # Merge extra_body overrides (thinking toggles, provider-specific params).
     # Cache keys include extra_body, so thinking-on vs -off runs don't collide.
@@ -496,6 +506,8 @@ def cli():
                         help="Override local LLM temperature")
     parser.add_argument("--cloud-max-tokens", type=int, help="Override cloud LLM max tokens")
     parser.add_argument("--local-max-tokens", type=int, help="Override local LLM max tokens")
+    parser.add_argument("--cloud-timeout", type=int, help="Override cloud LLM request timeout (seconds)")
+    parser.add_argument("--local-timeout", type=int, help="Override local LLM request timeout (seconds)")
     parser.add_argument("--cloud-extra-body",
                         help="JSON object merged into every cloud LLM request body")
     parser.add_argument("--local-extra-body",

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -82,22 +82,42 @@ def resolve_extra_body(base: dict | None, no_think: bool, override_json: str | N
 
 
 def apply_config_overrides(config: dict, args: argparse.Namespace) -> None:
-    """Apply CLI model/temperature/max_tokens/timeout overrides onto *config* in place.
+    """Apply all CLI overrides onto *config* in place (CLI always wins over config).
 
-    A CLI value of None means "not provided" and leaves the config value intact.
-    0 / 0.0 are valid overrides (e.g. temperature 0), so the guard is `is not None`,
-    not truthiness.
+    Covers the model/temperature/max_tokens/timeout scalars and extra_body
+    (thinking toggles / provider-specific params) in one pass, so all CLI->config
+    plumbing lives in a single tested function.
+
+    A scalar CLI value of None means "not provided" and leaves the config value
+    intact; 0 / 0.0 are valid overrides (e.g. temperature 0), so the guard is
+    `is not None`, not truthiness. extra_body is merged via resolve_extra_body
+    (the eval cache key includes extra_body, so thinking-on vs -off runs don't
+    collide).
+
+    Raises:
+        ValueError: if a --*-extra-body value is not a valid JSON object.
     """
-    overrides = {
+    scalars = {
         "cloud": {"model": args.cloud_model, "temperature": args.cloud_temperature,
                   "max_tokens": args.cloud_max_tokens, "timeout": args.cloud_timeout},
         "local": {"model": args.local_model, "temperature": args.local_temperature,
                   "max_tokens": args.local_max_tokens, "timeout": args.local_timeout},
     }
-    for section, fields in overrides.items():
+    for section, fields in scalars.items():
         for key, value in fields.items():
             if value is not None:
                 config["llm"][section][key] = value
+
+    extra_body = {
+        "cloud": (args.cloud_no_think, args.cloud_extra_body),
+        "local": (args.local_no_think, args.local_extra_body),
+    }
+    for section, (no_think, eb_json) in extra_body.items():
+        resolved = resolve_extra_body(
+            config["llm"][section].get("extra_body"), no_think, eb_json,
+        )
+        if resolved is not None:
+            config["llm"][section]["extra_body"] = resolved
 
 
 def load_golden_set(path: Path, reviewed_only: bool = False) -> list[GoldenThread]:
@@ -336,22 +356,10 @@ async def main(args: argparse.Namespace) -> None:
     # Resolve parallelism: CLI wins, otherwise fall back to config
     args.parallelism = resolve_parallelism(args.parallelism, config)
 
-    # Apply CLI overrides to config (CLI always wins over config file)
-    apply_config_overrides(config, args)
-
-    # Merge extra_body overrides (thinking toggles, provider-specific params).
-    # Cache keys include extra_body, so thinking-on vs -off runs don't collide.
-    _eb_overrides = {
-        "cloud": (args.cloud_no_think, args.cloud_extra_body),
-        "local": (args.local_no_think, args.local_extra_body),
-    }
+    # Apply CLI overrides to config (CLI always wins over config file). extra_body
+    # parsing can fail on bad JSON, so surface that as a clean exit.
     try:
-        for section, (no_think, eb_json) in _eb_overrides.items():
-            resolved = resolve_extra_body(
-                config["llm"][section].get("extra_body"), no_think, eb_json,
-            )
-            if resolved is not None:
-                config["llm"][section]["extra_body"] = resolved
+        apply_config_overrides(config, args)
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(2)

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -41,6 +41,37 @@ def resolve_parallelism(cli_value: int | None, config: dict) -> int:
     return config.get("daemon", {}).get("cloud_parallel", 1)
 
 
+def resolve_extra_body(base: dict | None, no_think: bool, override_json: str | None) -> dict | None:
+    """Merge CLI extra_body overrides onto one LLM's config extra_body.
+
+    Precedence (later wins):
+      1. config's existing extra_body (*base*)
+      2. --no-think -> sets chat_template_kwargs.enable_thinking = False
+      3. --extra-body JSON object (its keys override the above)
+
+    Returns the merged dict, or None when nothing is set (so the LLMClient keeps
+    its default). The eval cache key includes extra_body, so thinking-on vs
+    thinking-off runs never collide in the cache. Does not mutate *base*.
+
+    Raises:
+        ValueError: if override_json is not a valid JSON object.
+    """
+    result = dict(base) if base else {}
+    if no_think:
+        ctk = dict(result.get("chat_template_kwargs") or {})
+        ctk["enable_thinking"] = False
+        result["chat_template_kwargs"] = ctk
+    if override_json:
+        try:
+            override = json.loads(override_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid --extra-body JSON: {exc}") from exc
+        if not isinstance(override, dict):
+            raise ValueError("--extra-body must be a JSON object")
+        result.update(override)
+    return result or None
+
+
 def load_golden_set(path: Path, reviewed_only: bool = False) -> list[GoldenThread]:
     """Load golden set from JSONL."""
     threads = []
@@ -289,6 +320,23 @@ async def main(args: argparse.Namespace) -> None:
             if value is not None:
                 config["llm"][section][key] = value
 
+    # Merge extra_body overrides (thinking toggles, provider-specific params).
+    # Cache keys include extra_body, so thinking-on vs -off runs don't collide.
+    _eb_overrides = {
+        "cloud": (args.cloud_no_think, args.cloud_extra_body),
+        "local": (args.local_no_think, args.local_extra_body),
+    }
+    try:
+        for section, (no_think, eb_json) in _eb_overrides.items():
+            resolved = resolve_extra_body(
+                config["llm"][section].get("extra_body"), no_think, eb_json,
+            )
+            if resolved is not None:
+                config["llm"][section]["extra_body"] = resolved
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
     # Load golden set
     golden_path = Path(args.golden_set)
     golden_set = load_golden_set(golden_path, reviewed_only=not args.include_unreviewed)
@@ -448,6 +496,17 @@ def cli():
                         help="Override local LLM temperature")
     parser.add_argument("--cloud-max-tokens", type=int, help="Override cloud LLM max tokens")
     parser.add_argument("--local-max-tokens", type=int, help="Override local LLM max tokens")
+    parser.add_argument("--cloud-extra-body",
+                        help="JSON object merged into every cloud LLM request body")
+    parser.add_argument("--local-extra-body",
+                        help='JSON object merged into every local LLM request body '
+                             '(e.g. \'{"chat_template_kwargs": {"enable_thinking": false}}\')')
+    parser.add_argument("--cloud-no-think", action="store_true",
+                        help="Disable thinking for the cloud LLM "
+                             "(sets chat_template_kwargs.enable_thinking=false)")
+    parser.add_argument("--local-no-think", action="store_true",
+                        help="Disable thinking for the local LLM "
+                             "(sets chat_template_kwargs.enable_thinking=false)")
     args = parser.parse_args()
 
     if args.stages not in VALID_STAGES:

--- a/llm_client.py
+++ b/llm_client.py
@@ -11,6 +11,16 @@ import httpx
 from retry import retry_with_backoff
 
 
+class LLMUnavailableError(Exception):
+    """The LLM endpoint is unreachable or dropped the connection (transient).
+
+    Distinct from request-specific failures: a non-200 response or a read/write
+    timeout means the *request* is the problem (too-large input, bad payload) and
+    is eligible for the daemon's give-up logic, whereas an unavailable endpoint is
+    a transient outage that should simply be retried next cycle.
+    """
+
+
 class LLMClient:
     """Client for OpenAI-compatible chat completion endpoints."""
 
@@ -51,8 +61,12 @@ class LLMClient:
             If include_thinking is True: (stripped_response, thinking_content) tuple.
 
         Raises:
+            TimeoutError: If the request times out (read/write) — request-specific
+                (e.g. input too large to prefill within the timeout).
+            LLMUnavailableError: If the endpoint is unreachable (connection refused
+                or connect/pool timeout) or the connection drops mid-request —
+                transient unavailability.
             RuntimeError: If the LLM returns a non-200 response.
-            httpx.ConnectError: If the server is unreachable.
         """
         headers = {"Content-Type": "application/json"}
         if self.api_key:
@@ -79,20 +93,29 @@ class LLMClient:
 
         try:
             response = await retry_with_backoff(_do_request, f"LLM {self.model}")
+        except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout) as exc:
+            # Couldn't establish a connection (server down / unreachable / pool
+            # exhausted). This is endpoint *unavailability*, not a problem with this
+            # request, so callers retry next cycle and never count it toward giving
+            # up on a thread. NOTE: ConnectTimeout/PoolTimeout subclass
+            # TimeoutException, so they must be caught before the timeout clause.
+            raise LLMUnavailableError(
+                f"LLM endpoint {self.model} unavailable ({type(exc).__name__}): {exc}"
+            ) from exc
         except httpx.TimeoutException:
+            # Connection established but the response was too slow (read/write
+            # timeout) — request-specific (e.g. a transcript too large to prefill
+            # within the timeout). Surfaced as TimeoutError so the daemon may give
+            # up on one oversized thread rather than retry it forever.
             raise TimeoutError(
                 f"LLM request to {self.model} timed out after {self.timeout}s"
             ) from None
-        except httpx.ConnectError:
-            # Couldn't establish a connection (server down) — let callers handle
-            # this as "endpoint unavailable" (the daemon skips + retries next cycle).
-            raise
         except httpx.TransportError as exc:
             # Connection established then dropped/reset mid-request (ReadError,
-            # WriteError, RemoteProtocolError, ...). Surface it as an informative
-            # error; some of these stringify to "" and would otherwise look like a
-            # silent empty result downstream.
-            raise RuntimeError(
+            # WriteError, RemoteProtocolError, ...): the server crashed, restarted,
+            # or flapped — an availability event, also transient. (Some of these
+            # stringify to ""; the wrapper guarantees an informative, non-empty msg.)
+            raise LLMUnavailableError(
                 f"LLM connection to {self.model} dropped ({type(exc).__name__}): {exc}"
             ) from exc
 

--- a/llm_client.py
+++ b/llm_client.py
@@ -83,6 +83,18 @@ class LLMClient:
             raise TimeoutError(
                 f"LLM request to {self.model} timed out after {self.timeout}s"
             ) from None
+        except httpx.ConnectError:
+            # Couldn't establish a connection (server down) — let callers handle
+            # this as "endpoint unavailable" (the daemon skips + retries next cycle).
+            raise
+        except httpx.TransportError as exc:
+            # Connection established then dropped/reset mid-request (ReadError,
+            # WriteError, RemoteProtocolError, ...). Surface it as an informative
+            # error; some of these stringify to "" and would otherwise look like a
+            # silent empty result downstream.
+            raise RuntimeError(
+                f"LLM connection to {self.model} dropped ({type(exc).__name__}): {exc}"
+            ) from exc
 
         if response.status_code != 200:
             prompt_chars = len(system_prompt) + len(user_content)

--- a/llm_client.py
+++ b/llm_client.py
@@ -46,6 +46,19 @@ class LLMClient:
         """Check if model uses GLM-style reasoning_content instead of inline think tags."""
         return "glm" in self.model.lower()
 
+    def _extra_body_disables_thinking(self) -> bool:
+        """True if extra_body asks to turn thinking off.
+
+        Recognizes both the chat_template_kwargs.enable_thinking form (Qwen / LM
+        Studio, what --no-think emits) and a top-level enable_thinking flag. GLM
+        ignores those fields, so complete() uses this to set GLM's native thinking
+        field to disabled rather than contradicting the request with enabled.
+        """
+        ctk = self.extra_body.get("chat_template_kwargs")
+        if isinstance(ctk, dict) and ctk.get("enable_thinking") is False:
+            return True
+        return self.extra_body.get("enable_thinking") is False
+
     async def complete(
         self, system_prompt: str, user_content: str, include_thinking: bool = False,
     ) -> str | tuple[str, str]:
@@ -83,9 +96,13 @@ class LLMClient:
             **self.extra_body,
         }
 
-        # GLM models require explicit thinking enablement in request
-        if include_thinking and self._is_glm_model():
-            body["thinking"] = {"type": "enabled"}
+        # GLM models require an explicit thinking field. Honor a disable request
+        # from extra_body (e.g. --no-think, which GLM otherwise ignores) instead of
+        # contradicting it with enabled, and never override a `thinking` field the
+        # caller set explicitly in extra_body.
+        if include_thinking and self._is_glm_model() and "thinking" not in body:
+            disabled = self._extra_body_disables_thinking()
+            body["thinking"] = {"type": "disabled" if disabled else "enabled"}
 
         async def _do_request() -> httpx.Response:
             async with httpx.AsyncClient(timeout=self.timeout) as client:

--- a/scripts/smoke_concurrency.py
+++ b/scripts/smoke_concurrency.py
@@ -42,6 +42,18 @@ def extract(body):
     return text.strip()[:30] or f"<no text; message keys={list(msg)}>"
 
 
+def first_message(body):
+    """Best-effort message object from an OpenAI-style response; never raises.
+
+    Unlike body["choices"][0], this tolerates a present-but-empty choices array
+    (the `[{}]` default of dict.get only applies when the key is absent), falling
+    back to the whole body for display.
+    """
+    choices = body.get("choices") or [{}]
+    first = choices[0] if isinstance(choices, list) and choices else {}
+    return first.get("message", body) if isinstance(first, dict) else body
+
+
 def call(url, max_tokens, i):
     dt, body = post(url, max_tokens)
     return i, dt, extract(body)
@@ -61,7 +73,7 @@ def main():
 
     print(f"Endpoint {url}  N={n}  max_tokens={args.max_tokens}")
     _, warm = post(url, args.max_tokens)        # warmup: compiles graph / loads model
-    sample = warm.get("choices", [{}])[0].get("message", warm)
+    sample = first_message(warm)
     print(f"sample response message: {json.dumps(sample)[:200]}")
     base, _ = post(url, args.max_tokens)        # single-request baseline
     print(f"single request: {base:.2f}s")

--- a/scripts/smoke_concurrency.py
+++ b/scripts/smoke_concurrency.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Smoke-test mlx_lm.server continuous batching: N concurrent vs 1 request.
+
+Run on the machine serving the model (or another tailnet box pointed at it).
+With continuous batching working, N concurrent requests finish in roughly the
+wall time of a single request; ~1x throughput gain means requests are
+serializing. Dependency-free (stdlib only).
+"""
+import argparse
+import json
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+# Mirrors the local model's real job: Stage 2 label classification of a person
+# email body (NEEDS_RESPONSE / FYI / LOW_PRIORITY). The person-vs-service call
+# is the cloud model's job, not the local model's.
+PROMPT = ("From: jane@example.com\nSubject: Re: budget review\n\n"
+          "Hi — can you look over the Q3 numbers I sent and tell me if the travel "
+          "line looks right before I submit it Friday? Thanks, Jane\n\n"
+          "Classify this email as exactly one of: NEEDS_RESPONSE, FYI, LOW_PRIORITY.")
+
+
+def post(url, max_tokens):
+    payload = {"messages": [{"role": "user", "content": PROMPT}],
+               "temperature": 0, "max_tokens": max_tokens}
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(),
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.monotonic()
+    with urllib.request.urlopen(req, timeout=600) as r:
+        body = json.loads(r.read())
+    return time.monotonic() - t0, body
+
+
+def extract(body):
+    """Best-effort text from an OpenAI-style response; never raises."""
+    try:
+        msg = body["choices"][0]["message"]
+    except (KeyError, IndexError, TypeError):
+        return f"<no choices: {json.dumps(body)[:80]}>"
+    text = msg.get("content") or msg.get("reasoning_content") or ""
+    return text.strip()[:30] or f"<no text; message keys={list(msg)}>"
+
+
+def call(url, max_tokens, i):
+    dt, body = post(url, max_tokens)
+    return i, dt, extract(body)
+
+
+def main():
+    p = argparse.ArgumentParser(description="Smoke-test mlx_lm.server continuous batching.")
+    p.add_argument("-n", "--concurrency", type=int, default=4,
+                   help="number of concurrent requests (default: 4)")
+    p.add_argument("--url", default="http://127.0.0.1:8080",
+                   help="server base URL (default: http://127.0.0.1:8080)")
+    p.add_argument("--max-tokens", type=int, default=8,
+                   help="max output tokens per request (default: 8)")
+    args = p.parse_args()
+    n = args.concurrency
+    url = args.url.rstrip("/") + "/v1/chat/completions"
+
+    print(f"Endpoint {url}  N={n}  max_tokens={args.max_tokens}")
+    _, warm = post(url, args.max_tokens)        # warmup: compiles graph / loads model
+    sample = warm.get("choices", [{}])[0].get("message", warm)
+    print(f"sample response message: {json.dumps(sample)[:200]}")
+    base, _ = post(url, args.max_tokens)        # single-request baseline
+    print(f"single request: {base:.2f}s")
+
+    t0 = time.monotonic()
+    with ThreadPoolExecutor(max_workers=n) as ex:
+        res = list(ex.map(lambda i: call(url, args.max_tokens, i), range(n)))
+    wall = time.monotonic() - t0
+    for i, dt, out in res:
+        print(f"  req {i}: {dt:5.2f}s -> {out!r}")
+    print(f"\n{n} concurrent wall: {wall:.2f}s   (serialized would be ~{base * n:.2f}s)")
+    print(f"throughput gain: {base * n / wall:.1f}x   (~1x = NOT batching, ~{n}x = fully batched)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -20,6 +20,7 @@ from daemon import (
     resolve_int_env,
 )
 from labeler import _get_priority
+from llm_client import LLMUnavailableError
 from newsletter import NewsletterTier, StoryResult
 
 
@@ -328,6 +329,56 @@ class TestProcessSingleThread:
 
         mock_label_manager.mark_processed.assert_not_called()
 
+    async def test_llm_unavailable_does_not_count_toward_give_up(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+        mock_thread_response,
+    ):
+        """An LLM endpoint outage (LLMUnavailableError) is transient and must never give up.
+
+        Covers review finding #1: a connect-timeout / dropped connection from a down
+        local MLX server surfaces as LLMUnavailableError, which must be retried, not
+        counted toward marking the thread processed.
+        """
+        mock_proxy.get_thread.return_value = mock_thread_response
+        mock_classifier.classify_sender.side_effect = LLMUnavailableError("MLX endpoint down")
+        tracker = FailureTracker(max_failures=2)
+
+        for _ in range(5):
+            result = await process_single_thread(
+                "thread_001", ["msg_001"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
+            )
+            assert result is False
+
+        mock_label_manager.mark_processed.assert_not_called()
+
+    async def test_give_up_marks_all_thread_messages_not_just_query_stubs(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+        mock_thread_response,
+    ):
+        """When a fetched thread is given up, ALL its messages are marked processed.
+
+        Covers review finding #3: the query may return a subset of a thread's messages,
+        but once get_thread succeeds the full thread is known. Give-up must mark every
+        message (so the thread stops re-matching the query) — not just the query stub.
+        """
+        # Thread has msg_001 + msg_002, but the query only surfaced msg_001.
+        mock_proxy.get_thread.return_value = mock_thread_response
+        mock_classifier.classify_sender.side_effect = RuntimeError("classification boom")
+        tracker = FailureTracker(max_failures=2)
+
+        results = [
+            await process_single_thread(
+                "thread_001", ["msg_001"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
+            )
+            for _ in range(2)
+        ]
+
+        assert results[0] is False  # first failure: retry
+        assert results[1] is True   # threshold hit: give up
+        mock_label_manager.mark_processed.assert_called_once_with(["msg_001", "msg_002"])
+
     async def test_service_thread_classified_via_cloud(
         self,
         mock_proxy,
@@ -496,6 +547,26 @@ class TestResolveIntEnv:
     def test_strips_whitespace_around_value(self, monkeypatch):
         monkeypatch.setenv("LOCAL_PARALLEL", "  2 ")
         assert resolve_int_env("LOCAL_PARALLEL", 4) == 2
+
+    def test_zero_falls_back_to_default(self, monkeypatch):
+        # 0 parses fine but is out of range: Semaphore(0) deadlocks the daemon.
+        monkeypatch.setenv("LOCAL_PARALLEL", "0")
+        assert resolve_int_env("LOCAL_PARALLEL", 4) == 4
+
+    def test_negative_falls_back_to_default(self, monkeypatch):
+        # -1 parses fine but is out of range: Semaphore(-1) crashes at startup.
+        monkeypatch.setenv("LOCAL_PARALLEL", "-1")
+        assert resolve_int_env("LOCAL_PARALLEL", 4) == 4
+
+    def test_value_at_minimum_is_allowed(self, monkeypatch):
+        monkeypatch.setenv("LOCAL_PARALLEL", "1")
+        assert resolve_int_env("LOCAL_PARALLEL", 4) == 1
+
+    def test_max_emails_zero_falls_back_to_default(self, monkeypatch):
+        # The lower-bound guard protects every numeric override, not just concurrency:
+        # max_results=0 would make the daemon process nothing each cycle.
+        monkeypatch.setenv("MAX_EMAILS_PER_CYCLE", "0")
+        assert resolve_int_env("MAX_EMAILS_PER_CYCLE", 10) == 10
 
 
 @pytest.fixture

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -379,6 +379,45 @@ class TestProcessSingleThread:
         assert results[1] is True   # threshold hit: give up
         mock_label_manager.mark_processed.assert_called_once_with(["msg_001", "msg_002"])
 
+    async def test_get_thread_is_bounded_by_fetch_sem(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+        mock_thread_response,
+    ):
+        """get_thread runs under fetch_sem, so proxy fetches can't fan out unbounded.
+
+        Covers review finding #5: a large max_emails_per_cycle would otherwise burst
+        one simultaneous get_thread per thread (the LLM semaphores gate only the
+        classify calls, not the fetch).
+        """
+        mock_proxy.get_thread.return_value = mock_thread_response
+        exhausted = asyncio.Semaphore(0)  # no permits available
+
+        task = asyncio.create_task(process_single_thread(
+            "thread_001", ["msg_001"], mock_proxy, mock_classifier, mock_label_manager,
+            cloud_sem, local_sem, max_thread_chars=16000, fetch_sem=exhausted,
+        ))
+        await asyncio.sleep(0.05)
+        # Blocked acquiring the fetch semaphore — get_thread must not have run.
+        mock_proxy.get_thread.assert_not_called()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    async def test_processes_normally_with_available_fetch_sem(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+        mock_thread_response,
+    ):
+        """With a permitting fetch_sem, the thread is fetched and classified normally."""
+        mock_proxy.get_thread.return_value = mock_thread_response
+
+        result = await process_single_thread(
+            "thread_001", ["msg_001"], mock_proxy, mock_classifier, mock_label_manager,
+            cloud_sem, local_sem, max_thread_chars=16000, fetch_sem=asyncio.Semaphore(2),
+        )
+
+        assert result is True
+        mock_proxy.get_thread.assert_called_once()
+
     async def test_service_thread_classified_via_cloud(
         self,
         mock_proxy,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -12,7 +12,7 @@ from classifier import (
     EmailLabel,
     SenderType,
 )
-from daemon import format_thread_transcript, load_config, process_single_thread
+from daemon import format_thread_transcript, load_config, process_single_thread, resolve_int_env
 from labeler import _get_priority
 from newsletter import NewsletterTier, StoryResult
 
@@ -402,6 +402,28 @@ class TestLoadConfig:
         for key in ("story_extraction", "quality_assessment", "theme_classification"):
             assert "system" in prompts[key]
             assert "user_template" in prompts[key]
+
+
+class TestResolveIntEnv:
+    def test_returns_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("LOCAL_PARALLEL", raising=False)
+        assert resolve_int_env("LOCAL_PARALLEL", 4) == 4
+
+    def test_env_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("LOCAL_PARALLEL", "6")
+        assert resolve_int_env("LOCAL_PARALLEL", 4) == 6
+
+    def test_blank_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("LOCAL_PARALLEL", "   ")
+        assert resolve_int_env("LOCAL_PARALLEL", 4) == 4
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("MAX_EMAILS_PER_CYCLE", "lots")
+        assert resolve_int_env("MAX_EMAILS_PER_CYCLE", 10) == 10
+
+    def test_strips_whitespace_around_value(self, monkeypatch):
+        monkeypatch.setenv("LOCAL_PARALLEL", "  2 ")
+        assert resolve_int_env("LOCAL_PARALLEL", 4) == 2
 
 
 @pytest.fixture

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -312,6 +312,8 @@ class TestProcessSingleThread:
         # Third failure hits the threshold: give up — mark processed and report handled.
         assert results[2] is True
         mock_label_manager.mark_processed.assert_called_once_with(["msg_1"])
+        # The give-up is recorded so the cycle summary can report it distinctly.
+        assert tracker.take_given_up() == ["thread_stuck"]
 
     async def test_connect_error_does_not_count_toward_give_up(
         self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
@@ -479,6 +481,14 @@ class TestFailureTracker:
         t.record_failure("b")
         assert t.should_give_up("a") is True
         assert t.should_give_up("b") is False
+
+    def test_records_and_takes_give_ups(self):
+        t = FailureTracker(max_failures=1)
+        assert t.take_given_up() == []
+        t.record_give_up("a")
+        t.record_give_up("b")
+        assert t.take_given_up() == ["a", "b"]
+        assert t.take_given_up() == []  # draining resets the per-cycle list
 
 
 class TestLoadConfig:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -490,6 +490,23 @@ class TestFailureTracker:
         assert t.take_given_up() == ["a", "b"]
         assert t.take_given_up() == []  # draining resets the per-cycle list
 
+    def test_prune_evicts_counts_for_absent_threads(self):
+        # A thread that fails a few times then vanishes from the query must not
+        # leak its count forever (review finding #7).
+        t = FailureTracker(max_failures=2)
+        t.record_failure("gone")
+        t.record_failure("gone")
+        assert t.should_give_up("gone") is True
+        t.prune({"still_here"})
+        assert t.should_give_up("gone") is False  # evicted
+
+    def test_prune_keeps_active_threads(self):
+        t = FailureTracker(max_failures=2)
+        t.record_failure("active")
+        t.record_failure("active")
+        t.prune({"active"})
+        assert t.should_give_up("active") is True  # still counted toward give-up
+
 
 class TestLoadConfig:
     def test_loads_config_toml(self):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -18,6 +18,7 @@ from daemon import (
     load_config,
     process_single_thread,
     resolve_int_env,
+    summarize_cycle,
 )
 from labeler import _get_priority
 from llm_client import LLMUnavailableError
@@ -506,6 +507,34 @@ class TestFailureTracker:
         t.record_failure("active")
         t.prune({"active"})
         assert t.should_give_up("active") is True  # still counted toward give-up
+
+
+class TestSummarizeCycle:
+    def test_counts_handled_threads_and_drains_give_ups(self):
+        t = FailureTracker(max_failures=1)
+        t.record_give_up("gaveup")
+        items = [("ok", ["1"]), ("retry", ["2"]), ("gaveup", ["3"])]
+        results = [True, False, True]  # gaveup returned True (handled via give-up)
+        processed, given_up = summarize_cycle(items, results, t)
+        assert processed == 2  # ok + gaveup
+        assert given_up == ["gaveup"]  # a subset of processed
+        assert t.take_given_up() == []  # already drained
+
+    def test_clears_counts_for_handled_threads(self):
+        t = FailureTracker(max_failures=2)
+        t.record_failure("ok")  # failed last cycle, succeeds now
+        summarize_cycle([("ok", ["1"])], [True], t)
+        t.record_failure("ok")
+        assert t.should_give_up("ok") is False  # count was reset on success
+
+    def test_prunes_counts_for_threads_absent_this_cycle(self):
+        t = FailureTracker(max_failures=2)
+        t.record_failure("stale")
+        t.record_failure("stale")  # at threshold from a prior cycle
+        assert t.should_give_up("stale") is True
+        # This cycle only has "active"; "stale" is gone from the query.
+        summarize_cycle([("active", ["1"])], [False], t)
+        assert t.should_give_up("stale") is False  # pruned
 
 
 class TestLoadConfig:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -12,7 +12,13 @@ from classifier import (
     EmailLabel,
     SenderType,
 )
-from daemon import format_thread_transcript, load_config, process_single_thread, resolve_int_env
+from daemon import (
+    FailureTracker,
+    format_thread_transcript,
+    load_config,
+    process_single_thread,
+    resolve_int_env,
+)
 from labeler import _get_priority
 from newsletter import NewsletterTier, StoryResult
 
@@ -284,6 +290,44 @@ class TestProcessSingleThread:
 
         assert result is False
 
+    async def test_gives_up_on_thread_after_repeated_failures(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+    ):
+        """A thread that keeps failing is marked processed after max_failures, breaking the loop."""
+        mock_proxy.get_thread.side_effect = RuntimeError("API error")
+        tracker = FailureTracker(max_failures=3)
+
+        results = [
+            await process_single_thread(
+                "thread_stuck", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
+            )
+            for _ in range(3)
+        ]
+
+        # First two failures: retry next cycle (not handled), nothing marked processed.
+        assert results[0] is False
+        assert results[1] is False
+        # Third failure hits the threshold: give up — mark processed and report handled.
+        assert results[2] is True
+        mock_label_manager.mark_processed.assert_called_once_with(["msg_1"])
+
+    async def test_connect_error_does_not_count_toward_give_up(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+    ):
+        """An endpoint outage (ConnectError) is transient and must never trigger give-up."""
+        mock_proxy.get_thread.side_effect = httpx.ConnectError("connection refused")
+        tracker = FailureTracker(max_failures=2)
+
+        for _ in range(5):
+            result = await process_single_thread(
+                "thread_down", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
+            )
+            assert result is False
+
+        mock_label_manager.mark_processed.assert_not_called()
+
     async def test_service_thread_classified_via_cloud(
         self,
         mock_proxy,
@@ -317,6 +361,34 @@ class TestProcessSingleThread:
         assert result is True
         mock_classifier.classify.assert_called_once()
         mock_label_manager.apply_classification.assert_called_once()
+
+
+class TestFailureTracker:
+    def test_gives_up_only_at_threshold(self):
+        t = FailureTracker(max_failures=3)
+        assert t.should_give_up("x") is False
+        t.record_failure("x")
+        assert t.should_give_up("x") is False
+        t.record_failure("x")
+        assert t.should_give_up("x") is False
+        t.record_failure("x")
+        assert t.should_give_up("x") is True
+
+    def test_clear_resets_count(self):
+        t = FailureTracker(max_failures=2)
+        t.record_failure("x")
+        t.record_failure("x")
+        assert t.should_give_up("x") is True
+        t.clear("x")
+        assert t.should_give_up("x") is False
+
+    def test_threads_tracked_independently(self):
+        t = FailureTracker(max_failures=2)
+        t.record_failure("a")
+        t.record_failure("a")
+        t.record_failure("b")
+        assert t.should_give_up("a") is True
+        assert t.should_give_up("b") is False
 
 
 class TestLoadConfig:

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -18,6 +18,8 @@ def _override_args(**kw):
     base = dict(
         cloud_model=None, cloud_temperature=None, cloud_max_tokens=None, cloud_timeout=None,
         local_model=None, local_temperature=None, local_max_tokens=None, local_timeout=None,
+        cloud_no_think=False, cloud_extra_body=None,
+        local_no_think=False, local_extra_body=None,
     )
     base.update(kw)
     return argparse.Namespace(**base)
@@ -68,6 +70,26 @@ class TestApplyConfigOverrides:
         assert cfg["llm"]["local"]["max_tokens"] == 512
         assert cfg["llm"]["local"]["timeout"] == 600
         assert cfg["llm"]["cloud"]["timeout"] == 30
+
+    def test_no_think_applies_extra_body_in_one_pass(self):
+        # extra_body overrides are folded into apply_config_overrides, not a second
+        # parallel loop in main() (review finding #10).
+        cfg = _override_config()
+        apply_config_overrides(cfg, _override_args(local_no_think=True))
+        assert cfg["llm"]["local"]["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": False}
+        }
+        assert "extra_body" not in cfg["llm"]["cloud"]  # cloud untouched
+
+    def test_extra_body_json_is_merged(self):
+        cfg = _override_config()
+        apply_config_overrides(cfg, _override_args(cloud_extra_body='{"top_p": 0.9}'))
+        assert cfg["llm"]["cloud"]["extra_body"] == {"top_p": 0.9}
+
+    def test_invalid_extra_body_json_raises_valueerror(self):
+        cfg = _override_config()
+        with pytest.raises(ValueError):
+            apply_config_overrides(cfg, _override_args(local_extra_body="{not json}"))
 
 
 class TestResolveMaxThreadChars:

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -1,9 +1,68 @@
 """Tests for eval runner parallelism defaults and extra_body overrides."""
 
+import argparse
+
 import pytest
 
 from daemon import load_config
-from evals.run_eval import resolve_extra_body, resolve_parallelism
+from evals.run_eval import apply_config_overrides, resolve_extra_body, resolve_parallelism
+
+
+def _override_args(**kw):
+    """argparse.Namespace with every override field defaulting to None (not provided)."""
+    base = dict(
+        cloud_model=None, cloud_temperature=None, cloud_max_tokens=None, cloud_timeout=None,
+        local_model=None, local_temperature=None, local_max_tokens=None, local_timeout=None,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _override_config():
+    return {"llm": {
+        "cloud": {"model": "cloud-default", "temperature": 0.5, "max_tokens": 100, "timeout": 60},
+        "local": {"model": "local-default", "temperature": 0.7, "max_tokens": 200, "timeout": 180},
+    }}
+
+
+class TestApplyConfigOverrides:
+    def test_no_overrides_leaves_config_unchanged(self):
+        cfg = _override_config()
+        apply_config_overrides(cfg, _override_args())
+        assert cfg == _override_config()
+
+    def test_local_timeout_override(self):
+        cfg = _override_config()
+        apply_config_overrides(cfg, _override_args(local_timeout=900))
+        assert cfg["llm"]["local"]["timeout"] == 900
+        assert cfg["llm"]["cloud"]["timeout"] == 60  # cloud untouched
+
+    def test_cloud_timeout_override(self):
+        cfg = _override_config()
+        apply_config_overrides(cfg, _override_args(cloud_timeout=45))
+        assert cfg["llm"]["cloud"]["timeout"] == 45
+        assert cfg["llm"]["local"]["timeout"] == 180  # local untouched
+
+    def test_timeout_override_does_not_disturb_other_fields(self):
+        cfg = _override_config()
+        apply_config_overrides(cfg, _override_args(local_timeout=900))
+        assert cfg["llm"]["local"]["model"] == "local-default"
+        assert cfg["llm"]["local"]["max_tokens"] == 200
+
+    def test_zero_is_a_valid_override(self):
+        # 0.0 is not None, so it must override even though it's falsy.
+        cfg = _override_config()
+        apply_config_overrides(cfg, _override_args(local_temperature=0.0))
+        assert cfg["llm"]["local"]["temperature"] == 0.0
+
+    def test_multiple_overrides_at_once(self):
+        cfg = _override_config()
+        apply_config_overrides(cfg, _override_args(
+            local_model="m", local_max_tokens=512, local_timeout=600, cloud_timeout=30))
+        assert cfg["llm"]["local"]["model"] == "m"
+        assert cfg["llm"]["local"]["max_tokens"] == 512
+        assert cfg["llm"]["local"]["timeout"] == 600
+        assert cfg["llm"]["cloud"]["timeout"] == 30
 
 
 class TestResolveParallelism:

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -4,8 +4,13 @@ import argparse
 
 import pytest
 
-from daemon import load_config
-from evals.run_eval import apply_config_overrides, resolve_extra_body, resolve_parallelism
+from daemon import DEFAULT_MAX_THREAD_CHARS, load_config
+from evals.run_eval import (
+    apply_config_overrides,
+    resolve_extra_body,
+    resolve_max_thread_chars,
+    resolve_parallelism,
+)
 
 
 def _override_args(**kw):
@@ -63,6 +68,20 @@ class TestApplyConfigOverrides:
         assert cfg["llm"]["local"]["max_tokens"] == 512
         assert cfg["llm"]["local"]["timeout"] == 600
         assert cfg["llm"]["cloud"]["timeout"] == 30
+
+
+class TestResolveMaxThreadChars:
+    def test_uses_config_value_when_present(self):
+        assert resolve_max_thread_chars({"daemon": {"max_thread_chars": 12345}}) == 12345
+
+    def test_falls_back_to_shared_daemon_default(self):
+        assert resolve_max_thread_chars({"daemon": {}}) == DEFAULT_MAX_THREAD_CHARS
+        assert resolve_max_thread_chars({}) == DEFAULT_MAX_THREAD_CHARS
+
+    def test_default_is_not_the_stale_50000(self):
+        # Regression (finding #9): the eval fallback drifted to 50000 while the
+        # daemon/config canonical default moved to 16000.
+        assert resolve_max_thread_chars({}) == 16000
 
 
 class TestResolveParallelism:

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -1,7 +1,9 @@
-"""Tests for eval runner parallelism defaults."""
+"""Tests for eval runner parallelism defaults and extra_body overrides."""
+
+import pytest
 
 from daemon import load_config
-from evals.run_eval import resolve_parallelism
+from evals.run_eval import resolve_extra_body, resolve_parallelism
 
 
 class TestResolveParallelism:
@@ -20,3 +22,41 @@ class TestResolveParallelism:
         """When config has no cloud_parallel, fall back to 1."""
         config = {"daemon": {}}
         assert resolve_parallelism(None, config) == 1
+
+
+class TestResolveExtraBody:
+    def test_none_when_nothing_set(self):
+        assert resolve_extra_body(None, False, None) is None
+
+    def test_passes_through_base_when_no_overrides(self):
+        assert resolve_extra_body({"top_p": 0.9}, False, None) == {"top_p": 0.9}
+
+    def test_no_think_sets_chat_template_kwargs(self):
+        assert resolve_extra_body(None, True, None) == {
+            "chat_template_kwargs": {"enable_thinking": False}
+        }
+
+    def test_no_think_preserves_existing_chat_template_kwargs(self):
+        out = resolve_extra_body({"chat_template_kwargs": {"foo": 1}}, True, None)
+        assert out == {"chat_template_kwargs": {"foo": 1, "enable_thinking": False}}
+
+    def test_explicit_json_merges_and_wins(self):
+        out = resolve_extra_body({"top_p": 0.9}, False, '{"top_p": 0.5, "min_p": 0.1}')
+        assert out == {"top_p": 0.5, "min_p": 0.1}
+
+    def test_explicit_json_overrides_no_think(self):
+        out = resolve_extra_body(None, True, '{"chat_template_kwargs": {"enable_thinking": true}}')
+        assert out == {"chat_template_kwargs": {"enable_thinking": True}}
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError):
+            resolve_extra_body(None, False, "{not json}")
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(ValueError):
+            resolve_extra_body(None, False, "[1, 2, 3]")
+
+    def test_does_not_mutate_base(self):
+        base = {"chat_template_kwargs": {"foo": 1}}
+        resolve_extra_body(base, True, None)
+        assert base == {"chat_template_kwargs": {"foo": 1}}

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -471,6 +471,81 @@ class TestGLMReasoningContent:
             body = mock_client.post.call_args.kwargs["json"]
             assert body["thinking"] == {"type": "enabled"}
 
+    async def test_glm_no_think_extra_body_disables_native_thinking(self):
+        """--no-think (chat_template_kwargs.enable_thinking=False) must disable GLM's
+        native thinking, not be contradicted by an unconditional thinking=enabled.
+
+        Regression (review finding #4): GLM is the default cloud model, so the
+        documented thinking on/off A/B run would otherwise send enable_thinking=false
+        AND thinking={type:enabled} in the same body.
+        """
+        client = LLMClient(
+            base_url="https://api.example.com/v1/chat/completions",
+            api_key="sk-test",
+            model="zai-org/glm-5",
+            extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+        )
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {"content": "SERVICE"}}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await client.complete("sys", "user", include_thinking=True)
+
+            body = mock_client.post.call_args.kwargs["json"]
+            assert body["thinking"] == {"type": "disabled"}
+
+    async def test_glm_top_level_enable_thinking_false_disables_native_thinking(self):
+        """A top-level enable_thinking=False in extra_body also disables GLM thinking."""
+        client = LLMClient(
+            base_url="https://api.example.com/v1/chat/completions",
+            api_key="sk-test",
+            model="zai-org/glm-5",
+            extra_body={"enable_thinking": False},
+        )
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {"content": "SERVICE"}}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await client.complete("sys", "user", include_thinking=True)
+
+            body = mock_client.post.call_args.kwargs["json"]
+            assert body["thinking"] == {"type": "disabled"}
+
+    async def test_glm_explicit_thinking_field_is_not_overridden(self):
+        """An explicit `thinking` field in extra_body wins over the auto-injection."""
+        client = LLMClient(
+            base_url="https://api.example.com/v1/chat/completions",
+            api_key="sk-test",
+            model="zai-org/glm-5",
+            extra_body={"thinking": {"type": "disabled"}},
+        )
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {"content": "SERVICE"}}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await client.complete("sys", "user", include_thinking=True)
+
+            body = mock_client.post.call_args.kwargs["json"]
+            assert body["thinking"] == {"type": "disabled"}
+
     async def test_glm_no_thinking_param_without_include(self, glm_client):
         """GLM models don't get thinking param when include_thinking=False."""
         mock_response = _mock_response(json_data={

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -222,6 +222,36 @@ class TestComplete:
             with pytest.raises(TimeoutError, match="timed out after 60s"):
                 await cloud_client.complete("sys", "user")
 
+    async def test_surfaces_read_error_as_informative_runtime_error(self, cloud_client):
+        """A dropped/reset connection (httpx.ReadError) surfaces as a non-empty RuntimeError.
+
+        Regression: a bare reset previously propagated as an exception whose str() was
+        empty, so callers recorded it as an empty error / no result instead of a failure.
+        """
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.ReadError("")  # empty msg, like a bare reset
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(RuntimeError) as exc_info:
+                await cloud_client.complete("sys", "user")
+            msg = str(exc_info.value)
+            assert msg  # non-empty even though the underlying error message was empty
+            assert "ReadError" in msg
+            assert "test-cloud-model" in msg
+
+    async def test_surfaces_remote_protocol_error(self, cloud_client):
+        """A server disconnect (httpx.RemoteProtocolError) surfaces as RuntimeError."""
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.RemoteProtocolError("Server disconnected")
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(RuntimeError, match="RemoteProtocolError"):
+                await cloud_client.complete("sys", "user")
+
     async def test_uses_configured_timeout(self, cloud_client):
         """Verify timeout is passed to httpx client."""
         mock_response = _mock_response(json_data={

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from llm_client import LLMClient
+from llm_client import LLMClient, LLMUnavailableError
 
 
 @pytest.fixture
@@ -200,19 +200,47 @@ class TestComplete:
             with pytest.raises(RuntimeError, match="LLM request failed"):
                 await cloud_client.complete("sys", "user")
 
-    async def test_raises_on_connection_error(self, cloud_client):
-        """Connection errors propagate."""
+    async def test_connect_error_surfaces_as_unavailable(self, cloud_client):
+        """A refused connection (server down) surfaces as LLMUnavailableError (transient)."""
         with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.post.side_effect = httpx.ConnectError("Connection refused")
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            with pytest.raises(httpx.ConnectError):
+            with pytest.raises(LLMUnavailableError):
                 await cloud_client.complete("sys", "user")
 
-    async def test_raises_timeout_error_on_timeout(self, cloud_client):
-        """Timeout exceptions are converted to TimeoutError with helpful message."""
+    async def test_connect_timeout_surfaces_as_unavailable_not_timeout(self, cloud_client):
+        """A connect timeout is endpoint unavailability, NOT a request-specific timeout.
+
+        Regression (review finding #1): httpx.ConnectTimeout is a subclass of
+        TimeoutException, so it used to be mapped to TimeoutError and counted toward
+        give-up. It must surface as LLMUnavailableError (transient) instead.
+        """
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.ConnectTimeout("connect timed out")
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(LLMUnavailableError):
+                await cloud_client.complete("sys", "user")
+
+    async def test_pool_timeout_surfaces_as_unavailable(self, cloud_client):
+        """A pool timeout (connection pool exhausted) is transient unavailability."""
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.PoolTimeout("pool exhausted")
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(LLMUnavailableError):
+                await cloud_client.complete("sys", "user")
+
+    async def test_read_timeout_stays_request_specific_timeout_error(self, cloud_client):
+        """A read timeout (slow prefill on large input) stays TimeoutError — request-specific,
+        so the daemon may give up on one oversized thread rather than retry forever."""
         with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.post.side_effect = httpx.ReadTimeout("timed out")
@@ -222,11 +250,12 @@ class TestComplete:
             with pytest.raises(TimeoutError, match="timed out after 60s"):
                 await cloud_client.complete("sys", "user")
 
-    async def test_surfaces_read_error_as_informative_runtime_error(self, cloud_client):
-        """A dropped/reset connection (httpx.ReadError) surfaces as a non-empty RuntimeError.
+    async def test_surfaces_read_error_as_informative_unavailable_error(self, cloud_client):
+        """A dropped/reset connection (httpx.ReadError) surfaces as a non-empty LLMUnavailableError.
 
         Regression: a bare reset previously propagated as an exception whose str() was
         empty, so callers recorded it as an empty error / no result instead of a failure.
+        It is treated as transient unavailability (server crashed/restarted/flapped).
         """
         with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
@@ -234,22 +263,22 @@ class TestComplete:
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            with pytest.raises(RuntimeError) as exc_info:
+            with pytest.raises(LLMUnavailableError) as exc_info:
                 await cloud_client.complete("sys", "user")
             msg = str(exc_info.value)
             assert msg  # non-empty even though the underlying error message was empty
             assert "ReadError" in msg
             assert "test-cloud-model" in msg
 
-    async def test_surfaces_remote_protocol_error(self, cloud_client):
-        """A server disconnect (httpx.RemoteProtocolError) surfaces as RuntimeError."""
+    async def test_surfaces_remote_protocol_error_as_unavailable(self, cloud_client):
+        """A server disconnect (httpx.RemoteProtocolError) surfaces as LLMUnavailableError."""
         with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.post.side_effect = httpx.RemoteProtocolError("Server disconnected")
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            with pytest.raises(RuntimeError, match="RemoteProtocolError"):
+            with pytest.raises(LLMUnavailableError, match="RemoteProtocolError"):
                 await cloud_client.complete("sys", "user")
 
     async def test_uses_configured_timeout(self, cloud_client):

--- a/tests/test_smoke_concurrency.py
+++ b/tests/test_smoke_concurrency.py
@@ -1,0 +1,27 @@
+"""Tests for the mlx_lm.server concurrency smoke-test helpers."""
+
+from scripts.smoke_concurrency import extract, first_message
+
+
+class TestFirstMessage:
+    def test_extracts_message_object(self):
+        body = {"choices": [{"message": {"content": "hi"}}]}
+        assert first_message(body) == {"content": "hi"}
+
+    def test_empty_choices_falls_back_to_body_without_raising(self):
+        # Regression (review finding #11): choices present-but-empty must not
+        # IndexError the warmup the way body["choices"][0] would.
+        body = {"choices": []}
+        assert first_message(body) == body
+
+    def test_missing_choices_falls_back_to_body(self):
+        assert first_message({}) == {}
+
+
+class TestExtract:
+    def test_extracts_content(self):
+        body = {"choices": [{"message": {"content": "  SERVICE  "}}]}
+        assert extract(body) == "SERVICE"
+
+    def test_empty_choices_does_not_raise(self):
+        assert extract({"choices": []}).startswith("<no choices")


### PR DESCRIPTION
## Summary

Makes the local-MLX classification path tunable and resilient on memory-constrained hardware, and adds the eval-harness levers needed to measure changes to it. The work started as "raise local concurrency for backlog draining," but bringing up a real M1 Max / Qwen3.6-27B-8bit server surfaced a chain of issues (GPU OOM crashes, silent connection failures, infinite retry loops on oversized threads) that this branch also hardens against.

## What's in here

**Concurrency, now env-tunable**
- `local_parallel` and `max_emails_per_cycle` are overridable per run via `LOCAL_PARALLEL` / `MAX_EMAILS_PER_CYCLE` (numeric env overrides read in `run_daemon`, since `{env.VAR}` substitution only handles strings).
- The daemon processes a poll cycle's threads concurrently, bounded by the cloud/local semaphores.

**Eval harness overrides** (so model/serving changes are measurable on the golden set)
- `run_eval` gained `--cloud/--local-extra-body`, `--cloud/--local-no-think` (A/B thinking on vs off), and `--cloud/--local-timeout` (long prefills on slow local hardware).
- Override logic extracted into pure, unit-tested helpers (`apply_config_overrides`, `resolve_extra_body`). `extra_body` is in the eval cache key, so on/off runs cache independently.

**Memory-safe defaults + resilience** (from the OOM/debugging detour)
- `local_parallel` **defaults to 1** and `max_thread_chars` to **16000**. On this hardware the GPU's Metal working set (~75% of RAM) leaves little headroom above a 34 GB model; concurrent long-transcript KV caches OOM-crash the server, and 17k-token prefills exceed the request timeout. Raising `LOCAL_PARALLEL` is an opt-in once the serving side is tuned.
- `LLMClient` surfaces dropped/reset connections (`ReadError`/`WriteError`/`RemoteProtocolError`) as informative `RuntimeError`s instead of exceptions that stringify to `""` and read as silent empty results. `ConnectError` still propagates for the graceful MLX-down path.
- `FailureTracker` marks a thread processed after repeated *thread-specific* failures, breaking the infinite-retry loop on a thread that can never succeed. A `ConnectError` outage never counts, so degradation behavior (skip person emails while MLX is down, retry later) is preserved.

**Tooling & docs**
- `scripts/smoke_concurrency.py` — dependency-free probe to confirm a server is actually continuous-batching before relying on raised concurrency.
- New README-technical "Local Model Serving & Memory" section (GPU working-set ceiling, the OOM symptom, `--prompt-cache-size`, `iogpu.wired_limit_mb`, prefill/timeout). CLAUDE.md and env-var docs updated.

## A note on the `local_parallel` default

This branch first raised the default to 4, then the eval evidence (server OOM-crashing on concurrent long-transcript requests) walked it back to **1** — safe by default, tunable up via `LOCAL_PARALLEL` once the server is provisioned for it. The env-tunability and the serving docs are the durable value; the "batching is ~free" assumption only holds for short context, not 12k+-token email threads.

## Testing

- Full suite: **435 passed, 57 subtests**; lint clean.
- New logic built test-first (red → green) and mutation-checked: the eval override guard (`is not None` vs truthiness) and the give-up threshold (`>=` vs `>`) each fail the intended tests when mutated, and restore to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZcCU4rrPzZG52C4ms9MnA
