### PR TITLE
Disable native thinking on the local person-email classifier

### DIFF
--- a/README-technical.md
+++ b/README-technical.md
@@ -123,14 +123,16 @@ Each `[llm.*]` section supports an optional `extra_body` table. Any key-value pa
 
 **Disabling thinking for reasoning models** — Models like Qwen3, DeepSeek-R1, and GLM-4.5 generate chain-of-thought reasoning in `<think>` tags before answering. While the daemon already strips these tags from responses, you can disable thinking entirely to save tokens and reduce latency.
 
-For providers that accept a top-level `enable_thinking` flag (Novita.ai, many OpenAI-compatible APIs):
+The shipped `config.toml` **disables native thinking on the local person-email classifier** (`[llm.local.extra_body.chat_template_kwargs]` → `enable_thinking = false`). A paired `stage2_only --sender-type person` eval (n=20) found native thinking strictly worse here: the model spent its `max_tokens` budget reasoning in the `<think>` channel and emitted no label on some threads (a `KeyError: 'content'` failure), while think-off was ≥ think-on on every thread (85% vs 78% accuracy, 0 vs 2 errors). The classification prompt already drives step-by-step reasoning into the *content* channel, so disabling native thinking preserves reasoning quality without the budget-split failure. `mlx_lm.server` honors this request-level `chat_template_kwargs` form; a top-level `enable_thinking` is ignored by that server.
+
+For providers that accept a top-level `enable_thinking` flag instead (Novita.ai, many OpenAI-compatible APIs):
 
 ```toml
 [llm.local.extra_body]
 enable_thinking = false
 ```
 
-For LM Studio with models that use `chat_template_kwargs` (e.g. Qwen3):
+For LM Studio and `mlx_lm.server` with models that use `chat_template_kwargs` (e.g. Qwen3) — the shipped default:
 
 ```toml
 [llm.local.extra_body.chat_template_kwargs]

--- a/config.toml
+++ b/config.toml
@@ -48,10 +48,16 @@ model = "{env.MLX_MODEL}"
 max_tokens = 1024
 temperature = 0
 timeout = 180
-# Optional: extra fields merged into every API request body.
-# See README for examples (e.g. disabling thinking for reasoning models).
-# [llm.local.extra_body]
-# enable_thinking = false
+# Extra fields merged into every API request body.
+# Disable native thinking on the local person-email classifier (issue #10): the
+# eval showed native thinking is strictly worse here — reasoning overruns the
+# max_tokens budget in the <think> channel and no label is emitted. The
+# classification prompt already drives step-by-step reasoning into the content
+# channel, so this keeps reasoning quality without the budget-split failure.
+# mlx_lm.server honors this request-level chat_template_kwargs form; a top-level
+# enable_thinking is ignored by that server.
+[llm.local.extra_body.chat_template_kwargs]
+enable_thinking = false
 
 [prompts.sender_classification]
 system = """You are an email classifier. Your job is to determine whether an email is from a real person or from an automated service/company.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -22,7 +22,7 @@ from daemon import (
     summarize_cycle,
 )
 from labeler import _get_priority
-from llm_client import LLMUnavailableError
+from llm_client import LLMClient, LLMUnavailableError
 from newsletter import NewsletterTier, StoryResult
 from proxy_client import ProxyAuthError, ProxyError
 
@@ -601,8 +601,21 @@ class TestLoadConfig:
         # disabled via request-level chat_template_kwargs (the form mlx_lm.server
         # honors). The cloud classifier is unaffected.
         config = load_config()
-        ctk = config["llm"]["local"]["extra_body"]["chat_template_kwargs"]
+        local = config["llm"]["local"]
+        # Layout guard: the flag must be in the nested chat_template_kwargs form.
+        # mlx_lm.server (the real local server) honors this form and ignores a
+        # top-level enable_thinking, so this specific nesting is load-bearing — a
+        # refactor to the top-level form would silently re-enable thinking on the
+        # local server even though llm_client treats both as no-think.
+        ctk = local["extra_body"]["chat_template_kwargs"]
         assert ctk["enable_thinking"] is False
+        # Behavior guard: the LLMClient the daemon builds from this config must
+        # actually treat the request as thinking-disabled.
+        client = LLMClient(
+            base_url="", api_key="", model=local["model"],
+            extra_body=local.get("extra_body"),
+        )
+        assert client._extra_body_disables_thinking() is True
 
     def test_config_has_newsletter_section(self):
         config = load_config()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -593,6 +593,17 @@ class TestLoadConfig:
         assert config["daemon"]["cloud_parallel"] >= 1
         assert config["daemon"]["local_parallel"] >= 1
 
+    def test_config_disables_native_thinking_on_local_classifier(self):
+        # Issue #10: the eval showed native thinking on the local person-email
+        # classifier is strictly worse (budget-split failures where reasoning
+        # overruns max_tokens and no label is emitted). The classification prompt
+        # already drives reasoning into the content channel, so native thinking is
+        # disabled via request-level chat_template_kwargs (the form mlx_lm.server
+        # honors). The cloud classifier is unaffected.
+        config = load_config()
+        ctk = config["llm"]["local"]["extra_body"]["chat_template_kwargs"]
+        assert ctk["enable_thinking"] is False
+
     def test_config_has_newsletter_section(self):
         config = load_config()
         assert "newsletter" in config


### PR DESCRIPTION
Closes #10.

## What

Disables native thinking on the **local** person-email classifier by shipping `enable_thinking = false` under `[llm.local.extra_body.chat_template_kwargs]` in `config.toml`. The cloud classifier is unchanged.

## Why

A paired `stage2_only --sender-type person` eval (n=20), native thinking on vs off:

- **think-off ≥ think-on on every thread, strictly better on 3** (think-on won none).
- Accuracy **17/20 (85%)** vs 14/18 (78%); **0 errors vs 2**.
- The 2 think-on errors were `KeyError: 'content'` — the model spent its `max_tokens` budget reasoning in the `<think>` channel and never emitted a label (see #11).

The classification prompt already drives step-by-step reasoning into the **content** channel (`prose-y raw: 20/20` under think-off), so disabling *native* thinking keeps reasoning quality but avoids the budget-split failure.

## Implementation note

The `extra_body` → `chat_template_kwargs.enable_thinking` plumbing already existed (PR #9 added the `--local-no-think` harness and `LLMClient` support). This PR just activates it as the shipped default. `mlx_lm.server` honors the request-level `chat_template_kwargs` form; a top-level `enable_thinking` is ignored by that server.

## Changes

- `config.toml` — activate the setting (was a commented-out example), with rationale comment.
- `tests/test_daemon.py` — TDD'd test (RED→GREEN) asserting the loaded config disables thinking on the local classifier.
- `README-technical.md` — document the new default and the eval evidence.

## Verification

- New test: RED (`KeyError: 'extra_body'`) → GREEN.
- Full suite: **475 passed, 59 subtests passed**.
- `ruff check`: clean.
- The end-to-end path (config → request body) is already covered by `test_nested_extra_body` in `test_llm_client.py`.

## Acceptance criterion still pending

The issue's "golden-set re-run shows ≥ parity accuracy and zero content errors" requires a **live local MLX server**, which isn't reachable from the dev environment. @brianroberg will run that re-run against the MLX box before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)