### PR TITLE
Resilience track: finish the transient-vs-permanent error model (#11, #16, #18, #17, #23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Hotkeys: `e/g/f/p` filter by tier, `1-5` filter by theme, `s` filter by sender, 
 - `NEWSLETTER_ONLY` — When `1`/`true`/`yes`, daemon runs newsletter classification pipeline instead of email labeling
 - `LOCAL_PARALLEL` — Override `local_parallel` (max concurrent local MLX requests; default 1, keep ≤ 8)
 - `MAX_EMAILS_PER_CYCLE` — Override `max_emails_per_cycle` (max threads per poll cycle; default 10)
+- `WRITE_PARALLEL` — Override `write_parallel` (max concurrent label-application writes; default 4). Sized separately from reads because writes may block on human approval (`WRITE_TIMEOUT`, 300s)
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ Hotkeys: `e/g/f/p` filter by tier, `1-5` filter by theme, `s` filter by sender, 
 - `agent/needs-response` — Leave in inbox
 - `agent/fyi` — Leave in inbox
 - `agent/low-priority` — Archive
-- `agent/processed` — Marker (always applied)
+- `agent/processed` — Marker (applied on success / already-handled)
+- `agent/attempted` — Marker applied on give-up (after repeated failures); excluded from `gmail_query` like `agent/processed`, but kept distinct so abandoned threads stay findable
 - `agent/personal` — Sender classified as person (body processed locally)
 - `agent/non-personal` — Sender classified as service (body processed via cloud)
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -57,6 +57,7 @@ email-labeler/
 | `NEWSLETTER_ONLY` | No | — | Set to `1`, `true`, or `yes` to skip non-newsletter threads. Useful for testing newsletter classification in isolation. |
 | `LOCAL_PARALLEL` | No | `1` (from `config.toml`) | Max concurrent local MLX requests, overriding `local_parallel` in `config.toml`. Modern MLX servers batch these (shared weights), so concurrency mostly costs KV cache. Keep ≤ 8 — mlx-lm has a KV-cache cross-contamination bug at 16+. |
 | `MAX_EMAILS_PER_CYCLE` | No | `10` (from `config.toml`) | Max threads processed per poll cycle, overriding `max_emails_per_cycle` in `config.toml`. Raise temporarily to drain a large backlog faster. |
+| `WRITE_PARALLEL` | No | `4` (from `config.toml`) | Max concurrent label-application writes (`modify_message`), overriding `write_parallel` in `config.toml`. Bounds the proxy-write burst when `max_emails_per_cycle` is large. Sized separately from reads because writes may block on human approval (`WRITE_TIMEOUT`, 300s). |
 
 Note: The cloud LLM **model name** is configured in `config.toml` under `[llm.cloud]`, not in `.env`. The local LLM **model name** is set via the `MLX_MODEL` environment variable (shared with email-agent) and referenced in `config.toml` as `{env.MLX_MODEL}`. This keeps secrets (keys, URLs) in `.env` while operational parameters (temperature, prompts) stay in version-controlled `config.toml`.
 
@@ -70,11 +71,12 @@ All operational parameters are in `config.toml`. The daemon reads this file on s
 [daemon]
 poll_interval_seconds = 60     # How often to poll Gmail
 max_emails_per_cycle = 10      # Max threads per poll (override: MAX_EMAILS_PER_CYCLE)
-gmail_query = "in:inbox -label:agent/processed"  # Gmail search query
+gmail_query = "in:inbox -label:agent/processed -label:agent/attempted"  # Gmail search query
 max_thread_chars = 16000       # Cap on transcript chars sent to the classifier
 cloud_parallel = 2             # Max concurrent cloud LLM requests
 local_parallel = 1             # Max concurrent local MLX requests (override: LOCAL_PARALLEL)
 fetch_parallel = 4             # Max concurrent Gmail thread fetches (get_thread)
+write_parallel = 4             # Max concurrent label-application writes (override: WRITE_PARALLEL)
 healthcheck_file = "/tmp/healthcheck"            # Healthcheck timestamp path
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The daemon classifies emails into three categories and applies the corresponding
 | `agent/fyi` | Worth reading, no action needed | Stays in inbox |
 | `agent/low-priority` | Routine notifications, newsletters, spam, unwanted | Archived |
 
-Additional marker labels (`agent/processed`, `agent/personal`, `agent/non-personal`) track processing state and routing decisions. The newsletter pipeline adds its own labels under `agent/newsletter/`.
+Additional marker labels (`agent/processed`, `agent/attempted`, `agent/personal`, `agent/non-personal`) track processing state and routing decisions. The newsletter pipeline adds its own labels under `agent/newsletter/`.
 
 Newsletter labels (see [Newsletter Classification](#newsletter-classification)):
 
@@ -139,6 +139,7 @@ agent/needs-response
 agent/fyi
 agent/low-priority
 agent/processed
+agent/attempted
 agent/personal
 agent/non-personal
 agent/newsletter

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ agent/newsletter/theme/disciple-making
 
 Gmail will treat the `/` as a label hierarchy separator, nesting them under an `agent` parent. The daemon verifies all labels exist on startup and exits with an error if any are missing.
 
+> **Upgrading an existing deployment:** because startup validation is strict, a release that adds a new required label will exit (and, under Docker, crash-loop) until you create it. Create any newly-required labels in Gmail **before** deploying the new version. This release adds **`agent/attempted`** (applied to threads abandoned after repeated failures); create it first, then upgrade.
+
 ## Running
 
 ### Local development

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 [daemon]
 poll_interval_seconds = 60
 max_emails_per_cycle = 10       # Override per-run with the MAX_EMAILS_PER_CYCLE env var
-gmail_query = "in:inbox -label:agent/processed"
+gmail_query = "in:inbox -label:agent/processed -label:agent/attempted"
 # Max characters of thread transcript sent to the classifier. Kept modest
 # because the local model prefills the WHOLE transcript before answering:
 # tens-of-thousands-of-char threads take minutes to prefill on consumer
@@ -29,6 +29,7 @@ needs_response = "agent/needs-response"
 fyi = "agent/fyi"
 low_priority = "agent/low-priority"
 processed = "agent/processed"
+attempted = "agent/attempted"   # applied on give-up (repeated failures); excluded from gmail_query
 personal = "agent/personal"
 non_personal = "agent/non-personal"
 

--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,12 @@ local_parallel = 1
 # when max_emails_per_cycle is large; the cloud/local semaphores gate only the
 # downstream classify calls, not the fetch.
 fetch_parallel = 4
+# Max concurrent label-application writes (modify_message via apply_classification /
+# mark_processed / mark_attempted / apply_newsletter_classification). Bounds the
+# proxy-WRITE burst when max_emails_per_cycle is large (e.g. draining a backlog).
+# Separate from fetch_parallel because writes may block on human approval
+# (WRITE_TIMEOUT, 300s), so the sizing tradeoff differs. Override: WRITE_PARALLEL.
+write_parallel = 4
 healthcheck_file = "/tmp/healthcheck"
 
 [labels]

--- a/daemon.py
+++ b/daemon.py
@@ -160,6 +160,7 @@ async def _give_up_if_stuck(
     msg_ids: list[str],
     failure_tracker: "FailureTracker | None",
     label_manager: LabelManager,
+    write_sem: asyncio.Semaphore | None = None,
 ) -> bool:
     """Record a thread-specific failure; if it has failed too many times, mark it
     agent/attempted so it stops being retried every cycle.
@@ -181,7 +182,8 @@ async def _give_up_if_stuck(
         thread_id, failure_tracker.max_failures,
     )
     try:
-        await label_manager.mark_attempted(msg_ids)
+        async with (write_sem or nullcontext()):
+            await label_manager.mark_attempted(msg_ids)
     except Exception:
         log.exception("Could not mark stuck thread %s attempted", thread_id)
         return False
@@ -245,6 +247,7 @@ async def process_single_thread(
     newsletter_only: bool = False,
     failure_tracker: "FailureTracker | None" = None,
     fetch_sem: asyncio.Semaphore | None = None,
+    write_sem: asyncio.Semaphore | None = None,
 ) -> bool:
     """Process a single thread through the classification pipeline.
 
@@ -318,11 +321,12 @@ async def process_single_thread(
                     all_themes.extend(sr.themes)
                 all_themes = list(dict.fromkeys(all_themes))  # dedupe, preserve order
 
-                await label_manager.apply_newsletter_classification(
-                    message_ids=all_msg_ids,
-                    tier=best_tier,
-                    themes=all_themes,
-                )
+                async with (write_sem or nullcontext()):
+                    await label_manager.apply_newsletter_classification(
+                        message_ids=all_msg_ids,
+                        tier=best_tier,
+                        themes=all_themes,
+                    )
 
                 # Write structured results
                 if newsletter_output_file:
@@ -415,11 +419,14 @@ async def process_single_thread(
                 new_priority,
             )
             # Still mark as processed so the thread isn't retried every cycle
-            await label_manager.mark_processed(all_msg_ids)
+            async with (write_sem or nullcontext()):
+                await label_manager.mark_processed(all_msg_ids)
             return True
 
-        # Apply labels to ALL messages in thread
-        await label_manager.apply_classification(all_msg_ids, result.label, result.sender_type)
+        # Apply labels to ALL messages in thread (bounded by write_sem so a large
+        # max_emails_per_cycle can't burst one concurrent write per thread).
+        async with (write_sem or nullcontext()):
+            await label_manager.apply_classification(all_msg_ids, result.label, result.sender_type)
         log.info(
             "Classified thread %s (%d msgs): sender=%s label=%s — %s",
             thread_id,
@@ -456,13 +463,13 @@ async def process_single_thread(
         # the timeout) — eligible for give-up so one huge thread can't be retried
         # forever. (Connect/pool timeouts are LLMUnavailableError, handled above.)
         log.error("Timeout processing thread %s: %s", thread_id, exc)
-        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager)
+        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager, write_sem)
     except RuntimeError as exc:
         log.error("Thread %s: %s", thread_id, exc)
-        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager)
+        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager, write_sem)
     except Exception:
         log.exception("Error processing thread %s", thread_id)
-        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager)
+        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager, write_sem)
 
 
 def summarize_cycle(
@@ -608,9 +615,11 @@ async def run_daemon() -> None:
     local_parallel = resolve_int_env("LOCAL_PARALLEL", daemon_config.get("local_parallel", 1))
     local_sem = asyncio.Semaphore(local_parallel)
     fetch_sem = asyncio.Semaphore(daemon_config.get("fetch_parallel", 4))
+    write_parallel = resolve_int_env("WRITE_PARALLEL", daemon_config.get("write_parallel", 4))
+    write_sem = asyncio.Semaphore(write_parallel)
     log.info(
-        "Concurrency limits: cloud=%d, local=%d, fetch=%d",
-        cloud_sem._value, local_sem._value, fetch_sem._value,
+        "Concurrency limits: cloud=%d, local=%d, fetch=%d, write=%d",
+        cloud_sem._value, local_sem._value, fetch_sem._value, write_sem._value,
     )
     if local_parallel > 8:
         log.warning(
@@ -678,6 +687,7 @@ async def run_daemon() -> None:
                         newsletter_only=newsletter_only,
                         failure_tracker=failure_tracker,
                         fetch_sem=fetch_sem,
+                        write_sem=write_sem,
                     )
                     for tid, msg_ids in thread_items
                 ),

--- a/daemon.py
+++ b/daemon.py
@@ -186,22 +186,19 @@ async def _give_up_if_stuck(
     failure_tracker.record_failure(thread_id)
     if not failure_tracker.should_give_up(thread_id):
         return False
-    log.error(
-        "Thread %s failed %d+ times — marking agent/attempted to break the retry loop",
-        thread_id, failure_tracker.max_failures,
-    )
     try:
         async with (write_sem or nullcontext()):
             await label_manager.mark_attempted(msg_ids)
     except ProxyUnavailableError as exc:
         # The proxy is transiently down, so the agent/attempted marker can't be written
-        # right now — expected during an outage, not a bug. The failure count stays
-        # ≥ max_failures (we don't record the give-up), so the thread remains
-        # give-up-eligible and the marker write is retried next cycle once the proxy
-        # recovers. Log a clean warning rather than spamming a traceback for an expected
-        # transient condition. (The thread keeps re-matching the query until it is
-        # actually labeled; skipping the re-classification in that window is a separate
-        # efficiency concern, tracked in #29.)
+        # right now — expected during an outage, not a bug. We return without recording
+        # the give-up, so the thread stays give-up-eligible: its failure count is left
+        # ≥ max_failures (this arm returns False, so the poll loop's success-only
+        # count-clear never runs), and the marker write is retried next cycle once the
+        # proxy recovers. Log a clean warning rather than spamming a traceback for an
+        # expected transient condition. (The thread keeps re-matching the query until it
+        # is actually labeled; skipping the re-classification in that window is a
+        # separate efficiency concern, tracked in #29.)
         log.warning(
             "Proxy unavailable marking stuck thread %s attempted — will retry next cycle: %s",
             thread_id, exc,
@@ -213,6 +210,13 @@ async def _give_up_if_stuck(
         # than looping silently as if benign.
         log.exception("Could not mark stuck thread %s attempted", thread_id)
         return False
+    # Logged once here — AFTER the marker write actually lands — not before it: a
+    # transient write-outage can retry this for several cycles, and logging on every
+    # attempt would re-spam ERROR for what is an expected, recoverable condition.
+    log.error(
+        "Thread %s failed %d+ times — marked agent/attempted to break the retry loop",
+        thread_id, failure_tracker.max_failures,
+    )
     failure_tracker.record_give_up(thread_id)
     # Note: the poll loop clears the failure count on every True result (which a
     # give-up returns), so the count is reset there — no need to clear it here too.
@@ -473,20 +477,22 @@ async def process_single_thread(
         return False
     except ProxyUnavailableError as exc:
         # api-proxy unavailable for THIS thread's call — connection refused, a timeout,
-        # a dropped connection, or a 5xx / exhausted-429 response.
+        # a dropped connection, a 5xx / exhausted-429 response, or a non-JSON 2xx body.
         #
         # Unlike LLMUnavailableError above, this is give-up-eligible (issue #26). The
-        # asymmetry is deliberate: an endpoint-wide PROXY outage is caught one level up
-        # — list_messages (also a proxy call) fails first, so the whole cycle defers
-        # (see the poll loop) and no thread is ever processed or counted. So reaching
-        # here means the proxy served other calls this cycle and only this thread's
-        # call failed; a fault that PERSISTS across cycles is poison (e.g. a
-        # deterministic 5xx on one unserializable thread) and must be bounded like
-        # Timeout/RuntimeError below, not retried forever. A transient blip clears its
-        # count via the poll-loop success-clear before reaching the threshold.
-        # (An LLM outage, by contrast, is invisible at the cycle level — the proxy is
-        # up — so LLMUnavailableError must never give up, or one MLX outage would
-        # abandon every person thread.)
+        # asymmetry is deliberate: a *fully* endpoint-wide PROXY outage is caught one
+        # level up — list_messages (also a proxy call) fails first, so the whole cycle
+        # defers (see the poll loop) and no thread is ever processed or counted. A fault
+        # that reaches here is therefore either thread-specific (e.g. a deterministic
+        # 5xx on one unserializable thread) or a partial/route-selective degradation
+        # (e.g. get_thread garbles while list_messages stays healthy); if it PERSISTS
+        # across cycles it must be bounded like Timeout/RuntimeError below, not retried
+        # forever. A transient blip clears its count via the poll-loop success-clear
+        # before reaching the threshold. The accepted residual is that a *sustained*
+        # partial outage can abandon the backlog — but to the findable, re-processable
+        # agent/attempted (issue #23), not to lost mail. (An LLM outage, by contrast, is
+        # invisible at the cycle level — the proxy is up — so LLMUnavailableError must
+        # never give up, or one MLX outage would abandon every person thread.)
         log.warning("api-proxy unavailable processing thread %s: %s", thread_id, exc)
         return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager, write_sem)
     except httpx.ConnectError as exc:
@@ -749,11 +755,12 @@ async def run_daemon() -> None:
             )
             backoff = min(backoff * 2, poll_interval * 10)
         except ProxyError as exc:
-            # A request-specific proxy fault from the cycle-level list_messages call
-            # (a 4xx — e.g. a malformed gmail_query 400 — or a non-JSON 2xx body).
-            # It won't fix itself, but it's a known, named condition: log it as a
-            # warning and back off rather than spewing a full traceback every cycle.
-            # (ProxyUnavailableError is handled above as transient.)
+            # A request-specific proxy fault from the cycle-level list_messages call:
+            # a 4xx, e.g. a malformed gmail_query 400. It won't fix itself, but it's a
+            # known, named condition: log it as a warning and back off rather than
+            # spewing a full traceback every cycle. (The transient faults — 5xx, an
+            # exhausted 429, a non-JSON 2xx body — are ProxyUnavailableError, handled
+            # by the arm above.)
             log.warning(
                 "api-proxy rejected the poll request (%s: %s) — retrying in %ds",
                 type(exc).__name__, exc, backoff,

--- a/daemon.py
+++ b/daemon.py
@@ -23,7 +23,12 @@ from gmail_utils import decode_body, get_header
 from labeler import LabelManager, _get_priority
 from llm_client import LLMClient, LLMUnavailableError
 from newsletter import NewsletterClassifier, NewsletterTier, is_newsletter, write_assessment
-from proxy_client import GmailProxyClient, ProxyError, ProxyUnavailableError
+from proxy_client import (
+    TRANSIENT_TRANSPORT_ERRORS,
+    GmailProxyClient,
+    ProxyError,
+    ProxyUnavailableError,
+)
 
 load_dotenv()
 
@@ -495,19 +500,6 @@ def summarize_cycle(
     return processed, given_up
 
 
-# Transport faults that mean the api-proxy is *transiently* unreachable —
-# connection refused, any timeout, a dropped/garbled connection — so the daemon
-# should wait and retry rather than crash. This is a deliberate subset of
-# httpx.TransportError: httpx.UnsupportedProtocol (a missing/unsupported
-# PROXY_URL scheme) is also a TransportError but is a permanent misconfiguration
-# that must surface immediately instead of being retried forever.
-TRANSIENT_TRANSPORT_ERRORS = (
-    httpx.TimeoutException,
-    httpx.NetworkError,
-    httpx.ProtocolError,
-)
-
-
 async def verify_labels_with_retry(
     label_manager: LabelManager,
     initial_backoff: int = 5,
@@ -521,10 +513,15 @@ async def verify_labels_with_retry(
     under Docker:
 
       * a transport fault — connection refused, a connect/read timeout, a
-        dropped connection (``TRANSIENT_TRANSPORT_ERRORS``); and
+        dropped connection; and
       * a proxy that is reachable but whose Gmail backend is still initializing,
-        which answers 5xx and surfaces as ``proxy_client.ProxyError`` (NOT an
-        ``httpx.TransportError``, so it must be named explicitly).
+        which answers 5xx (or 429).
+
+    ``verify_labels`` reaches the proxy through ``_send``, which already wraps both
+    of those into ``proxy_client.ProxyUnavailableError`` (a ``ProxyError`` subclass),
+    so catching ``ProxyError`` covers them. The ``TRANSIENT_TRANSPORT_ERRORS`` prefix
+    is kept as defence-in-depth in case a future code path reaches a raw transport
+    fault here without going through ``_send``.
 
     Permanent failures propagate immediately so the operator sees an actionable
     error rather than a silent, endless retry: a misconfigured ``PROXY_URL``
@@ -718,6 +715,17 @@ async def run_daemon() -> None:
                 proxy_client.proxy_url,
                 type(exc).__name__,
                 backoff,
+            )
+            backoff = min(backoff * 2, poll_interval * 10)
+        except ProxyError as exc:
+            # A request-specific proxy fault from the cycle-level list_messages call
+            # (a 4xx — e.g. a malformed gmail_query 400 — or a non-JSON 2xx body).
+            # It won't fix itself, but it's a known, named condition: log it as a
+            # warning and back off rather than spewing a full traceback every cycle.
+            # (ProxyUnavailableError is handled above as transient.)
+            log.warning(
+                "api-proxy rejected the poll request (%s: %s) — retrying in %ds",
+                type(exc).__name__, exc, backoff,
             )
             backoff = min(backoff * 2, poll_interval * 10)
         except Exception:

--- a/daemon.py
+++ b/daemon.py
@@ -23,7 +23,7 @@ from gmail_utils import decode_body, get_header
 from labeler import LabelManager, _get_priority
 from llm_client import LLMClient, LLMUnavailableError
 from newsletter import NewsletterClassifier, NewsletterTier, is_newsletter, write_assessment
-from proxy_client import GmailProxyClient, ProxyError
+from proxy_client import GmailProxyClient, ProxyError, ProxyUnavailableError
 
 load_dotenv()
 
@@ -434,8 +434,17 @@ async def process_single_thread(
         # next cycle (preserves graceful degradation of the privacy invariant).
         log.warning("LLM unavailable processing thread %s: %s", thread_id, exc)
         return False
+    except ProxyUnavailableError as exc:
+        # api-proxy transiently unreachable — connection refused, a timeout, a
+        # dropped connection, or a 5xx server error (almost always endpoint-wide).
+        # Transient like LLMUnavailableError: retry next cycle, never give up, so a
+        # proxy outage can't abandon emails. (A request-specific 4xx is a plain
+        # ProxyError and falls through to the give-up path below.)
+        log.warning("api-proxy unavailable processing thread %s: %s", thread_id, exc)
+        return False
     except httpx.ConnectError as exc:
-        # Proxy/endpoint unreachable — transient. Retry next cycle, don't give up.
+        # Defensive: a raw ConnectError shouldn't escape the wrapped clients, but if
+        # one does it's still a transient outage — retry next cycle, don't give up.
         log.warning("Connection error processing thread %s: %s", thread_id, exc)
         return False
     except TimeoutError as exc:
@@ -686,7 +695,10 @@ async def run_daemon() -> None:
             # Reset backoff on success
             backoff = poll_interval
 
-        except TRANSIENT_TRANSPORT_ERRORS as exc:
+        except TRANSIENT_TRANSPORT_ERRORS + (ProxyUnavailableError,) as exc:
+            # A transiently-unreachable proxy (raw transport fault, or a wrapped
+            # ProxyUnavailableError — connection/timeout/5xx — from list_messages):
+            # back off and retry rather than logging a full traceback.
             log.warning(
                 "Lost connection to api-proxy at %s (%s) — retrying in %ds",
                 proxy_client.proxy_url,

--- a/daemon.py
+++ b/daemon.py
@@ -115,11 +115,15 @@ def resolve_newsletter_llm_endpoint() -> tuple[str, str]:
 class FailureTracker:
     """Counts consecutive thread-specific failures to break infinite retry loops.
 
-    Only genuine processing failures are recorded — never transient
-    unavailability (a ConnectError when an LLM endpoint is down) — so an outage
-    doesn't cause threads to be given up. In-memory and session-scoped: counts
-    reset on daemon restart, so a thread that failed for a since-resolved reason
-    gets another chance after a restart.
+    Records only failures the caller deems give-up-eligible. An endpoint-wide
+    outage never lands here: an LLM outage (ConnectError → LLMUnavailableError) is
+    deferred per-thread without counting, and a proxy outage fails the cycle-level
+    list_messages first, so the whole cycle defers before any thread is counted.
+    A *persistent per-thread* fault — a poison thread, including a deterministic
+    per-request proxy 5xx (issue #26) — does accrue here and is given up once it
+    hits max_failures. In-memory and session-scoped: counts reset on daemon
+    restart, so a thread that failed for a since-resolved reason gets another
+    chance after a restart.
     """
 
     def __init__(self, max_failures: int = 5):
@@ -451,13 +455,23 @@ async def process_single_thread(
         log.warning("LLM unavailable processing thread %s: %s", thread_id, exc)
         return False
     except ProxyUnavailableError as exc:
-        # api-proxy transiently unreachable — connection refused, a timeout, a
-        # dropped connection, or a 5xx server error (almost always endpoint-wide).
-        # Transient like LLMUnavailableError: retry next cycle, never give up, so a
-        # proxy outage can't abandon emails. (A request-specific 4xx is a plain
-        # ProxyError and falls through to the give-up path below.)
+        # api-proxy unavailable for THIS thread's call — connection refused, a timeout,
+        # a dropped connection, or a 5xx / exhausted-429 response.
+        #
+        # Unlike LLMUnavailableError above, this is give-up-eligible (issue #26). The
+        # asymmetry is deliberate: an endpoint-wide PROXY outage is caught one level up
+        # — list_messages (also a proxy call) fails first, so the whole cycle defers
+        # (see the poll loop) and no thread is ever processed or counted. So reaching
+        # here means the proxy served other calls this cycle and only this thread's
+        # call failed; a fault that PERSISTS across cycles is poison (e.g. a
+        # deterministic 5xx on one unserializable thread) and must be bounded like
+        # Timeout/RuntimeError below, not retried forever. A transient blip clears its
+        # count via the poll-loop success-clear before reaching the threshold.
+        # (An LLM outage, by contrast, is invisible at the cycle level — the proxy is
+        # up — so LLMUnavailableError must never give up, or one MLX outage would
+        # abandon every person thread.)
         log.warning("api-proxy unavailable processing thread %s: %s", thread_id, exc)
-        return False
+        return await _give_up_if_stuck(thread_id, ids_to_mark, failure_tracker, label_manager, write_sem)
     except httpx.ConnectError as exc:
         # Defensive: a raw ConnectError shouldn't escape the wrapped clients, but if
         # one does it's still a transient outage — retry next cycle, don't give up.

--- a/daemon.py
+++ b/daemon.py
@@ -193,7 +193,24 @@ async def _give_up_if_stuck(
     try:
         async with (write_sem or nullcontext()):
             await label_manager.mark_attempted(msg_ids)
+    except ProxyUnavailableError as exc:
+        # The proxy is transiently down, so the agent/attempted marker can't be written
+        # right now — expected during an outage, not a bug. The failure count stays
+        # ≥ max_failures (we don't record the give-up), so the thread remains
+        # give-up-eligible and the marker write is retried next cycle once the proxy
+        # recovers. Log a clean warning rather than spamming a traceback for an expected
+        # transient condition. (The thread keeps re-matching the query until it is
+        # actually labeled; skipping the re-classification in that window is a separate
+        # efficiency concern, tracked in #29.)
+        log.warning(
+            "Proxy unavailable marking stuck thread %s attempted — will retry next cycle: %s",
+            thread_id, exc,
+        )
+        return False
     except Exception:
+        # An unexpected, likely-permanent marker-write failure (a real bug, or a
+        # misconfigured label): keep the full traceback so it stays diagnosable rather
+        # than looping silently as if benign.
         log.exception("Could not mark stuck thread %s attempted", thread_id)
         return False
     failure_tracker.record_give_up(thread_id)

--- a/daemon.py
+++ b/daemon.py
@@ -144,7 +144,7 @@ class FailureTracker:
         self._counts = {tid: n for tid, n in self._counts.items() if tid in active}
 
     def record_give_up(self, thread_id: str) -> None:
-        """Record that a thread was abandoned (marked processed without a label),
+        """Record that a thread was abandoned (marked agent/attempted, no classification),
         so the per-cycle summary can report give-ups distinctly from classifications."""
         self._given_up.append(thread_id)
 
@@ -162,10 +162,14 @@ async def _give_up_if_stuck(
     label_manager: LabelManager,
 ) -> bool:
     """Record a thread-specific failure; if it has failed too many times, mark it
-    processed so it stops being retried every cycle.
+    agent/attempted so it stops being retried every cycle.
 
-    Returns True if the thread was given up (marked processed → handled), or False
-    if it should simply be retried next cycle.
+    Uses agent/attempted (not agent/processed): the thread is excluded from the
+    unprocessed query either way, but the distinct label keeps abandoned threads
+    findable and separate from successfully-classified mail.
+
+    Returns True if the thread was given up (marked agent/attempted → handled), or
+    False if it should simply be retried next cycle.
     """
     if failure_tracker is None:
         return False
@@ -173,13 +177,13 @@ async def _give_up_if_stuck(
     if not failure_tracker.should_give_up(thread_id):
         return False
     log.error(
-        "Thread %s failed %d+ times — marking processed to break the retry loop",
+        "Thread %s failed %d+ times — marking agent/attempted to break the retry loop",
         thread_id, failure_tracker.max_failures,
     )
     try:
-        await label_manager.mark_processed(msg_ids)
+        await label_manager.mark_attempted(msg_ids)
     except Exception:
-        log.exception("Could not mark stuck thread %s processed", thread_id)
+        log.exception("Could not mark stuck thread %s attempted", thread_id)
         return False
     failure_tracker.record_give_up(thread_id)
     # Note: the poll loop clears the failure count on every True result (which a

--- a/labeler.py
+++ b/labeler.py
@@ -141,6 +141,22 @@ class LabelManager:
                 kwargs["remove_label_ids"] = remove_label_ids
             await self.proxy.modify_message(**kwargs)
 
+    async def _apply_marker(self, message_ids: str | list[str], config_key: str) -> None:
+        """Apply a single marker label (no INBOX change) to each message.
+
+        Shared by mark_processed/mark_attempted, which differ only in which
+        labels_config key names the marker.
+        """
+        if isinstance(message_ids, str):
+            ids = [message_ids]
+        else:
+            ids = list(message_ids)
+
+        marker_name = self.labels_config[config_key]
+        add_label_ids = [self.label_ids[marker_name]]
+        for msg_id in ids:
+            await self.proxy.modify_message(message_id=msg_id, add_label_ids=add_label_ids)
+
     async def mark_processed(self, message_ids: str | list[str]) -> None:
         """Apply only the agent/processed marker label.
 
@@ -148,15 +164,7 @@ class LabelManager:
         higher priority, so we skip re-classification but still need to
         mark it processed to prevent infinite retry loops.
         """
-        if isinstance(message_ids, str):
-            ids = [message_ids]
-        else:
-            ids = list(message_ids)
-
-        processed_name = self.labels_config["processed"]
-        add_label_ids = [self.label_ids[processed_name]]
-        for msg_id in ids:
-            await self.proxy.modify_message(message_id=msg_id, add_label_ids=add_label_ids)
+        await self._apply_marker(message_ids, "processed")
 
     async def mark_attempted(self, message_ids: str | list[str]) -> None:
         """Apply only the agent/attempted marker label.
@@ -167,15 +175,7 @@ class LabelManager:
         findable in Gmail for manual cleanup and remain semantically separate from
         successfully-classified mail.
         """
-        if isinstance(message_ids, str):
-            ids = [message_ids]
-        else:
-            ids = list(message_ids)
-
-        attempted_name = self.labels_config["attempted"]
-        add_label_ids = [self.label_ids[attempted_name]]
-        for msg_id in ids:
-            await self.proxy.modify_message(message_id=msg_id, add_label_ids=add_label_ids)
+        await self._apply_marker(message_ids, "attempted")
 
     async def apply_newsletter_classification(
         self,

--- a/labeler.py
+++ b/labeler.py
@@ -61,6 +61,7 @@ class LabelManager:
             "fyi",
             "low_priority",
             "processed",
+            "attempted",
             "personal",
             "non_personal",
         ):
@@ -154,6 +155,25 @@ class LabelManager:
 
         processed_name = self.labels_config["processed"]
         add_label_ids = [self.label_ids[processed_name]]
+        for msg_id in ids:
+            await self.proxy.modify_message(message_id=msg_id, add_label_ids=add_label_ids)
+
+    async def mark_attempted(self, message_ids: str | list[str]) -> None:
+        """Apply only the agent/attempted marker label.
+
+        Used when the daemon gives up on a thread after repeated failures. Like
+        agent/processed it stops the thread re-matching the unprocessed query (so
+        the retry loop ends), but it is a *distinct* label so abandoned threads are
+        findable in Gmail for manual cleanup and remain semantically separate from
+        successfully-classified mail.
+        """
+        if isinstance(message_ids, str):
+            ids = [message_ids]
+        else:
+            ids = list(message_ids)
+
+        attempted_name = self.labels_config["attempted"]
+        add_label_ids = [self.label_ids[attempted_name]]
         for msg_id in ids:
             await self.proxy.modify_message(message_id=msg_id, add_label_ids=add_label_ids)
 

--- a/llm_client.py
+++ b/llm_client.py
@@ -145,7 +145,19 @@ class LLMClient:
             )
 
         msg = response.json()["choices"][0]["message"]
-        content = msg["content"]
+        content = msg.get("content")
+        if content is None:
+            # A reasoning model that exhausts max_tokens mid-<think> (or a GLM reply
+            # that returns only reasoning_content) yields a message with no usable
+            # `content`. Retrying as-is won't help, so this is request-specific/
+            # permanent: surface a clear RuntimeError (give-up-eligible via the daemon),
+            # never LLMUnavailableError (would retry forever) or a raw KeyError.
+            has_reasoning = bool(msg.get("reasoning_content") or msg.get("reasoning"))
+            raise RuntimeError(
+                f"LLM {self.model} returned no content "
+                f"(max_tokens={self.max_tokens} likely exhausted before a final answer; "
+                f"reasoning_content {'present' if has_reasoning else 'absent'})"
+            )
 
         if include_thinking:
             # GLM models return reasoning in a separate field

--- a/llm_client.py
+++ b/llm_client.py
@@ -146,12 +146,15 @@ class LLMClient:
 
         msg = response.json()["choices"][0]["message"]
         content = msg.get("content")
-        if content is None:
+        if not content:
             # A reasoning model that exhausts max_tokens mid-<think> (or a GLM reply
             # that returns only reasoning_content) yields a message with no usable
-            # `content`. Retrying as-is won't help, so this is request-specific/
+            # `content` — whether that arrives as null, a missing key, or an empty
+            # string. Retrying as-is won't help, so this is request-specific/
             # permanent: surface a clear RuntimeError (give-up-eligible via the daemon),
             # never LLMUnavailableError (would retry forever) or a raw KeyError.
+            # (An empty string must be caught too: it would otherwise parse to a
+            # default SERVICE / LOW_PRIORITY label and silently mislabel the email.)
             has_reasoning = bool(msg.get("reasoning_content") or msg.get("reasoning"))
             raise RuntimeError(
                 f"LLM {self.model} returned no content "

--- a/newsletter.py
+++ b/newsletter.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pathlib import Path
 
 from gmail_utils import get_header
-from llm_client import LLMClient
+from llm_client import LLMClient, LLMUnavailableError
 
 log = logging.getLogger(__name__)
 
@@ -230,8 +230,14 @@ class NewsletterClassifier:
     async def classify_newsletter(self, body: str) -> list[StoryResult]:
         """Run the full newsletter classification pipeline.
 
-        Individual story failures are isolated — a quality failure doesn't
+        Individual *per-story* failures are isolated — a quality failure doesn't
         prevent theme classification, and vice versa.
+
+        A *transient* LLM outage (LLMUnavailableError) is NOT isolated: it
+        propagates so the daemon retries the whole newsletter thread next cycle,
+        rather than committing a permanently mis-graded newsletter (empty
+        tier/themes) and marking it processed. Mirrors the email pipeline's
+        transient-outage guarantee.
         """
         stories = await self.extract_stories(body)
         if not stories:
@@ -248,6 +254,8 @@ class NewsletterClassifier:
                     result.scores = scores
                     result.average_score = sum(scores.values()) / len(scores)
                     result.tier = compute_tier(scores)
+            except LLMUnavailableError:
+                raise  # transient — let the daemon retry the whole newsletter
             except Exception:
                 log.warning("Quality assessment failed for story: %s", title)
 
@@ -255,6 +263,8 @@ class NewsletterClassifier:
                 themes, theme_cot = await self.classify_themes(title, text)
                 result.themes = themes
                 result.theme_cot = theme_cot
+            except LLMUnavailableError:
+                raise  # transient — let the daemon retry the whole newsletter
             except Exception:
                 log.warning("Theme classification failed for story: %s", title)
 

--- a/proxy_client.py
+++ b/proxy_client.py
@@ -59,11 +59,13 @@ class ProxyUnavailableError(ProxyError):
 
 
 # Transport faults that mean the proxy is *transiently* unreachable — connection
-# refused, any timeout, a dropped/garbled connection. Mirrors
-# daemon.TRANSIENT_TRANSPORT_ERRORS: httpx.UnsupportedProtocol (a missing/unsupported
-# PROXY_URL scheme) is also a TransportError but is a permanent misconfiguration that
-# must surface immediately instead of being wrapped and retried forever.
-_TRANSIENT_TRANSPORT_ERRORS = (
+# refused, any timeout, a dropped/garbled connection. NOTE: httpx.UnsupportedProtocol
+# (a missing/unsupported PROXY_URL scheme) is also a TransportError but is a permanent
+# misconfiguration that must surface immediately instead of being wrapped and retried
+# forever. This is the single source of truth for that classification; daemon.py
+# imports it (rather than re-declaring it) so the two layers can't silently disagree
+# about what counts as transient.
+TRANSIENT_TRANSPORT_ERRORS = (
     httpx.TimeoutException,
     httpx.NetworkError,
     httpx.ProtocolError,
@@ -135,11 +137,15 @@ class GmailProxyClient:
             message = self._parse_error_message(response, "Forbidden - operation blocked or rejected")
             raise ProxyForbiddenError(message)
 
-        if response.status_code >= 500:
-            # Server-side failure — almost always endpoint-wide (proxy crashed, or
-            # Gmail returned 5xx upstream), so treat it as transient and defer,
-            # rather than abandoning the thread. 502/503/504 are already retried at
-            # the HTTP layer (retry.py) before reaching here.
+        if response.status_code == 429 or response.status_code >= 500:
+            # Transient, endpoint-wide conditions that clear on their own → defer and
+            # retry rather than abandoning the thread:
+            #   * 429 — rate-limited. Reaching here means retry.py already exhausted
+            #     its retry budget (429 ∈ RETRYABLE_STATUS_CODES), so the throttle is
+            #     sustained; next poll cycle is the right place to retry, not give-up.
+            #   * 5xx — server-side failure (proxy crashed, or Gmail returned 5xx
+            #     upstream). 502/503/504 are likewise already retried at the HTTP
+            #     layer (retry.py) before reaching here.
             message = self._parse_error_message(response, f"Proxy error: {response.status_code}")
             raise ProxyUnavailableError(message)
 
@@ -163,7 +169,7 @@ class GmailProxyClient:
         """
         try:
             response = await retry_with_backoff(do_request, operation)
-        except _TRANSIENT_TRANSPORT_ERRORS as exc:
+        except TRANSIENT_TRANSPORT_ERRORS as exc:
             raise ProxyUnavailableError(
                 f"api-proxy unavailable during {operation} "
                 f"({type(exc).__name__}): {exc}"

--- a/proxy_client.py
+++ b/proxy_client.py
@@ -59,16 +59,22 @@ class ProxyUnavailableError(ProxyError):
 
 
 # Transport faults that mean the proxy is *transiently* unreachable — connection
-# refused, any timeout, a dropped/garbled connection. NOTE: httpx.UnsupportedProtocol
-# (a missing/unsupported PROXY_URL scheme) is also a TransportError but is a permanent
-# misconfiguration that must surface immediately instead of being wrapped and retried
-# forever. This is the single source of truth for that classification; daemon.py
-# imports it (rather than re-declaring it) so the two layers can't silently disagree
-# about what counts as transient.
+# refused, any timeout, a dropped/garbled connection (RemoteProtocolError: the server
+# disconnected mid-response). This is the single source of truth for that
+# classification; daemon.py imports it (rather than re-declaring it) so the two layers
+# can't silently disagree about what counts as transient.
+#
+# Two TransportError siblings are DELIBERATELY excluded because they are permanent, not
+# transient, and must surface / be give-up-eligible rather than retried forever:
+#   * httpx.UnsupportedProtocol — a missing/unsupported PROXY_URL scheme.
+#   * httpx.LocalProtocolError — a client-side request-construction fault (e.g. an
+#     illegal header built from our own inputs). It is a subclass of httpx.ProtocolError,
+#     so we list the transient sibling (RemoteProtocolError) explicitly rather than the
+#     ProtocolError base, which would re-capture LocalProtocolError. (Issue #26.)
 TRANSIENT_TRANSPORT_ERRORS = (
     httpx.TimeoutException,
     httpx.NetworkError,
-    httpx.ProtocolError,
+    httpx.RemoteProtocolError,
 )
 
 

--- a/proxy_client.py
+++ b/proxy_client.py
@@ -34,9 +34,40 @@ class ProxyForbiddenError(Exception):
 
 
 class ProxyError(Exception):
-    """Raised for other proxy errors (5xx, connection errors, etc.)."""
+    """Raised for request-specific proxy errors — a 4xx response (other than 401/403)
+    or a non-JSON success body. These are eligible for the daemon's give-up logic:
+    retrying the same request as-is won't help.
+
+    The transient subset (endpoint unavailable / 5xx) is raised as the more specific
+    ProxyUnavailableError below; catching ProxyError still catches both.
+    """
 
     pass
+
+
+class ProxyUnavailableError(ProxyError):
+    """The api-proxy is transiently unreachable — connection refused, a timeout, a
+    dropped/garbled connection, or a 5xx server error.
+
+    Mirrors llm_client.LLMUnavailableError: a transient outage that should be
+    deferred and retried next cycle, NOT counted toward giving up on a thread.
+    Subclasses ProxyError so existing `except ProxyError` sites (e.g. startup label
+    verification) keep treating it as retryable.
+    """
+
+    pass
+
+
+# Transport faults that mean the proxy is *transiently* unreachable — connection
+# refused, any timeout, a dropped/garbled connection. Mirrors
+# daemon.TRANSIENT_TRANSPORT_ERRORS: httpx.UnsupportedProtocol (a missing/unsupported
+# PROXY_URL scheme) is also a TransportError but is a permanent misconfiguration that
+# must surface immediately instead of being wrapped and retried forever.
+_TRANSIENT_TRANSPORT_ERRORS = (
+    httpx.TimeoutException,
+    httpx.NetworkError,
+    httpx.ProtocolError,
+)
 
 
 class GmailProxyClient:
@@ -105,8 +136,12 @@ class GmailProxyClient:
             raise ProxyForbiddenError(message)
 
         if response.status_code >= 500:
+            # Server-side failure — almost always endpoint-wide (proxy crashed, or
+            # Gmail returned 5xx upstream), so treat it as transient and defer,
+            # rather than abandoning the thread. 502/503/504 are already retried at
+            # the HTTP layer (retry.py) before reaching here.
             message = self._parse_error_message(response, f"Proxy error: {response.status_code}")
-            raise ProxyError(message)
+            raise ProxyUnavailableError(message)
 
         if response.status_code >= 400:
             message = self._parse_error_message(response, f"Request error: {response.status_code}")
@@ -116,6 +151,24 @@ class GmailProxyClient:
             return response.json()
         except ValueError:
             raise ProxyError("Proxy returned non-JSON response for successful request")
+
+    async def _send(self, do_request, operation: str) -> dict:
+        """Run a request (with HTTP-status retries) and classify its outcome.
+
+        Wraps transient transport faults (connection refused, timeouts, dropped
+        connections) in ProxyUnavailableError so the daemon defers-and-retries
+        instead of counting them toward giving up on a thread. Response-status
+        errors are classified by _handle_response (5xx → ProxyUnavailableError,
+        4xx → ProxyError).
+        """
+        try:
+            response = await retry_with_backoff(do_request, operation)
+        except _TRANSIENT_TRANSPORT_ERRORS as exc:
+            raise ProxyUnavailableError(
+                f"api-proxy unavailable during {operation} "
+                f"({type(exc).__name__}): {exc}"
+            ) from exc
+        return self._handle_response(response)
 
     async def list_messages(
         self,
@@ -146,7 +199,7 @@ class GmailProxyClient:
             async with httpx.AsyncClient(timeout=self.READ_TIMEOUT) as client:
                 return await client.get(url, headers=self._get_headers(), params=params)
 
-        return self._handle_response(await retry_with_backoff(_do_request, "Gmail list_messages"))
+        return await self._send(_do_request, "Gmail list_messages")
 
     async def get_message(
         self,
@@ -171,7 +224,7 @@ class GmailProxyClient:
             async with httpx.AsyncClient(timeout=self.READ_TIMEOUT) as client:
                 return await client.get(url, headers=self._get_headers(), params=params)
 
-        return self._handle_response(await retry_with_backoff(_do_request, "Gmail get_message"))
+        return await self._send(_do_request, "Gmail get_message")
 
     async def get_thread(
         self,
@@ -196,7 +249,7 @@ class GmailProxyClient:
             async with httpx.AsyncClient(timeout=self.READ_TIMEOUT) as client:
                 return await client.get(url, headers=self._get_headers(), params=params)
 
-        return self._handle_response(await retry_with_backoff(_do_request, "Gmail get_thread"))
+        return await self._send(_do_request, "Gmail get_thread")
 
     async def modify_message(
         self,
@@ -227,7 +280,7 @@ class GmailProxyClient:
             async with httpx.AsyncClient(timeout=self.WRITE_TIMEOUT) as client:
                 return await client.post(url, headers=self._get_headers(), json=body)
 
-        return self._handle_response(await retry_with_backoff(_do_request, "Gmail modify_message"))
+        return await self._send(_do_request, "Gmail modify_message")
 
     async def trash_message(self, message_id: str, user_id: str = "me") -> dict:
         """Move a message to trash.
@@ -245,7 +298,7 @@ class GmailProxyClient:
             async with httpx.AsyncClient(timeout=self.WRITE_TIMEOUT) as client:
                 return await client.post(url, headers=self._get_headers())
 
-        return self._handle_response(await retry_with_backoff(_do_request, "Gmail trash_message"))
+        return await self._send(_do_request, "Gmail trash_message")
 
     async def untrash_message(self, message_id: str, user_id: str = "me") -> dict:
         """Remove a message from trash.
@@ -263,7 +316,7 @@ class GmailProxyClient:
             async with httpx.AsyncClient(timeout=self.WRITE_TIMEOUT) as client:
                 return await client.post(url, headers=self._get_headers())
 
-        return self._handle_response(await retry_with_backoff(_do_request, "Gmail untrash_message"))
+        return await self._send(_do_request, "Gmail untrash_message")
 
     async def list_labels(self, user_id: str = "me") -> dict:
         """List all labels in the user's mailbox.
@@ -280,7 +333,7 @@ class GmailProxyClient:
             async with httpx.AsyncClient(timeout=self.READ_TIMEOUT) as client:
                 return await client.get(url, headers=self._get_headers())
 
-        return self._handle_response(await retry_with_backoff(_do_request, "Gmail list_labels"))
+        return await self._send(_do_request, "Gmail list_labels")
 
     async def get_label(self, label_id: str, user_id: str = "me") -> dict:
         """Get a specific label by ID.
@@ -298,7 +351,7 @@ class GmailProxyClient:
             async with httpx.AsyncClient(timeout=self.READ_TIMEOUT) as client:
                 return await client.get(url, headers=self._get_headers())
 
-        return self._handle_response(await retry_with_backoff(_do_request, "Gmail get_label"))
+        return await self._send(_do_request, "Gmail get_label")
 
 
 # Singleton instance for convenience

--- a/proxy_client.py
+++ b/proxy_client.py
@@ -133,7 +133,9 @@ class GmailProxyClient:
         Raises:
             ProxyAuthError: For 401 responses.
             ProxyForbiddenError: For 403 responses.
-            ProxyError: For 5xx or other error responses.
+            ProxyUnavailableError: For transient faults — 5xx, an exhausted 429, or a
+                non-JSON 2xx body. (Subclass of ProxyError; the daemon defers on it.)
+            ProxyError: For a request-specific 4xx (give-up-eligible).
         """
         if response.status_code == 401:
             message = self._parse_error_message(response, "Unauthorized - invalid or missing API key")
@@ -162,7 +164,12 @@ class GmailProxyClient:
         try:
             return response.json()
         except ValueError:
-            raise ProxyError("Proxy returned non-JSON response for successful request")
+            # A 2xx with a non-JSON body — a truncated/garbled response, or an upstream
+            # gateway briefly returning an HTML error page with status 200. Transient
+            # like a 5xx, so raise the transient subclass: the daemon defers and retries
+            # rather than abandoning the thread, and a *persistent* non-JSON 2xx is still
+            # bounded by the FailureTracker give-up path (issue #27, building on #26).
+            raise ProxyUnavailableError("Proxy returned non-JSON response for successful request")
 
     async def _send(self, do_request, operation: str) -> dict:
         """Run a request (with HTTP-status retries) and classify its outcome.

--- a/proxy_client.py
+++ b/proxy_client.py
@@ -34,12 +34,13 @@ class ProxyForbiddenError(Exception):
 
 
 class ProxyError(Exception):
-    """Raised for request-specific proxy errors — a 4xx response (other than 401/403)
-    or a non-JSON success body. These are eligible for the daemon's give-up logic:
-    retrying the same request as-is won't help.
+    """Raised for a request-specific proxy fault — a 4xx response other than 401/403.
+    These are eligible for the daemon's give-up logic: retrying the same request as-is
+    won't help, so a persistent one is bounded by the FailureTracker.
 
-    The transient subset (endpoint unavailable / 5xx) is raised as the more specific
-    ProxyUnavailableError below; catching ProxyError still catches both.
+    The transient subset — endpoint unavailable, a 5xx, an exhausted 429, or a non-empty
+    non-JSON 2xx body — is raised as the more specific ProxyUnavailableError below;
+    catching ProxyError still catches both.
     """
 
     pass
@@ -164,11 +165,18 @@ class GmailProxyClient:
         try:
             return response.json()
         except ValueError:
-            # A 2xx with a non-JSON body — a truncated/garbled response, or an upstream
-            # gateway briefly returning an HTML error page with status 200. Transient
-            # like a 5xx, so raise the transient subclass: the daemon defers and retries
-            # rather than abandoning the thread, and a *persistent* non-JSON 2xx is still
-            # bounded by the FailureTracker give-up path (issue #27, building on #26).
+            if not response.content:
+                # An EMPTY 2xx body (e.g. 204 No Content from a write) is a success with
+                # nothing to parse — return {} rather than misclassifying it as a fault.
+                # (Classifying it transient would defer-and-retry forever, since the
+                # give-up marker write hits the same endpoint and would trip the same
+                # path; classifying it give-up-eligible would abandon a successful write.)
+                return {}
+            # A non-empty, non-JSON 2xx body — a truncated/garbled response, or an
+            # upstream gateway briefly returning an HTML error page with status 200.
+            # Transient like a 5xx, so raise the transient subclass: the daemon defers
+            # and retries rather than abandoning the thread, and a *persistent* one is
+            # still bounded by the FailureTracker give-up path (issue #27, building on #26).
             raise ProxyUnavailableError("Proxy returned non-JSON response for successful request")
 
     async def _send(self, do_request, operation: str) -> dict:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -312,9 +312,11 @@ class TestProcessSingleThread:
         # First two failures: retry next cycle (not handled), nothing marked processed.
         assert results[0] is False
         assert results[1] is False
-        # Third failure hits the threshold: give up — mark processed and report handled.
+        # Third failure hits the threshold: give up — mark agent/attempted (not
+        # agent/processed) so the abandoned thread is findable, and report handled.
         assert results[2] is True
-        mock_label_manager.mark_processed.assert_called_once_with(["msg_1"])
+        mock_label_manager.mark_attempted.assert_called_once_with(["msg_1"])
+        mock_label_manager.mark_processed.assert_not_called()
         # The give-up is recorded so the cycle summary can report it distinctly.
         assert tracker.take_given_up() == ["thread_stuck"]
 
@@ -427,7 +429,7 @@ class TestProcessSingleThread:
 
         assert results[0] is False  # first failure: retry
         assert results[1] is True   # threshold hit: give up
-        mock_label_manager.mark_processed.assert_called_once_with(["msg_001", "msg_002"])
+        mock_label_manager.mark_attempted.assert_called_once_with(["msg_001", "msg_002"])
 
     async def test_get_thread_is_bounded_by_fetch_sem(
         self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -470,6 +470,34 @@ class TestProcessSingleThread:
         assert result is True
         mock_proxy.get_thread.assert_called_once()
 
+    async def test_label_application_is_bounded_by_write_sem(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+        mock_thread_response,
+    ):
+        """Label-application writes run under write_sem, so they can't fan out unbounded.
+
+        Covers issue #17: the cloud/local/fetch semaphores gate reads + classify, but
+        the label-application phase (modify_message via apply_classification etc.)
+        previously ran with no bound, so a large max_emails_per_cycle could burst many
+        concurrent writes at the api-proxy / Gmail.
+        """
+        mock_proxy.get_thread.return_value = mock_thread_response
+        exhausted = asyncio.Semaphore(0)  # no write permits available
+
+        task = asyncio.create_task(process_single_thread(
+            "thread_001", ["msg_001"], mock_proxy, mock_classifier, mock_label_manager,
+            cloud_sem, local_sem, max_thread_chars=16000,
+            fetch_sem=asyncio.Semaphore(2), write_sem=exhausted,
+        ))
+        await asyncio.sleep(0.05)
+        # Fetch + classify ran, but blocked acquiring write_sem — no label write yet.
+        mock_proxy.get_thread.assert_called_once()
+        mock_label_manager.apply_classification.assert_not_called()
+        mock_label_manager.mark_processed.assert_not_called()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
     async def test_service_thread_classified_via_cloud(
         self,
         mock_proxy,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -359,27 +359,37 @@ class TestProcessSingleThread:
 
         mock_label_manager.mark_processed.assert_not_called()
 
-    async def test_proxy_unavailable_does_not_count_toward_give_up(
+    async def test_proxy_unavailable_is_give_up_eligible_per_thread(
         self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
     ):
-        """A transient api-proxy outage (ProxyUnavailableError) must defer, never give up.
+        """A per-thread ProxyUnavailableError is give-up-eligible (issue #26).
 
-        Covers issue #16: proxy-side timeouts / dropped connections / 5xx now surface
-        as ProxyUnavailableError, which is transient like LLMUnavailableError — it must
-        be retried next cycle, not counted toward abandoning the thread.
+        An endpoint-wide proxy outage is caught one level up: list_messages (also a
+        proxy call) fails first, so the whole cycle defers and no thread is processed
+        or counted. Reaching this per-thread handler means the proxy served other
+        calls this cycle but THIS thread's call failed — a fault that persists is
+        poison (e.g. a deterministic 5xx on one unserializable thread) and must be
+        bounded by the FailureTracker, not retried forever.
+
+        Contrast test_llm_unavailable_does_not_count_toward_give_up: an MLX outage is
+        NOT visible at the cycle level (the proxy is up), so it must never give up.
         """
-        mock_proxy.get_thread.side_effect = ProxyUnavailableError("proxy 503")
+        mock_proxy.get_thread.side_effect = ProxyUnavailableError("proxy 500 for one poison thread")
         tracker = FailureTracker(max_failures=2)
 
-        for _ in range(5):
-            result = await process_single_thread(
-                "thread_down", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
+        results = [
+            await process_single_thread(
+                "thread_poison", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
                 cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
             )
-            assert result is False
+            for _ in range(2)
+        ]
 
+        assert results[0] is False  # first failure: retry next cycle
+        assert results[1] is True   # threshold hit: give up
+        mock_label_manager.mark_attempted.assert_called_once_with(["msg_1"])
         mock_label_manager.mark_processed.assert_not_called()
-        mock_label_manager.mark_attempted.assert_not_called()
+        assert tracker.take_given_up() == ["thread_poison"]
 
     async def test_proxy_4xx_is_give_up_eligible(
         self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -24,7 +24,7 @@ from daemon import (
 from labeler import _get_priority
 from llm_client import LLMClient, LLMUnavailableError
 from newsletter import NewsletterTier, StoryResult
-from proxy_client import ProxyAuthError, ProxyError
+from proxy_client import ProxyAuthError, ProxyError, ProxyUnavailableError
 
 
 @pytest.fixture
@@ -356,6 +356,51 @@ class TestProcessSingleThread:
             assert result is False
 
         mock_label_manager.mark_processed.assert_not_called()
+
+    async def test_proxy_unavailable_does_not_count_toward_give_up(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+    ):
+        """A transient api-proxy outage (ProxyUnavailableError) must defer, never give up.
+
+        Covers issue #16: proxy-side timeouts / dropped connections / 5xx now surface
+        as ProxyUnavailableError, which is transient like LLMUnavailableError — it must
+        be retried next cycle, not counted toward abandoning the thread.
+        """
+        mock_proxy.get_thread.side_effect = ProxyUnavailableError("proxy 503")
+        tracker = FailureTracker(max_failures=2)
+
+        for _ in range(5):
+            result = await process_single_thread(
+                "thread_down", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
+            )
+            assert result is False
+
+        mock_label_manager.mark_processed.assert_not_called()
+        mock_label_manager.mark_attempted.assert_not_called()
+
+    async def test_proxy_4xx_is_give_up_eligible(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+    ):
+        """A request-specific proxy 4xx (plain ProxyError) stays give-up-eligible.
+
+        The transient subclass defers; the base ProxyError (e.g. a 404 for a thread
+        deleted between listing and fetching) should still be bounded by the
+        FailureTracker so it isn't retried forever.
+        """
+        mock_proxy.get_thread.side_effect = ProxyError("404 not found")
+        tracker = FailureTracker(max_failures=2)
+
+        results = [
+            await process_single_thread(
+                "thread_gone", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
+            )
+            for _ in range(2)
+        ]
+
+        assert results[0] is False  # first failure: retry
+        assert results[1] is True   # threshold hit: give up
 
     async def test_give_up_marks_all_thread_messages_not_just_query_stubs(
         self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -433,6 +433,9 @@ class TestProcessSingleThread:
             )
 
         assert result is False
+        # A failed marker write must NOT be recorded as a give-up: the thread wasn't
+        # labeled, so reporting it abandoned would be misleading and it keeps re-matching.
+        assert tracker.take_given_up() == []
         marker_logs = [r for r in caplog.records if "Could not mark" in r.getMessage()]
         assert marker_logs and any(r.levelno >= logging.ERROR and r.exc_info for r in marker_logs)
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -390,6 +391,50 @@ class TestProcessSingleThread:
         mock_label_manager.mark_attempted.assert_called_once_with(["msg_1"])
         mock_label_manager.mark_processed.assert_not_called()
         assert tracker.take_given_up() == ["thread_poison"]
+
+    async def test_give_up_write_transient_failure_logs_clean_warning(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem, caplog,
+    ):
+        """A transient proxy outage DURING the give-up marker write is expected, not a
+        bug (issue #32): log a retryable warning (no traceback) and retry next cycle —
+        distinct from an unexpected/permanent marker-write failure. The give-up is not
+        recorded, so the thread stays give-up-eligible until the marker write lands.
+        """
+        mock_proxy.get_thread.side_effect = RuntimeError("classification boom")
+        mock_label_manager.mark_attempted.side_effect = ProxyUnavailableError("proxy 503 on write")
+        tracker = FailureTracker(max_failures=1)  # give up on the first failure
+
+        with caplog.at_level(logging.WARNING):
+            result = await process_single_thread(
+                "thread_x", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
+            )
+
+        assert result is False                # couldn't mark → retry next cycle
+        assert tracker.take_given_up() == []  # not recorded as given up
+        retry_logs = [r for r in caplog.records if "will retry" in r.getMessage()]
+        assert retry_logs, "expected a clean retry warning for the transient marker-write failure"
+        # Transient: a clean WARNING, never an ERROR-with-traceback.
+        assert all(r.levelno == logging.WARNING and r.exc_info is None for r in retry_logs)
+
+    async def test_give_up_write_unexpected_failure_keeps_traceback(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem, caplog,
+    ):
+        """An UNEXPECTED (likely permanent) marker-write failure keeps its full traceback
+        so it stays diagnosable rather than being swallowed as benign (issue #32)."""
+        mock_proxy.get_thread.side_effect = RuntimeError("classification boom")
+        mock_label_manager.mark_attempted.side_effect = ValueError("unexpected marker bug")
+        tracker = FailureTracker(max_failures=1)
+
+        with caplog.at_level(logging.WARNING):
+            result = await process_single_thread(
+                "thread_y", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
+            )
+
+        assert result is False
+        marker_logs = [r for r in caplog.records if "Could not mark" in r.getMessage()]
+        assert marker_logs and any(r.levelno >= logging.ERROR and r.exc_info for r in marker_logs)
 
     async def test_proxy_4xx_is_give_up_eligible(
         self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,

--- a/tests/test_labeler.py
+++ b/tests/test_labeler.py
@@ -17,6 +17,7 @@ def config():
             "fyi": "agent/fyi",
             "low_priority": "agent/low-priority",
             "processed": "agent/processed",
+            "attempted": "agent/attempted",
             "personal": "agent/personal",
             "non_personal": "agent/non-personal",
             "actions": {
@@ -40,6 +41,7 @@ def all_labels_response():
             {"id": "Label_4", "name": "agent/processed", "type": "user"},
             {"id": "Label_5", "name": "agent/personal", "type": "user"},
             {"id": "Label_6", "name": "agent/non-personal", "type": "user"},
+            {"id": "Label_7", "name": "agent/attempted", "type": "user"},
         ]
     }
 
@@ -72,6 +74,7 @@ class TestVerifyLabels:
         assert set(missing) == {
             "agent/fyi",
             "agent/low-priority",
+            "agent/attempted",
             "agent/personal",
             "agent/non-personal",
         }
@@ -79,7 +82,7 @@ class TestVerifyLabels:
     async def test_no_labels_present(self, label_manager, mock_proxy):
         mock_proxy.list_labels.return_value = {"labels": [{"id": "INBOX", "name": "INBOX", "type": "system"}]}
         missing = await label_manager.verify_labels()
-        assert len(missing) == 6
+        assert len(missing) == 7
 
     async def test_builds_label_id_map(self, label_manager, mock_proxy, all_labels_response):
         """verify_labels populates the internal label name -> ID mapping."""
@@ -243,6 +246,29 @@ class TestMarkProcessed:
         )
 
 
+class TestMarkAttempted:
+    async def test_applies_only_attempted_label(self, label_manager, mock_proxy, all_labels_response):
+        """Give-up applies agent/attempted (not agent/processed), so abandoned
+        threads are findable in Gmail and distinct from successfully-processed mail."""
+        mock_proxy.list_labels.return_value = all_labels_response
+        await label_manager.verify_labels()
+
+        await label_manager.mark_attempted(["msg1", "msg2"])
+        assert mock_proxy.modify_message.call_count == 2
+        for call in mock_proxy.modify_message.call_args_list:
+            assert call.kwargs["add_label_ids"] == ["Label_7"]  # agent/attempted
+            assert "remove_label_ids" not in call.kwargs
+
+    async def test_single_message_id(self, label_manager, mock_proxy, all_labels_response):
+        mock_proxy.list_labels.return_value = all_labels_response
+        await label_manager.verify_labels()
+
+        await label_manager.mark_attempted("msg1")
+        mock_proxy.modify_message.assert_called_once_with(
+            message_id="msg1", add_label_ids=["Label_7"],
+        )
+
+
 @pytest.fixture
 def newsletter_config():
     return {
@@ -251,6 +277,7 @@ def newsletter_config():
             "fyi": "agent/fyi",
             "low_priority": "agent/low-priority",
             "processed": "agent/processed",
+            "attempted": "agent/attempted",
             "personal": "agent/personal",
             "non_personal": "agent/non-personal",
             "actions": {
@@ -290,6 +317,7 @@ def all_labels_with_newsletter():
             {"id": "Label_4", "name": "agent/processed", "type": "user"},
             {"id": "Label_5", "name": "agent/personal", "type": "user"},
             {"id": "Label_6", "name": "agent/non-personal", "type": "user"},
+            {"id": "Label_7", "name": "agent/attempted", "type": "user"},
             {"id": "Label_10", "name": "agent/newsletter", "type": "user"},
             {"id": "Label_11", "name": "agent/newsletter/excellent", "type": "user"},
             {"id": "Label_12", "name": "agent/newsletter/good", "type": "user"},
@@ -333,7 +361,8 @@ class TestNewsletterVerifyLabels:
         missing = await newsletter_label_manager.verify_labels()
         assert "agent/newsletter" in missing
         assert "agent/newsletter/excellent" in missing
-        assert len(missing) == 11
+        assert "agent/attempted" in missing
+        assert len(missing) == 12
 
 
 class TestNewsletterApplyLabels:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -340,6 +340,26 @@ class TestContentlessResponse:
             with pytest.raises(RuntimeError, match="no content"):
                 await cloud_client.complete("sys", "user")
 
+    async def test_empty_string_content_raises_runtime_error(self, cloud_client):
+        """An empty-but-present `content: ""` is just as unusable as null/missing.
+
+        A reasoning model that exhausts max_tokens mid-think can emit `content: ""`
+        rather than null. That must raise the same no-content RuntimeError, not fall
+        through to be parsed as an empty classification (which would default to
+        SERVICE / LOW_PRIORITY and silently mislabel the email)."""
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {"role": "assistant", "content": ""}}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(RuntimeError, match="no content"):
+                await cloud_client.complete("sys", "user")
+
     async def test_glm_reasoning_only_no_content_raises_runtime_error(self):
         """GLM returning only reasoning_content (max_tokens exhausted mid-think) raises
         RuntimeError, not KeyError — the cloud-tier case from issue #11's comment.

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -298,6 +298,77 @@ class TestComplete:
             mock_client_cls.assert_called_once_with(timeout=60)
 
 
+class TestContentlessResponse:
+    """A response message lacking usable content must raise a clear, non-KeyError error.
+
+    A reasoning model (or GLM) that exhausts max_tokens mid-<think> returns a message
+    with reasoning/reasoning_content but no `content` — previously a raw KeyError. It is
+    request-specific/permanent (retrying as-is won't help), so it must surface as a
+    RuntimeError (give-up-eligible), NOT LLMUnavailableError (which would retry forever).
+    """
+
+    async def test_missing_content_key_raises_runtime_error(self, cloud_client):
+        """A message with no `content` key raises RuntimeError, not KeyError."""
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {"role": "assistant"}}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(RuntimeError, match="no content") as exc_info:
+                await cloud_client.complete("sys", "user")
+            msg = str(exc_info.value)
+            assert "test-cloud-model" in msg
+            assert "max_tokens" in msg  # names the likely cause
+
+    async def test_none_content_raises_runtime_error(self, cloud_client):
+        """An explicit `content: null` raises RuntimeError, not a downstream crash."""
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {"role": "assistant", "content": None}}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(RuntimeError, match="no content"):
+                await cloud_client.complete("sys", "user")
+
+    async def test_glm_reasoning_only_no_content_raises_runtime_error(self):
+        """GLM returning only reasoning_content (max_tokens exhausted mid-think) raises
+        RuntimeError, not KeyError — the cloud-tier case from issue #11's comment.
+
+        There is no final answer, only reasoning, so even include_thinking mode must
+        not silently treat a content-less reply as a classification.
+        """
+        glm_client = LLMClient(
+            base_url="https://api.example.com/v1/chat/completions",
+            api_key="sk-test",
+            model="zai-org/glm-5",
+        )
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {
+                "role": "assistant",
+                "reasoning_content": "Let me think about whether this is a person...",
+            }}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(RuntimeError, match="no content"):
+                await glm_client.complete("sys", "user", include_thinking=True)
+
+
 class TestIsAvailable:
     async def test_available_when_server_responds(self, local_client):
         """is_available returns True when server returns 200."""

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from llm_client import LLMUnavailableError
 from newsletter import (
     NewsletterClassifier,
     NewsletterTier,
@@ -326,6 +327,44 @@ class TestClassifyNewsletter:
         assert results[0].tier == NewsletterTier.EXCELLENT
         assert results[1].tier == NewsletterTier.FAIR
         assert mock_cloud_llm.complete.call_count == 5
+
+
+class TestClassifyNewsletterTransientOutage:
+    """Issue #18: a transient LLM outage mid-newsletter must propagate so the daemon
+    retries the whole thread — not be swallowed into a permanently mis-graded result.
+    Genuinely per-story/permanent failures stay isolated as before."""
+
+    async def test_transient_quality_outage_propagates(self, nl_classifier, mock_cloud_llm):
+        """LLMUnavailableError during quality assessment propagates (not swallowed)."""
+        mock_cloud_llm.complete.side_effect = [
+            ("TITLE: Story\nTEXT: Content", ""),         # extract_stories
+            LLMUnavailableError("cloud endpoint down"),  # assess_quality
+        ]
+        with pytest.raises(LLMUnavailableError):
+            await nl_classifier.classify_newsletter("body")
+
+    async def test_transient_theme_outage_propagates(self, nl_classifier, mock_cloud_llm):
+        """LLMUnavailableError during theme classification propagates too."""
+        mock_cloud_llm.complete.side_effect = [
+            ("TITLE: Story\nTEXT: Content", ""),                       # extract_stories
+            ("SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3", ""),  # assess_quality
+            LLMUnavailableError("cloud endpoint down"),               # classify_themes
+        ]
+        with pytest.raises(LLMUnavailableError):
+            await nl_classifier.classify_newsletter("body")
+
+    async def test_non_transient_quality_error_stays_isolated(self, nl_classifier, mock_cloud_llm):
+        """A non-transient per-story error (RuntimeError) is still swallowed: the story
+        gets no scores but themes are still classified and the result is returned."""
+        mock_cloud_llm.complete.side_effect = [
+            ("TITLE: Story\nTEXT: Content", ""),  # extract_stories
+            RuntimeError("malformed story crashed scoring"),  # assess_quality
+            ("SCRIPTURE", "theme cot"),  # classify_themes still runs
+        ]
+        results = await nl_classifier.classify_newsletter("body")
+        assert len(results) == 1
+        assert results[0].scores is None
+        assert results[0].themes == ["scripture"]
 
 
 class TestWriteAssessment:

--- a/tests/test_proxy_client.py
+++ b/tests/test_proxy_client.py
@@ -82,6 +82,20 @@ class TestTransientClassification:
         with pytest.raises(ProxyUnavailableError):
             client._handle_response(_mock_response(429, {"message": "rate limited"}))
 
+    async def test_non_json_2xx_is_unavailable(self, client):
+        """A 2xx whose body isn't JSON — a truncated/garbled response, or an upstream
+        gateway briefly returning an HTML error page with status 200 — is a transient
+        hiccup. It classifies as ProxyUnavailableError (retried next cycle), NOT a
+        give-up-eligible plain ProxyError. With the #26 give-up bound a *persistent*
+        non-JSON 2xx is still bounded by the FailureTracker, so this can't retry forever.
+        Asserted at _handle_response, where the success body is parsed (issue #27)."""
+        resp = httpx.Response(
+            200, text="<html>502 Bad Gateway</html>",
+            request=httpx.Request("GET", "http://proxy.test/x"),
+        )
+        with pytest.raises(ProxyUnavailableError):
+            client._handle_response(resp)
+
     async def test_read_timeout_raises_unavailable(self, client):
         """A read timeout to the proxy is infrastructure slowness → transient.
 

--- a/tests/test_proxy_client.py
+++ b/tests/test_proxy_client.py
@@ -103,6 +103,18 @@ class TestTransientClassification:
         with pytest.raises(ProxyUnavailableError):
             await client.get_thread("t1")
 
+    async def test_local_protocol_error_propagates_not_transient(self, client):
+        """A LocalProtocolError (permanent CLIENT-side request-construction fault — e.g.
+        an illegal header value built from our own inputs) is NOT a transient outage.
+
+        It is a sibling of RemoteProtocolError under httpx.ProtocolError, but unlike its
+        sibling it must propagate (like UnsupportedProtocol) so it surfaces / is
+        give-up-eligible, rather than being wrapped as ProxyUnavailableError and retried
+        forever (issue #26)."""
+        _patch_transport(get_side_effect=httpx.LocalProtocolError("illegal header value"))
+        with pytest.raises(httpx.LocalProtocolError):
+            await client.get_thread("t1")
+
     async def test_unsupported_protocol_propagates_not_transient(self, client):
         """A bad PROXY_URL scheme (UnsupportedProtocol) is a permanent misconfig and
         must propagate, never be wrapped/retried as transient."""

--- a/tests/test_proxy_client.py
+++ b/tests/test_proxy_client.py
@@ -73,6 +73,15 @@ class TestTransientClassification:
         # Must be the base class, not the transient subclass.
         assert not isinstance(exc_info.value, ProxyUnavailableError)
 
+    async def test_429_is_unavailable(self, client):
+        """A 429 (rate-limit) that survives retry.py's retry budget is a sustained
+        throttle — transient by nature (it clears on its own), so it must classify as
+        ProxyUnavailableError and be retried next cycle, NOT grouped with the permanent
+        4xx and routed to the give-up path. Asserted at _handle_response because a 429
+        only reaches it once the HTTP-layer retries are exhausted."""
+        with pytest.raises(ProxyUnavailableError):
+            client._handle_response(_mock_response(429, {"message": "rate limited"}))
+
     async def test_read_timeout_raises_unavailable(self, client):
         """A read timeout to the proxy is infrastructure slowness → transient.
 

--- a/tests/test_proxy_client.py
+++ b/tests/test_proxy_client.py
@@ -1,0 +1,108 @@
+"""Tests for the Gmail proxy client's error classification.
+
+Focus: the transient-vs-permanent split (issue #16). The proxy must raise a
+transient ProxyUnavailableError for endpoint-unavailability (connection refused,
+timeouts, dropped/garbled connections, and 5xx server errors) so the daemon can
+defer-and-retry, while request-specific failures (4xx) stay ProxyError so they
+remain give-up-eligible. A permanent misconfiguration (an unsupported PROXY_URL
+scheme) must propagate, never be retried as if transient.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from proxy_client import (
+    GmailProxyClient,
+    ProxyAuthError,
+    ProxyError,
+    ProxyUnavailableError,
+)
+
+
+@pytest.fixture
+def client():
+    return GmailProxyClient(proxy_url="http://proxy.test", api_key="test-key")
+
+
+def _mock_response(status_code=200, json_data=None):
+    return httpx.Response(
+        status_code=status_code,
+        json=json_data if json_data is not None else {},
+        request=httpx.Request("GET", "http://proxy.test/x"),
+    )
+
+
+def _patch_transport(get_return=None, get_side_effect=None):
+    """Patch proxy_client.httpx.AsyncClient so client.get/post is controllable."""
+    mock_client_cls = patch("proxy_client.httpx.AsyncClient").start()
+    mock_client = AsyncMock()
+    if get_side_effect is not None:
+        mock_client.get.side_effect = get_side_effect
+        mock_client.post.side_effect = get_side_effect
+    else:
+        mock_client.get.return_value = get_return
+        mock_client.post.return_value = get_return
+    mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    return mock_client_cls
+
+
+class TestTransientClassification:
+    def teardown_method(self):
+        patch.stopall()
+
+    async def test_unavailable_is_subclass_of_proxy_error(self):
+        """ProxyUnavailableError specializes ProxyError (whose docstring already
+        covers '5xx, connection errors'), so existing `except ProxyError` sites
+        (e.g. startup label verification) keep catching the transient cases."""
+        assert issubclass(ProxyUnavailableError, ProxyError)
+
+    async def test_5xx_raises_unavailable(self, client):
+        """A 500 server error is transient → ProxyUnavailableError (not bare ProxyError)."""
+        _patch_transport(get_return=_mock_response(500, {"message": "boom"}))
+        with pytest.raises(ProxyUnavailableError):
+            await client.get_thread("t1")
+
+    async def test_4xx_stays_proxy_error(self, client):
+        """A 404 is request-specific → plain ProxyError (give-up-eligible), NOT transient."""
+        _patch_transport(get_return=_mock_response(404, {"message": "not found"}))
+        with pytest.raises(ProxyError) as exc_info:
+            await client.get_thread("missing")
+        # Must be the base class, not the transient subclass.
+        assert not isinstance(exc_info.value, ProxyUnavailableError)
+
+    async def test_read_timeout_raises_unavailable(self, client):
+        """A read timeout to the proxy is infrastructure slowness → transient.
+
+        (Unlike the LLM client, where a read timeout means oversized prefill; a
+        proxy read timeout is just Gmail/proxy being slow.)"""
+        _patch_transport(get_side_effect=httpx.ReadTimeout("slow"))
+        with pytest.raises(ProxyUnavailableError):
+            await client.get_thread("t1")
+
+    async def test_connect_error_raises_unavailable(self, client):
+        """Connection refused (proxy down/restarting) → transient."""
+        _patch_transport(get_side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProxyUnavailableError):
+            await client.get_thread("t1")
+
+    async def test_remote_protocol_error_raises_unavailable(self, client):
+        """A dropped/garbled connection (RemoteProtocolError) → transient."""
+        _patch_transport(get_side_effect=httpx.RemoteProtocolError("server disconnected"))
+        with pytest.raises(ProxyUnavailableError):
+            await client.get_thread("t1")
+
+    async def test_unsupported_protocol_propagates_not_transient(self, client):
+        """A bad PROXY_URL scheme (UnsupportedProtocol) is a permanent misconfig and
+        must propagate, never be wrapped/retried as transient."""
+        _patch_transport(get_side_effect=httpx.UnsupportedProtocol("bad scheme"))
+        with pytest.raises(httpx.UnsupportedProtocol):
+            await client.get_thread("t1")
+
+    async def test_401_still_raises_auth_error(self, client):
+        """The 5xx split must not disturb the 401 → ProxyAuthError mapping."""
+        _patch_transport(get_return=_mock_response(401, {"message": "bad key"}))
+        with pytest.raises(ProxyAuthError):
+            await client.get_thread("t1")

--- a/tests/test_proxy_client.py
+++ b/tests/test_proxy_client.py
@@ -96,6 +96,30 @@ class TestTransientClassification:
         with pytest.raises(ProxyUnavailableError):
             client._handle_response(resp)
 
+    async def test_empty_2xx_body_is_success_not_a_fault(self, client):
+        """An EMPTY 2xx body (e.g. 204 No Content from a write) is a success with nothing
+        to parse — it must return {}, not raise. Distinct from a non-empty non-JSON body:
+        if an empty body were classified transient (#27), a write returning 204 would
+        defer-and-retry forever, since the give-up marker write hits the same endpoint and
+        would trip the same classification (review follow-up to #27)."""
+        resp = httpx.Response(
+            204, content=b"",
+            request=httpx.Request("POST", "http://proxy.test/x"),
+        )
+        assert client._handle_response(resp) == {}
+
+    async def test_list_messages_non_json_2xx_is_unavailable(self, client):
+        """End-to-end through _send: a garbled 200 on the cycle-level list_messages call
+        surfaces as ProxyUnavailableError, so the poll loop defers and backs off rather
+        than crashing or abandoning the cycle (review follow-up to #27)."""
+        resp = httpx.Response(
+            200, text="<html>oops</html>",
+            request=httpx.Request("GET", "http://proxy.test/x"),
+        )
+        _patch_transport(get_return=resp)
+        with pytest.raises(ProxyUnavailableError):
+            await client.list_messages()
+
     async def test_read_timeout_raises_unavailable(self, client):
         """A read timeout to the proxy is infrastructure slowness → transient.
 


### PR DESCRIPTION
## Summary

Completes the **resilience track** of the open-issues roadmap — the PR #9 follow-ups that finish the transient-vs-permanent error model (previously only on the LLM read path) across the proxy, newsletter, and write paths, plus a give-up-labeling improvement.

Each change is test-first; full suite green (**528 passed**), ruff clean.

## What's included

| Commit | Issue | Change |
|---|---|---|
| `dccd4cf` | #11 | Guard `LLMClient` against content-less responses — a reasoning/GLM reply that exhausts `max_tokens` mid-`<think>` returns no `content`, which raised a raw `KeyError`. Now raises a clear `RuntimeError` (request-specific → routes to give-up, not retried forever). |
| `c5831fe` | #16 | Classify proxy-side transient errors as retryable. New `ProxyUnavailableError` (subclass of `ProxyError`) for the transient transport family + **5xx** responses; **4xx** stays a plain `ProxyError` (give-up-eligible). The daemon defers on it instead of abandoning emails during a proxy outage. |
| `f61be9f` | #23 | Mark abandoned threads `agent/attempted` instead of `agent/processed`, so give-ups are findable in Gmail and semantically distinct from triaged mail (still excluded from `gmail_query`, so the retry loop still ends). |
| `a1403c8` | #18 | Let transient outages propagate in the newsletter pipeline — `classify_newsletter`'s per-story `except Exception` swallowed `LLMUnavailableError` and committed a degraded result; now re-raised so the daemon retries the whole newsletter. Per-story/permanent failures stay isolated. |
| `f66cb28` | #17 | Bound the label-application (write) fan-out with a dedicated `write_sem` (`write_parallel`, default 4; env `WRITE_PARALLEL`). Reads were throttled by `fetch_sem`; writes ran unbounded, so draining a backlog could burst many concurrent `modify_message` calls. |
| `32c2720` | review | Address xhigh code-review findings on this branch: empty-string content-less guard, exhausted-429 → transient `ProxyUnavailableError`, clean poll-loop logging for plain `ProxyError`, `_apply_marker` dedup, single-source `TRANSIENT_TRANSPORT_ERRORS`, stale docstring. |
| `e74057f` | #26 | Bound a persistent per-thread proxy fault instead of retrying forever — route the per-thread `ProxyUnavailableError` handler through the give-up path (endpoint-wide outages still defer at the cycle level); exclude permanent `LocalProtocolError` from the transient tuple. |
| `348543c` | #27 | Classify a non-JSON 2xx proxy body as transient `ProxyUnavailableError` (defer-and-retry) instead of give-up-eligible `ProxyError`; composes with #26's give-up bound so a persistent one is still bounded. |
| `f56c7ad` | #32 | Split `_give_up_if_stuck`'s marker-write `except`: a transient `ProxyUnavailableError` logs a clean retryable warning, any other failure keeps its traceback (was a blanket `except Exception`). |
| `48c0265` | #31 | Document that newly-required labels (this release adds `agent/attempted`) must be created before upgrading, or strict startup validation crash-loops the daemon. |
| `16ac4e0` | review | Address xhigh-review findings on #27/#32: treat an empty/204 2xx as success (was a retry-forever edge); emit the give-up `ERROR` only after the marker write lands; correct stale `ProxyError`/poll-loop/#26 comments; +2 tests. |

## Key design decisions

- **Proxy 5xx is treated as transient (defer), 4xx as give-up-eligible** (issue #16). A 5xx is almost always endpoint-wide (proxy crashed / Gmail 5xx upstream) — same blast radius as a connection error — so deferring it self-heals when the proxy returns, without abandoning email or mass-relabeling the backlog. A 4xx (e.g. a 404 for a thread deleted between listing and fetching) is request-specific, so the `FailureTracker` still bounds it. `ProxyUnavailableError` subclasses `ProxyError` so existing `except ProxyError` sites (startup label verification) keep treating it as retryable.
- **`agent/attempted` (issue #23)** makes the give-up path non-destructive and recoverable. This complements #16/#17: those decide *which* failures give up; this decides *what label* a give-up applies. It also de-risks #16's "4xx can give up" branch, since a misjudged give-up is now findable instead of lost.

## New label (must be pre-created in Gmail)

- `agent/attempted` — applied on give-up after repeated failures; excluded from `gmail_query` like `agent/processed`, but kept distinct so abandoned threads stay findable.

Documented in the must-create label lists (`README.md`, `CLAUDE.md`) and the reference docs.

## Follow-ups (not in this PR)

- The **startup "re-attempt `agent/attempted` once"** recovery hook is the deferred portion of **#23** — tracked there. #23 remains open after this PR (the commit says "Add #23", so it is not auto-closed); the core labeling change ships here.
- **#24** — treat local-LLM outages as routine: log at `INFO` (not `WARNING`) and de-duplicate the per-thread spam, since the local MLX laptop is offline for hours as a normal matter of course. Surfaced while implementing this branch.

## Test coverage added

- `tests/test_proxy_client.py` — **new** (proxy had no dedicated tests): 5xx→transient, 4xx→give-up, timeout/connect/protocol→transient, `UnsupportedProtocol`→propagates.
- `LLMClient` content-less response cases; newsletter transient-propagation vs per-story-isolation; daemon proxy-transient-defer / 4xx-give-up / write-sem-bounding; `mark_attempted` + the new required label.

## Code-review follow-ups (xhigh review)

Two `xhigh` workflow code reviews of this branch verified the transient-vs-permanent model end-to-end. The first (2026-06-25) produced the 6 fixes in `32c2720` and surfaced 8 follow-up gaps (#26–#33); a second review of the #27/#32 commits produced the fixes in `16ac4e0`. The follow-ups resolved here:

- **Closes #26** — a per-thread `ProxyUnavailableError` (deterministic 5xx / exhausted-429 / `LocalProtocolError`) was retried forever with no give-up bound. Option 1: route per-thread proxy faults through the give-up path so a poison thread is bounded after `max_failures`, while endpoint-wide outages still defer at the cycle level and `LLMUnavailableError` is unchanged.
- **Closes #27** — a non-JSON 2xx body was give-up-eligible; now transient (and an empty/204 2xx is treated as success).
- **Closes #32** — the give-up marker write swallowed all errors without a transient/permanent distinction.
- **Closes #31** — strict startup validation could crash-loop an upgrade that didn't pre-create `agent/attempted`; documented as an upgrade step.
- Tracked as follow-ups, **not** in this PR: #28 (403 human-reject semantics — also the 403-on-marker-write case), #29 (write-phase discards a completed classification — also the re-classify-while-give-up-pending waste), #30 (newsletter content-less swallow / never-converges), #33 (`write_sem` per-loop granularity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


