### PR TITLE
Streamline local-model evaluation

### DIFF
--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -45,6 +45,10 @@ Review hotkeys: `p`/`s` sender (person/service); `r`/`f`/`l` label (needs_respon
 | `--no-cache` | Disable LLM response cache (default: cache enabled) |
 | `--sender-type` | Only evaluate threads with this expected sender type (`person` or `service`) |
 | `--max-threads` | Max threads to evaluate (default: all) |
+| `--local-only` | Shortcut for `--stages stage2_only --sender-type person` — evaluate only the local classifier (no cloud creds needed). Errors if combined with a conflicting `--stages`/`--sender-type` |
+| `--skip-preflight` | Skip the endpoint reachability check that runs before evaluation |
+| `--report` | Print a metrics report (accuracy, confusion matrix, per-class P/R/F1) for this run after it completes |
+| `--compare-to` | After the run, print a side-by-side comparison against this prior results JSONL file |
 | `--cloud-model` | Override cloud LLM model name from config |
 | `--local-model` | Override local LLM model name from config |
 | `--cloud-temperature` | Override cloud LLM temperature (alias: `--cloud-temp`) |

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -47,6 +47,7 @@ Review hotkeys: `p`/`s` sender (person/service); `r`/`f`/`l` label (needs_respon
 | `--max-threads` | Max threads to evaluate (default: all) |
 | `--local-only` | Shortcut for `--stages stage2_only --sender-type person` — evaluate only the local classifier (no cloud creds needed). Errors if combined with a conflicting `--stages`/`--sender-type` |
 | `--skip-preflight` | Skip the endpoint reachability check that runs before evaluation |
+| `--preflight-timeout` | Seconds to wait for the pre-run endpoint check (default: the local model's request timeout). Raise it for a server that cold-loads a large model on demand |
 | `--report` | Print a metrics report (accuracy, confusion matrix, per-class P/R/F1) for this run after it completes |
 | `--compare-to` | After the run, print a side-by-side comparison against this prior results JSONL file |
 | `--cloud-model` | Override cloud LLM model name from config |

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -47,7 +47,7 @@ Review hotkeys: `p`/`s` sender (person/service); `r`/`f`/`l` label (needs_respon
 | `--max-threads` | Max threads to evaluate (default: all) |
 | `--local-only` | Shortcut for `--stages stage2_only --sender-type person` — evaluate only the local classifier (no cloud creds needed). Errors if combined with a conflicting `--stages`/`--sender-type` |
 | `--skip-preflight` | Skip the endpoint reachability check that runs before evaluation |
-| `--preflight-timeout` | Seconds to wait for the pre-run endpoint check (default: the local model's request timeout). Raise it for a server that cold-loads a large model on demand |
+| `--preflight-timeout` | Seconds to wait for the pre-run endpoint check, overriding both probes (default: each endpoint's own request timeout — generous for a local cold-load, fast-failing for the cloud). Raise it for a server that cold-loads a large model on demand |
 | `--report` | Print a metrics report (accuracy, confusion matrix, per-class P/R/F1) for this run after it completes |
 | `--compare-to` | After the run, print a side-by-side comparison against this prior results JSONL file |
 | `--cloud-model` | Override cloud LLM model name from config |

--- a/evals/README.md
+++ b/evals/README.md
@@ -127,6 +127,30 @@ Navigate to `http://localhost:5000`. Features:
 
 ## Typical Workflows
 
+**Evaluate a new local model (fast path):**
+
+The local model is only used for Stage 2 on person bodies, so `--local-only`
+(= `--stages stage2_only --sender-type person`) isolates it — and needs no cloud
+credentials. The one-command wrapper sets the model, auto-tags the run by the
+model name, preflights the endpoint, prints a report, and optionally compares to
+a prior run:
+
+```bash
+# Prereq: mlx_lm.server is already serving <hf-id>, and MLX_URL points at it.
+python scripts/eval_model.py qwen/qwen3-14b                 # run + report
+python scripts/eval_model.py qwen/qwen3-14b qwen3-8b        # ...also compare vs the newest qwen3-8b run
+```
+
+Equivalent explicit form (the wrapper just chains these):
+
+```bash
+uv run python -m evals.run_eval --local-only --local-model qwen/qwen3-14b --report
+```
+
+`--local-only` errors if the local endpoint is unreachable or `MLX_MODEL` doesn't
+match the served model (a 404), instead of producing a whole run of per-thread
+errors. Pass `--skip-preflight` to bypass that check.
+
 **Prompt A/B test:**
 
 ```bash

--- a/evals/README.md
+++ b/evals/README.md
@@ -149,7 +149,9 @@ uv run python -m evals.run_eval --local-only --local-model qwen/qwen3-14b --repo
 
 `--local-only` errors if the local endpoint is unreachable or `MLX_MODEL` doesn't
 match the served model (a 404), instead of producing a whole run of per-thread
-errors. Pass `--skip-preflight` to bypass that check.
+errors. The check waits up to the local model's request timeout, so a server that
+loads the model on demand has time to cold-load it; tune with `--preflight-timeout
+SECONDS`, or skip it entirely with `--skip-preflight`.
 
 **Prompt A/B test:**
 

--- a/evals/llm_cache.py
+++ b/evals/llm_cache.py
@@ -135,9 +135,9 @@ class CachedLLMClient:
         self._llm_seconds = 0.0
         return elapsed
 
-    async def is_available(self) -> bool:
+    async def is_available(self, timeout: float | None = None) -> bool:
         """Delegate to inner client."""
-        return await self.inner.is_available()
+        return await self.inner.is_available(timeout)
 
     def flush(self) -> None:
         """Append pending cache entries to disk."""

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -13,6 +13,7 @@ import asyncio
 import hashlib
 import json
 import os
+import re
 import sys
 import time
 import tomllib
@@ -25,13 +26,105 @@ import httpx
 from classifier import EmailClassifier, SenderType, ThreadMetadata
 from config_utils import substitute_env_vars
 from daemon import DEFAULT_MAX_THREAD_CHARS, format_thread_transcript
-from evals import format_network_error
+from evals import format_network_error, report
 from evals.llm_cache import CachedLLMClient
 from evals.schemas import GoldenThread, PredictionResult, RunMeta, ThinkingEntry
 from gmail_utils import get_header
 from llm_client import LLMClient
 
 VALID_STAGES = ("full", "stage1_only", "stage2_only")
+
+
+def resolve_local_only(args: argparse.Namespace) -> None:
+    """Expand --local-only into --stages stage2_only --sender-type person, in place.
+
+    Stage 2b on a person body is the *only* path that exercises solely the local
+    classifier (person bodies never reach the cloud), so this is the canonical
+    "evaluate just the local model" configuration. A no-op unless --local-only is
+    set. The default --stages ("full") is treated as unspecified and overridden.
+
+    Raises:
+        ValueError: if the user also passed an incompatible --stages or
+            --sender-type alongside --local-only.
+    """
+    if not getattr(args, "local_only", False):
+        return
+    if args.stages not in ("full", "stage2_only"):
+        raise ValueError(
+            f"--local-only implies --stages stage2_only, which conflicts with "
+            f"--stages {args.stages}"
+        )
+    if args.sender_type not in (None, "person"):
+        raise ValueError(
+            f"--local-only implies --sender-type person, which conflicts with "
+            f"--sender-type {args.sender_type}"
+        )
+    args.stages = "stage2_only"
+    args.sender_type = "person"
+
+
+def sanitize_tag(name: str) -> str:
+    """Make a model name safe for a results filename.
+
+    Filenames join parts with "_", so any run of characters outside
+    [A-Za-z0-9._-] (notably the "/" in HuggingFace ids like "qwen/qwen3-14b")
+    is collapsed to a single "-", with leading/trailing dashes stripped.
+    """
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-")
+
+
+def default_tag(stages: str, config: dict) -> str:
+    """Derive a default results tag from the model actually under test.
+
+    Stage 1 is the cloud model's job; everything else exercises the local model,
+    so tag by whichever model the run is really measuring. Makes result files
+    self-identifying without the user having to pass --tag.
+    """
+    section = "cloud" if stages == "stage1_only" else "local"
+    return sanitize_tag(config["llm"][section]["model"])
+
+
+def required_endpoints(stages: str, sender_type: str | None) -> tuple[bool, bool]:
+    """Return (need_cloud, need_local) for a run configuration.
+
+    Stage 1 (sender) is always cloud. Stage 2 routes person bodies to the local
+    model and service bodies to the cloud, so a stage2_only run narrowed by
+    --sender-type touches exactly one endpoint; without that filter (or a full
+    run) it may touch both. Used to scope the preflight check to endpoints the
+    run will actually hit.
+    """
+    if stages == "stage1_only":
+        return True, False
+    if stages == "stage2_only":
+        if sender_type == "person":
+            return False, True
+        if sender_type == "service":
+            return True, False
+        return True, True
+    return True, True  # full
+
+
+async def preflight_check(cloud_base, local_base, need_cloud: bool, need_local: bool) -> list[str]:
+    """Probe each required endpoint once; return a human-readable error per dead one.
+
+    Turns the most common silent failure — a local MLX_MODEL that doesn't match
+    the served --model (every request 404s) or an unreachable endpoint — into an
+    immediate, clear error instead of a whole run of per-thread errors. Endpoints
+    the run won't touch are never probed.
+    """
+    errors = []
+    if need_cloud and not await cloud_base.is_available():
+        errors.append(
+            f"cloud LLM '{cloud_base.model}' not reachable at "
+            f"{cloud_base.base_url or '<unset CLOUD_LLM_URL>'}"
+        )
+    if need_local and not await local_base.is_available():
+        errors.append(
+            f"local LLM '{local_base.model}' not reachable at "
+            f"{local_base.base_url or '<unset MLX_URL>'} "
+            "(a model-name mismatch with the served model returns 404)"
+        )
+    return errors
 
 
 def resolve_parallelism(cli_value: int | None, config: dict) -> int:
@@ -346,6 +439,35 @@ def write_thinking_sidecar(
             f.write(json.dumps(entry.to_dict()) + "\n")
 
 
+def maybe_report(
+    meta: RunMeta,
+    results: list[PredictionResult],
+    report_enabled: bool,
+    compare_to: str | None,
+) -> None:
+    """Print a metrics report (and optional comparison) for a just-finished run.
+
+    Saves the find-the-file-then-invoke-report round-trip: run_eval already knows
+    the run it produced. Reuses report.py so all formatting lives in one place.
+    A no-op unless --report or --compare-to was passed.
+    """
+    if not report_enabled and not compare_to:
+        return
+    metrics = report.compute_metrics(results)
+    if report_enabled:
+        report.print_report(meta, metrics)
+    if compare_to:
+        compare_path = Path(compare_to)
+        if not compare_path.exists():
+            print(f"Error: --compare-to file not found: {compare_path}", file=sys.stderr)
+            return
+        meta_b, results_b = report.load_results(compare_path)
+        report.print_comparison(
+            meta, metrics, meta_b, report.compute_metrics(results_b),
+            results1=results, results2=results_b,
+        )
+
+
 async def main(args: argparse.Namespace) -> None:
     # Load config
     config_path = Path(args.config) if args.config else Path(__file__).parent.parent / "config.toml"
@@ -357,12 +479,19 @@ async def main(args: argparse.Namespace) -> None:
     args.parallelism = resolve_parallelism(args.parallelism, config)
 
     # Apply CLI overrides to config (CLI always wins over config file). extra_body
-    # parsing can fail on bad JSON, so surface that as a clean exit.
+    # parsing and --local-only conflict detection can fail, so surface those as a
+    # clean exit.
     try:
+        resolve_local_only(args)
         apply_config_overrides(config, args)
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(2)
+
+    # Default the results tag to the model under test, so result files (and the
+    # report trend table) self-identify without the user having to pass --tag.
+    if args.tag is None:
+        args.tag = default_tag(args.stages, config)
 
     # Load golden set
     golden_path = Path(args.golden_set)
@@ -404,6 +533,17 @@ async def main(args: argparse.Namespace) -> None:
         timeout=config["llm"]["local"]["timeout"],
         extra_body=config["llm"]["local"].get("extra_body"),
     )
+
+    # Preflight: probe the endpoints this run will actually hit and fail fast on
+    # an unreachable / name-mismatched one, instead of a whole run of per-thread
+    # errors. (Skipped on --dry-run, which returned above.)
+    if not args.skip_preflight:
+        need_cloud, need_local = required_endpoints(args.stages, args.sender_type)
+        unreachable = await preflight_check(cloud_llm_base, local_llm_base, need_cloud, need_local)
+        if unreachable:
+            for msg in unreachable:
+                print(f"Error: {msg}", file=sys.stderr)
+            sys.exit(1)
 
     # Wrap with cache unless --no-cache
     if args.no_cache:
@@ -466,6 +606,10 @@ async def main(args: argparse.Namespace) -> None:
         write_results(output_path, meta, results)
         write_thinking_sidecar(output_path, thinking_entries)
 
+        # Optional inline metrics report / comparison (saves a separate
+        # `python -m evals.report` invocation on the file we just wrote).
+        maybe_report(meta, results, args.report, args.compare_to)
+
         # Summary
         errors = sum(1 for r in results if r.error)
         st_correct = sum(1 for r in results if r.sender_type_correct is True)
@@ -514,6 +658,15 @@ def cli():
     parser.add_argument("--sender-type", choices=("person", "service"),
                         help="Only evaluate threads with this expected sender type")
     parser.add_argument("--max-threads", type=int, help="Max threads to evaluate")
+    parser.add_argument("--local-only", action="store_true",
+                        help="Shortcut for --stages stage2_only --sender-type person "
+                             "(evaluate only the local classifier; no cloud creds needed)")
+    parser.add_argument("--skip-preflight", action="store_true",
+                        help="Skip the endpoint reachability check before evaluating")
+    parser.add_argument("--report", action="store_true",
+                        help="Print a metrics report for this run after it completes")
+    parser.add_argument("--compare-to", metavar="PATH",
+                        help="After the run, print a comparison against this prior results file")
     # Config overrides (CLI always wins over config file)
     parser.add_argument("--cloud-model", help="Override cloud LLM model name")
     parser.add_argument("--local-model", help="Override local LLM model name")

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -85,45 +85,50 @@ def default_tag(stages: str, config: dict) -> str:
 
 
 def required_endpoints(stages: str, sender_type: str | None) -> tuple[bool, bool]:
-    """Return (need_cloud, need_local) for a run configuration.
+    """Return (need_cloud, need_local): the endpoints WITHOUT which the run
+    produces no results at all, so preflight only hard-aborts a doomed run.
 
-    Stage 1 (sender) is always cloud. Stage 2 routes person bodies to the local
-    model and service bodies to the cloud, so a stage2_only run narrowed by
-    --sender-type touches exactly one endpoint; without that filter (or a full
-    run) it may touch both. Used to scope the preflight check to endpoints the
-    run will actually hit.
+    Stage 1 (sender) always uses the cloud; Stage 2 routes person bodies to the
+    local model and service bodies to the cloud. An endpoint is "wholly required"
+    only when every selected thread depends on it:
+      - stage1_only -> cloud (every thread classifies a sender).
+      - stage2_only person -> local; stage2_only service -> cloud.
+      - stage2_only with no filter -> neither (a down endpoint loses only the
+        person *or* service half, leaving partial results).
+      - full -> cloud only: Stage 1 gates every thread, but a down local endpoint
+        merely fails person Stage 2b, leaving Stage 1 + service Stage 2a results.
     """
-    if stages == "stage1_only":
-        return True, False
     if stages == "stage2_only":
         if sender_type == "person":
             return False, True
         if sender_type == "service":
             return True, False
-        return True, True
-    return True, True  # full
+        return False, False
+    return True, False  # stage1_only and full both wholly require only the cloud
 
 
 async def preflight_check(
-    cloud_base, local_base, need_cloud: bool, need_local: bool, timeout: float | None = None,
+    cloud_base, local_base, need_cloud: bool, need_local: bool,
+    cloud_timeout: float | None = None, local_timeout: float | None = None,
 ) -> list[str]:
     """Probe each required endpoint once; return a human-readable error per dead one.
 
     Turns the most common silent failure — a local MLX_MODEL that doesn't match
     the served --model (every request 404s) or an unreachable endpoint — into an
     immediate, clear error instead of a whole run of per-thread errors. Endpoints
-    the run won't touch are never probed.
+    the run won't wholly depend on are never probed.
 
-    *timeout* (seconds) bounds each probe; pass a generous value for a server that
-    loads the requested model on demand, so a cold load is not read as "down".
+    Each endpoint gets its own probe timeout so the cloud probe need not wait out
+    the long local cold-load budget; pass a generous *local_timeout* for a server
+    that loads the requested model on demand, so a cold load is not read as "down".
     """
     errors = []
-    if need_cloud and not await cloud_base.is_available(timeout):
+    if need_cloud and not await cloud_base.is_available(cloud_timeout):
         errors.append(
             f"cloud LLM '{cloud_base.model}' not reachable at "
             f"{cloud_base.base_url or '<unset CLOUD_LLM_URL>'}"
         )
-    if need_local and not await local_base.is_available(timeout):
+    if need_local and not await local_base.is_available(local_timeout):
         errors.append(
             f"local LLM '{local_base.model}' not reachable at "
             f"{local_base.base_url or '<unset MLX_URL>'} "
@@ -466,10 +471,24 @@ def maybe_report(
         if not compare_path.exists():
             print(f"Error: --compare-to file not found: {compare_path}", file=sys.stderr)
             return
-        meta_b, results_b = report.load_results(compare_path)
+        try:
+            meta_b, results_b = report.load_results(compare_path)
+        except (ValueError, OSError) as exc:
+            print(f"Error: could not read --compare-to results from {compare_path}: {exc}",
+                  file=sys.stderr)
+            return
+        if meta_b.stages != meta.stages:
+            print(
+                f"Warning: baseline stages={meta_b.stages} differ from this run's "
+                f"stages={meta.stages}; deltas may span different thread populations.",
+                file=sys.stderr,
+            )
+        # Baseline is Run A and the just-finished run is Run B, so print_comparison's
+        # Delta column reads (this run - baseline) — positive means improvement.
+        # verbose=True surfaces the per-thread regression/improvement list.
         report.print_comparison(
-            meta, metrics, meta_b, report.compute_metrics(results_b),
-            results1=results, results2=results_b,
+            meta_b, report.compute_metrics(results_b), meta, metrics,
+            verbose=True, results1=results_b, results2=results,
         )
 
 
@@ -544,14 +563,20 @@ async def main(args: argparse.Namespace) -> None:
     # errors. (Skipped on --dry-run, which returned above.)
     if not args.skip_preflight:
         need_cloud, need_local = required_endpoints(args.stages, args.sender_type)
-        # Default the probe timeout to the local model's request timeout: generous
-        # enough that a server loading the model on demand isn't read as "down".
-        pf_timeout = (
+        # Each probe defaults to its own endpoint's request timeout (so the local
+        # probe is generous enough for a load-on-demand cold start, while the cloud
+        # probe still fails fast); an explicit --preflight-timeout overrides both.
+        cloud_timeout = (
+            args.preflight_timeout if args.preflight_timeout is not None
+            else config["llm"]["cloud"]["timeout"]
+        )
+        local_timeout = (
             args.preflight_timeout if args.preflight_timeout is not None
             else config["llm"]["local"]["timeout"]
         )
         unreachable = await preflight_check(
-            cloud_llm_base, local_llm_base, need_cloud, need_local, timeout=pf_timeout,
+            cloud_llm_base, local_llm_base, need_cloud, need_local,
+            cloud_timeout=cloud_timeout, local_timeout=local_timeout,
         )
         if unreachable:
             for msg in unreachable:

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -104,21 +104,26 @@ def required_endpoints(stages: str, sender_type: str | None) -> tuple[bool, bool
     return True, True  # full
 
 
-async def preflight_check(cloud_base, local_base, need_cloud: bool, need_local: bool) -> list[str]:
+async def preflight_check(
+    cloud_base, local_base, need_cloud: bool, need_local: bool, timeout: float | None = None,
+) -> list[str]:
     """Probe each required endpoint once; return a human-readable error per dead one.
 
     Turns the most common silent failure — a local MLX_MODEL that doesn't match
     the served --model (every request 404s) or an unreachable endpoint — into an
     immediate, clear error instead of a whole run of per-thread errors. Endpoints
     the run won't touch are never probed.
+
+    *timeout* (seconds) bounds each probe; pass a generous value for a server that
+    loads the requested model on demand, so a cold load is not read as "down".
     """
     errors = []
-    if need_cloud and not await cloud_base.is_available():
+    if need_cloud and not await cloud_base.is_available(timeout):
         errors.append(
             f"cloud LLM '{cloud_base.model}' not reachable at "
             f"{cloud_base.base_url or '<unset CLOUD_LLM_URL>'}"
         )
-    if need_local and not await local_base.is_available():
+    if need_local and not await local_base.is_available(timeout):
         errors.append(
             f"local LLM '{local_base.model}' not reachable at "
             f"{local_base.base_url or '<unset MLX_URL>'} "
@@ -539,7 +544,15 @@ async def main(args: argparse.Namespace) -> None:
     # errors. (Skipped on --dry-run, which returned above.)
     if not args.skip_preflight:
         need_cloud, need_local = required_endpoints(args.stages, args.sender_type)
-        unreachable = await preflight_check(cloud_llm_base, local_llm_base, need_cloud, need_local)
+        # Default the probe timeout to the local model's request timeout: generous
+        # enough that a server loading the model on demand isn't read as "down".
+        pf_timeout = (
+            args.preflight_timeout if args.preflight_timeout is not None
+            else config["llm"]["local"]["timeout"]
+        )
+        unreachable = await preflight_check(
+            cloud_llm_base, local_llm_base, need_cloud, need_local, timeout=pf_timeout,
+        )
         if unreachable:
             for msg in unreachable:
                 print(f"Error: {msg}", file=sys.stderr)
@@ -663,6 +676,9 @@ def cli():
                              "(evaluate only the local classifier; no cloud creds needed)")
     parser.add_argument("--skip-preflight", action="store_true",
                         help="Skip the endpoint reachability check before evaluating")
+    parser.add_argument("--preflight-timeout", type=float, metavar="SECONDS",
+                        help="Timeout for the pre-run endpoint check (default: the local "
+                             "model's request timeout; raise it for a slow cold model load)")
     parser.add_argument("--report", action="store_true",
                         help="Print a metrics report for this run after it completes")
     parser.add_argument("--compare-to", metavar="PATH",

--- a/llm_client.py
+++ b/llm_client.py
@@ -10,6 +10,12 @@ import httpx
 
 from retry import retry_with_backoff
 
+# Default timeout (seconds) for the lightweight is_available() ping. Longer than
+# a typical liveness probe because a server that loads models on demand only
+# loads the requested model on the first request — a cold load of a large model
+# routinely exceeds 10s, and timing out would wrongly report it unreachable.
+DEFAULT_AVAILABILITY_TIMEOUT = 60
+
 
 class LLMUnavailableError(Exception):
     """The LLM endpoint is unreachable or dropped the connection (transient).
@@ -172,14 +178,22 @@ class LLMClient:
             return self._strip_thinking(content), thinking
         return self._strip_thinking(content)
 
-    async def is_available(self) -> bool:
+    async def is_available(self, timeout: float | None = None) -> bool:
         """Check if the LLM endpoint is reachable.
 
         Sends a minimal completion request to verify connectivity.
 
+        Args:
+            timeout: Seconds to wait for the ping. Defaults to
+                DEFAULT_AVAILABILITY_TIMEOUT, generous enough to cover a server
+                that loads the requested model on demand (a cold load can take
+                far longer than a normal liveness probe).
+
         Returns:
             True if the endpoint responds successfully, False otherwise.
         """
+        if timeout is None:
+            timeout = DEFAULT_AVAILABILITY_TIMEOUT
         try:
             headers = {"Content-Type": "application/json"}
             if self.api_key:
@@ -193,7 +207,7 @@ class LLMClient:
                 **self.extra_body,
             }
 
-            async with httpx.AsyncClient(timeout=10) as client:
+            async with httpx.AsyncClient(timeout=timeout) as client:
                 response = await client.post(self.base_url, headers=headers, json=body)
 
             return response.status_code == 200

--- a/llm_client.py
+++ b/llm_client.py
@@ -211,7 +211,10 @@ class LLMClient:
                 response = await client.post(self.base_url, headers=headers, json=body)
 
             return response.status_code == 200
-        except (httpx.ConnectError, httpx.TimeoutException):
+        except httpx.RequestError:
+            # Any failure to obtain a response means "not available": connect /
+            # timeout, but also UnsupportedProtocol (unset/schemeless URL) and
+            # read/protocol errors (e.g. a dropped connection mid cold-load).
             return False
 
     # Matches <think>...</think> and <<think>>...</<think>> (DeepSeek variant)

--- a/scripts/eval_model.py
+++ b/scripts/eval_model.py
@@ -8,6 +8,7 @@ against a prior run.
     python scripts/eval_model.py qwen/qwen3-14b            # run + report
     python scripts/eval_model.py qwen/qwen3-14b qwen3-8b   # ...also compare vs newest qwen3-8b run
     python scripts/eval_model.py qwen/qwen3-14b evals/results/20250101_....jsonl  # vs explicit file
+    python scripts/eval_model.py qwen/qwen3-14b --preflight-timeout 600   # very slow cold load
 
 PREREQUISITES (inherently manual, not done here):
   1. `mlx_lm.server --model <hf-id> --host 0.0.0.0 --port 8080 --temp 0 --prompt-cache-size 2`
@@ -26,17 +27,27 @@ from pathlib import Path
 DEFAULT_RESULTS_DIR = "evals/results/"
 
 
-def build_run_eval_command(model: str, compare_to: str | None) -> list[str]:
+def build_run_eval_command(
+    model: str,
+    compare_to: str | None,
+    skip_preflight: bool = False,
+    preflight_timeout: float | None = None,
+) -> list[str]:
     """Build the `uv run python -m evals.run_eval` argv for a local-only eval.
 
     --local-only restricts the run to the local classifier; --local-model sets
     (and, via run_eval's default-tag behaviour, names) the model; --report prints
-    metrics inline.
+    metrics inline. The preflight passthroughs let a caller skip or lengthen the
+    endpoint check for a server that cold-loads a large model on demand.
     """
     cmd = [
         "uv", "run", "python", "-m", "evals.run_eval",
         "--local-only", "--local-model", model, "--report",
     ]
+    if skip_preflight:
+        cmd.append("--skip-preflight")
+    if preflight_timeout is not None:
+        cmd += ["--preflight-timeout", str(preflight_timeout)]
     if compare_to:
         cmd += ["--compare-to", compare_to]
     return cmd
@@ -77,6 +88,10 @@ def main(argv: list[str] | None = None) -> int:
                         help="Prior results file path, or a tag to match the newest run of")
     parser.add_argument("--results-dir", default=DEFAULT_RESULTS_DIR,
                         help=f"Where to look up a baseline tag (default: {DEFAULT_RESULTS_DIR})")
+    parser.add_argument("--skip-preflight", action="store_true",
+                        help="Skip run_eval's pre-run endpoint reachability check")
+    parser.add_argument("--preflight-timeout", type=float, metavar="SECONDS",
+                        help="Override the pre-run endpoint check timeout (for a slow cold load)")
     args = parser.parse_args(argv)
 
     try:
@@ -85,7 +100,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    cmd = build_run_eval_command(args.model, compare_to)
+    cmd = build_run_eval_command(
+        args.model, compare_to,
+        skip_preflight=args.skip_preflight,
+        preflight_timeout=args.preflight_timeout,
+    )
     print("+ " + " ".join(cmd), file=sys.stderr)
     return subprocess.run(cmd).returncode
 

--- a/scripts/eval_model.py
+++ b/scripts/eval_model.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""One command to evaluate a downloaded model as the local person-email classifier.
+
+Wraps `python -m evals.run_eval` for the common case: evaluate ONLY the local
+classifier (Stage 2b on person bodies) and print a report — optionally compared
+against a prior run.
+
+    python scripts/eval_model.py qwen/qwen3-14b            # run + report
+    python scripts/eval_model.py qwen/qwen3-14b qwen3-8b   # ...also compare vs newest qwen3-8b run
+    python scripts/eval_model.py qwen/qwen3-14b evals/results/20250101_....jsonl  # vs explicit file
+
+PREREQUISITES (inherently manual, not done here):
+  1. `mlx_lm.server --model <hf-id> --host 0.0.0.0 --port 8080 --temp 0 --prompt-cache-size 2`
+     must already be serving the model, and MLX_URL must point at it. The served
+     --model must match the <hf-id> passed here or every request 404s.
+  2. Stop the daemon first if your MLX server only serves one model at a time.
+
+This delegates to run_eval, which auto-tags the results by the model name,
+runs the endpoint preflight check, and (via --report) prints metrics.
+"""
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_RESULTS_DIR = "evals/results/"
+
+
+def build_run_eval_command(model: str, compare_to: str | None) -> list[str]:
+    """Build the `uv run python -m evals.run_eval` argv for a local-only eval.
+
+    --local-only restricts the run to the local classifier; --local-model sets
+    (and, via run_eval's default-tag behaviour, names) the model; --report prints
+    metrics inline.
+    """
+    cmd = [
+        "uv", "run", "python", "-m", "evals.run_eval",
+        "--local-only", "--local-model", model, "--report",
+    ]
+    if compare_to:
+        cmd += ["--compare-to", compare_to]
+    return cmd
+
+
+def resolve_baseline(token: str | None, results_dir: Path) -> str | None:
+    """Resolve a baseline argument to a results file path, or None.
+
+    A token that is an existing path is used as-is. Otherwise it is treated as a
+    tag substring and matched against `*<token>*.jsonl` in *results_dir*, ignoring
+    `.cot.jsonl` chain-of-thought sidecars; the newest match wins (filenames are
+    timestamp-prefixed, so a lexical sort is chronological).
+
+    Raises:
+        FileNotFoundError: if a tag token matches no results file.
+    """
+    if not token:
+        return None
+    if Path(token).exists():
+        return token
+    matches = sorted(
+        p for p in results_dir.glob(f"*{token}*.jsonl")
+        if not p.name.endswith(".cot.jsonl")
+    )
+    if not matches:
+        raise FileNotFoundError(
+            f"No results file in {results_dir} matching tag '{token}'"
+        )
+    return str(matches[-1])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a downloaded model as the local person-email classifier."
+    )
+    parser.add_argument("model", help="HuggingFace model id served by mlx_lm.server")
+    parser.add_argument("baseline", nargs="?",
+                        help="Prior results file path, or a tag to match the newest run of")
+    parser.add_argument("--results-dir", default=DEFAULT_RESULTS_DIR,
+                        help=f"Where to look up a baseline tag (default: {DEFAULT_RESULTS_DIR})")
+    args = parser.parse_args(argv)
+
+    try:
+        compare_to = resolve_baseline(args.baseline, Path(args.results_dir))
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    cmd = build_run_eval_command(args.model, compare_to)
+    print("+ " + " ".join(cmd), file=sys.stderr)
+    return subprocess.run(cmd).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval_model.py
+++ b/scripts/eval_model.py
@@ -24,6 +24,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from evals.run_eval import sanitize_tag
+
 DEFAULT_RESULTS_DIR = "evals/results/"
 
 
@@ -32,13 +34,16 @@ def build_run_eval_command(
     compare_to: str | None,
     skip_preflight: bool = False,
     preflight_timeout: float | None = None,
+    output_dir: str | None = None,
 ) -> list[str]:
     """Build the `uv run python -m evals.run_eval` argv for a local-only eval.
 
     --local-only restricts the run to the local classifier; --local-model sets
     (and, via run_eval's default-tag behaviour, names) the model; --report prints
     metrics inline. The preflight passthroughs let a caller skip or lengthen the
-    endpoint check for a server that cold-loads a large model on demand.
+    endpoint check for a server that cold-loads a large model on demand. When set,
+    output_dir is forwarded as --output-dir so the run is written where baselines
+    are read from.
     """
     cmd = [
         "uv", "run", "python", "-m", "evals.run_eval",
@@ -48,6 +53,8 @@ def build_run_eval_command(
         cmd.append("--skip-preflight")
     if preflight_timeout is not None:
         cmd += ["--preflight-timeout", str(preflight_timeout)]
+    if output_dir is not None:
+        cmd += ["--output-dir", str(output_dir)]
     if compare_to:
         cmd += ["--compare-to", compare_to]
     return cmd
@@ -56,20 +63,32 @@ def build_run_eval_command(
 def resolve_baseline(token: str | None, results_dir: Path) -> str | None:
     """Resolve a baseline argument to a results file path, or None.
 
-    A token that is an existing path is used as-is. Otherwise it is treated as a
-    tag substring and matched against `*<token>*.jsonl` in *results_dir*, ignoring
-    `.cot.jsonl` chain-of-thought sidecars; the newest match wins (filenames are
-    timestamp-prefixed, so a lexical sort is chronological).
+    A token that is an explicit results file (a `.jsonl` path that exists) is used
+    as-is. Otherwise it is treated as a model tag: it is run through the same
+    sanitize_tag that named the results file, then matched as a whole underscore-
+    delimited segment against `*_<tag>_*.jsonl` in *results_dir* (ignoring
+    `.cot.jsonl` sidecars); the newest match wins, since timestamp-prefixed names
+    sort chronologically.
+
+    Sanitizing first means a tag with glob metacharacters or a '/' (e.g.
+    `qwen/qwen3-14b`) searches the same namespace run_eval wrote, and the segment
+    anchoring keeps `qwen3` from matching an unrelated `qwen3-14b` run.
 
     Raises:
         FileNotFoundError: if a tag token matches no results file.
     """
     if not token:
         return None
-    if Path(token).exists():
+    # Only an explicit results file is a path; a bare tag never is (avoids a cwd
+    # name collision being mistaken for a path).
+    path = Path(token)
+    if path.suffix == ".jsonl" and path.exists():
         return token
+    tag = sanitize_tag(token)
+    if not tag:
+        raise FileNotFoundError(f"Baseline tag '{token}' is empty after sanitizing")
     matches = sorted(
-        p for p in results_dir.glob(f"*{token}*.jsonl")
+        p for p in results_dir.glob(f"*_{tag}_*.jsonl")
         if not p.name.endswith(".cot.jsonl")
     )
     if not matches:
@@ -87,7 +106,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("baseline", nargs="?",
                         help="Prior results file path, or a tag to match the newest run of")
     parser.add_argument("--results-dir", default=DEFAULT_RESULTS_DIR,
-                        help=f"Where to look up a baseline tag (default: {DEFAULT_RESULTS_DIR})")
+                        help="Directory the run is written to AND baseline tags are "
+                             f"looked up in (default: {DEFAULT_RESULTS_DIR})")
     parser.add_argument("--skip-preflight", action="store_true",
                         help="Skip run_eval's pre-run endpoint reachability check")
     parser.add_argument("--preflight-timeout", type=float, metavar="SECONDS",
@@ -104,6 +124,7 @@ def main(argv: list[str] | None = None) -> int:
         args.model, compare_to,
         skip_preflight=args.skip_preflight,
         preflight_timeout=args.preflight_timeout,
+        output_dir=args.results_dir,
     )
     print("+ " + " ".join(cmd), file=sys.stderr)
     return subprocess.run(cmd).returncode

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -1,0 +1,47 @@
+"""Tests for the one-command-per-model eval wrapper (scripts/eval_model.py)."""
+
+import pytest
+
+from scripts.eval_model import build_run_eval_command, resolve_baseline
+
+
+class TestBuildRunEvalCommand:
+    def test_local_only_run_with_default_tag_and_report(self):
+        cmd = build_run_eval_command("qwen/qwen3-14b", compare_to=None)
+        assert cmd == [
+            "uv", "run", "python", "-m", "evals.run_eval",
+            "--local-only", "--local-model", "qwen/qwen3-14b", "--report",
+        ]
+
+    def test_includes_compare_to_when_given(self):
+        cmd = build_run_eval_command("qwen/qwen3-14b", compare_to="evals/results/prior.jsonl")
+        assert cmd[-2:] == ["--compare-to", "evals/results/prior.jsonl"]
+
+
+class TestResolveBaseline:
+    def test_none_returns_none(self, tmp_path):
+        assert resolve_baseline(None, tmp_path) is None
+
+    def test_existing_path_returned_as_is(self, tmp_path):
+        f = tmp_path / "some_run.jsonl"
+        f.write_text("{}\n")
+        assert resolve_baseline(str(f), tmp_path) == str(f)
+
+    def test_tag_resolves_to_newest_matching_run(self, tmp_path):
+        # Timestamp-prefixed names sort chronologically; newest wins.
+        old = tmp_path / "20250101_000000_stage2_only_qwen3_aaaa.jsonl"
+        new = tmp_path / "20250202_000000_stage2_only_qwen3_bbbb.jsonl"
+        old.write_text("{}\n")
+        new.write_text("{}\n")
+        assert resolve_baseline("qwen3", tmp_path) == str(new)
+
+    def test_tag_match_ignores_cot_sidecars(self, tmp_path):
+        run = tmp_path / "20250101_000000_stage2_only_qwen3_aaaa.jsonl"
+        sidecar = tmp_path / "20250101_000000_stage2_only_qwen3_aaaa.cot.jsonl"
+        run.write_text("{}\n")
+        sidecar.write_text("{}\n")
+        assert resolve_baseline("qwen3", tmp_path) == str(run)
+
+    def test_no_match_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="nomatch"):
+            resolve_baseline("nomatch", tmp_path)

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -2,7 +2,12 @@
 
 import pytest
 
+from scripts import eval_model
 from scripts.eval_model import build_run_eval_command, resolve_baseline
+
+
+class _FakeCompleted:
+    returncode = 0
 
 
 class TestBuildRunEvalCommand:
@@ -16,6 +21,22 @@ class TestBuildRunEvalCommand:
     def test_includes_compare_to_when_given(self):
         cmd = build_run_eval_command("qwen/qwen3-14b", compare_to="evals/results/prior.jsonl")
         assert cmd[-2:] == ["--compare-to", "evals/results/prior.jsonl"]
+
+    def test_skip_preflight_appended(self):
+        cmd = build_run_eval_command("qwen/qwen3-14b", compare_to=None, skip_preflight=True)
+        assert "--skip-preflight" in cmd
+
+    def test_preflight_timeout_appended(self):
+        cmd = build_run_eval_command("qwen/qwen3-14b", compare_to=None, preflight_timeout=240)
+        assert "--preflight-timeout" in cmd
+        assert cmd[cmd.index("--preflight-timeout") + 1] == "240"
+
+    def test_compare_to_stays_last_with_preflight_flags(self):
+        cmd = build_run_eval_command(
+            "qwen/qwen3-14b", compare_to="prior.jsonl",
+            skip_preflight=True, preflight_timeout=240,
+        )
+        assert cmd[-2:] == ["--compare-to", "prior.jsonl"]
 
 
 class TestResolveBaseline:
@@ -45,3 +66,28 @@ class TestResolveBaseline:
     def test_no_match_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError, match="nomatch"):
             resolve_baseline("nomatch", tmp_path)
+
+
+class TestMainForwardsPreflightFlags:
+    def _capture(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, *a, **k):
+            captured["cmd"] = cmd
+            return _FakeCompleted()
+
+        monkeypatch.setattr(eval_model.subprocess, "run", fake_run)
+        return captured
+
+    def test_skip_preflight_flag_reaches_run_eval(self, monkeypatch):
+        captured = self._capture(monkeypatch)
+        rc = eval_model.main(["qwen/qwen3-14b", "--skip-preflight"])
+        assert rc == 0
+        assert "--skip-preflight" in captured["cmd"]
+
+    def test_preflight_timeout_flag_reaches_run_eval(self, monkeypatch):
+        captured = self._capture(monkeypatch)
+        eval_model.main(["qwen/qwen3-14b", "--preflight-timeout", "240"])
+        cmd = captured["cmd"]
+        assert "--preflight-timeout" in cmd
+        assert cmd[cmd.index("--preflight-timeout") + 1] == "240.0"

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -38,6 +38,13 @@ class TestBuildRunEvalCommand:
         )
         assert cmd[-2:] == ["--compare-to", "prior.jsonl"]
 
+    def test_output_dir_forwarded_when_given(self):
+        cmd = build_run_eval_command("qwen/qwen3-14b", compare_to=None, output_dir="/data/results")
+        assert cmd[cmd.index("--output-dir") + 1] == "/data/results"
+
+    def test_output_dir_omitted_when_none(self):
+        assert "--output-dir" not in build_run_eval_command("qwen/qwen3-14b", compare_to=None)
+
 
 class TestResolveBaseline:
     def test_none_returns_none(self, tmp_path):
@@ -67,6 +74,33 @@ class TestResolveBaseline:
         with pytest.raises(FileNotFoundError, match="nomatch"):
             resolve_baseline("nomatch", tmp_path)
 
+    def test_glob_metacharacters_are_neutralized_by_sanitize(self, tmp_path):
+        # A glob metachar (here '?') must be sanitized to '-', not interpreted as a
+        # wildcard; 'qwen3?14b' -> 'qwen3-14b', matching the run run_eval wrote.
+        (tmp_path / "20250101_000000_stage2_only_qwen3-14b_aaaa.jsonl").write_text("{}\n")
+        assert resolve_baseline("qwen3?14b", tmp_path).endswith("qwen3-14b_aaaa.jsonl")
+
+    def test_slash_token_matches_sanitized_filename(self, tmp_path):
+        # run_eval writes the '/' as '-'; the lookup must search the same form.
+        (tmp_path / "20250101_000000_stage2_only_qwen-qwen3-14b_aaaa.jsonl").write_text("{}\n")
+        assert resolve_baseline("qwen/qwen3-14b", tmp_path).endswith("qwen-qwen3-14b_aaaa.jsonl")
+
+    def test_token_anchored_to_tag_not_arbitrary_substring(self, tmp_path):
+        # Only a qwen3-14b run exists; the token 'qwen3' must NOT match it (it is a
+        # different tag), rather than silently comparing against the wrong model.
+        (tmp_path / "20250101_000000_stage2_only_qwen3-14b_aaaa.jsonl").write_text("{}\n")
+        with pytest.raises(FileNotFoundError):
+            resolve_baseline("qwen3", tmp_path)
+
+    def test_cwd_name_collision_not_treated_as_path(self, tmp_path, monkeypatch):
+        # A bare tag that coincides with a cwd entry must not be taken as a path.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "qwen3").mkdir()  # cwd collision
+        results = tmp_path / "results"
+        results.mkdir()
+        (results / "20250101_000000_stage2_only_qwen3_aaaa.jsonl").write_text("{}\n")
+        assert resolve_baseline("qwen3", results).endswith("qwen3_aaaa.jsonl")
+
 
 class TestMainForwardsPreflightFlags:
     def _capture(self, monkeypatch):
@@ -91,3 +125,10 @@ class TestMainForwardsPreflightFlags:
         cmd = captured["cmd"]
         assert "--preflight-timeout" in cmd
         assert cmd[cmd.index("--preflight-timeout") + 1] == "240.0"
+
+    def test_results_dir_forwarded_as_output_dir(self, monkeypatch, tmp_path):
+        # The run is WRITTEN where baselines are READ, so the two never diverge.
+        captured = self._capture(monkeypatch)
+        eval_model.main(["qwen/qwen3-14b", "--results-dir", str(tmp_path)])
+        cmd = captured["cmd"]
+        assert cmd[cmd.index("--output-dir") + 1] == str(tmp_path)

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -1,19 +1,29 @@
 """Tests for eval runner parallelism defaults and extra_body overrides."""
 
 import argparse
+import asyncio
 import json
 
 import pytest
 
 from daemon import DEFAULT_MAX_THREAD_CHARS, load_config
+from evals import run_eval
 from evals.run_eval import (
     apply_config_overrides,
+    default_tag,
     load_golden_set,
+    main,
+    maybe_report,
+    preflight_check,
+    required_endpoints,
     resolve_extra_body,
+    resolve_local_only,
     resolve_max_thread_chars,
     resolve_parallelism,
+    sanitize_tag,
+    write_results,
 )
-from evals.schemas import GoldenThread
+from evals.schemas import GoldenThread, PredictionResult, RunMeta
 
 
 def _golden(thread_id, **kw):
@@ -196,3 +206,258 @@ class TestResolveExtraBody:
         base = {"chat_template_kwargs": {"foo": 1}}
         resolve_extra_body(base, True, None)
         assert base == {"chat_template_kwargs": {"foo": 1}}
+
+
+class TestResolveLocalOnly:
+    """--local-only is shorthand for --stages stage2_only --sender-type person,
+    the only run configuration that exercises ONLY the local classifier."""
+
+    def _args(self, **kw):
+        base = dict(local_only=False, stages="full", sender_type=None)
+        base.update(kw)
+        return argparse.Namespace(**base)
+
+    def test_noop_when_not_set(self):
+        args = self._args(local_only=False, stages="full", sender_type=None)
+        resolve_local_only(args)
+        assert args.stages == "full"
+        assert args.sender_type is None
+
+    def test_sets_stage2_person_when_set(self):
+        args = self._args(local_only=True)
+        resolve_local_only(args)
+        assert args.stages == "stage2_only"
+        assert args.sender_type == "person"
+
+    def test_compatible_explicit_values_allowed(self):
+        args = self._args(local_only=True, stages="stage2_only", sender_type="person")
+        resolve_local_only(args)
+        assert (args.stages, args.sender_type) == ("stage2_only", "person")
+
+    def test_conflicting_stages_raises(self):
+        args = self._args(local_only=True, stages="stage1_only")
+        with pytest.raises(ValueError, match="local-only"):
+            resolve_local_only(args)
+
+    def test_conflicting_sender_type_raises(self):
+        args = self._args(local_only=True, sender_type="service")
+        with pytest.raises(ValueError, match="local-only"):
+            resolve_local_only(args)
+
+
+class TestSanitizeTag:
+    def test_replaces_slashes_in_hf_id(self):
+        assert sanitize_tag("qwen/qwen3-14b") == "qwen-qwen3-14b"
+
+    def test_keeps_dots_dashes_underscores(self):
+        assert sanitize_tag("Qwen3-14B_v2.1") == "Qwen3-14B_v2.1"
+
+    def test_collapses_runs_and_strips_edges(self):
+        assert sanitize_tag("/foo //bar/") == "foo-bar"
+
+    def test_empty_stays_empty(self):
+        assert sanitize_tag("") == ""
+
+
+class TestDefaultTag:
+    def _config(self):
+        return {"llm": {
+            "cloud": {"model": "anthropic/claude-x"},
+            "local": {"model": "qwen/qwen3-14b"},
+        }}
+
+    def test_uses_local_model_for_stage2_only(self):
+        assert default_tag("stage2_only", self._config()) == "qwen-qwen3-14b"
+
+    def test_uses_local_model_for_full(self):
+        assert default_tag("full", self._config()) == "qwen-qwen3-14b"
+
+    def test_uses_cloud_model_for_stage1_only(self):
+        # Stage 1 is the cloud model's job; tagging by local model would mislabel.
+        assert default_tag("stage1_only", self._config()) == "anthropic-claude-x"
+
+
+class TestRequiredEndpoints:
+    """Which LLM endpoints a run actually touches, so preflight only checks those."""
+
+    def test_stage1_only_needs_cloud_only(self):
+        assert required_endpoints("stage1_only", None) == (True, False)
+
+    def test_stage2_only_person_needs_local_only(self):
+        assert required_endpoints("stage2_only", "person") == (False, True)
+
+    def test_stage2_only_service_needs_cloud_only(self):
+        assert required_endpoints("stage2_only", "service") == (True, False)
+
+    def test_stage2_only_mixed_needs_both(self):
+        assert required_endpoints("stage2_only", None) == (True, True)
+
+    def test_full_needs_both(self):
+        assert required_endpoints("full", "person") == (True, True)
+
+
+class _FakeClient:
+    def __init__(self, model, base_url, available):
+        self.model = model
+        self.base_url = base_url
+        self._available = available
+        self.checked = False
+
+    async def is_available(self):
+        self.checked = True
+        return self._available
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestPreflightCheck:
+    def test_no_errors_when_required_endpoints_reachable(self):
+        cloud = _FakeClient("c", "http://cloud", True)
+        local = _FakeClient("m", "http://local", True)
+        assert _run(preflight_check(cloud, local, True, True)) == []
+
+    def test_unreachable_required_local_reported(self):
+        cloud = _FakeClient("c", "http://cloud", True)
+        local = _FakeClient("qwen3", "http://local", False)
+        errors = _run(preflight_check(cloud, local, False, True))
+        assert len(errors) == 1
+        assert "qwen3" in errors[0] and "http://local" in errors[0]
+
+    def test_unreachable_required_cloud_reported(self):
+        cloud = _FakeClient("claude", "http://cloud", False)
+        local = _FakeClient("m", "http://local", True)
+        errors = _run(preflight_check(cloud, local, True, True))
+        assert len(errors) == 1
+        assert "claude" in errors[0]
+
+    def test_unneeded_endpoint_not_checked_even_if_down(self):
+        cloud = _FakeClient("c", "http://cloud", False)
+        local = _FakeClient("m", "http://local", True)
+        errors = _run(preflight_check(cloud, local, False, True))
+        assert errors == []
+        assert cloud.checked is False  # never probed
+
+
+def _meta(**overrides):
+    defaults = dict(
+        run_id="abc12345-6789", timestamp="2025-01-01T00:00:00", config_hash="deadbeef",
+        config_path="config.toml", cloud_model="test-cloud", local_model="test-local",
+        golden_set_path="golden.jsonl", golden_set_count=1,
+    )
+    defaults.update(overrides)
+    return RunMeta(**defaults)
+
+
+def _result(predicted_label="fyi"):
+    return PredictionResult(
+        thread_id="t1", expected_sender_type="person", expected_label="fyi",
+        predicted_sender_type="person", predicted_label=predicted_label,
+        sender_type_correct=True, label_correct=(predicted_label == "fyi"),
+    )
+
+
+class TestMaybeReport:
+    def test_prints_nothing_when_neither_flag_set(self, capsys):
+        maybe_report(_meta(), [_result()], report_enabled=False, compare_to=None)
+        assert capsys.readouterr().out == ""
+
+    def test_report_flag_prints_evaluation_report(self, capsys):
+        maybe_report(_meta(), [_result()], report_enabled=True, compare_to=None)
+        assert "Evaluation Report" in capsys.readouterr().out
+
+    def test_compare_to_prints_comparison(self, capsys, tmp_path):
+        prior = tmp_path / "20250101_000000_stage2_only_prior_aaaa1111.jsonl"
+        write_results(prior, _meta(run_id="prior999", tag="prior"), [_result()])
+        maybe_report(_meta(), [_result()], report_enabled=False, compare_to=str(prior))
+        assert "Comparison" in capsys.readouterr().out
+
+    def test_missing_compare_file_errors_without_raising(self, capsys, tmp_path):
+        missing = tmp_path / "nope.jsonl"
+        maybe_report(_meta(), [_result()], report_enabled=False, compare_to=str(missing))
+        err = capsys.readouterr().err
+        assert "not found" in err
+
+
+def _full_args(**kw):
+    """A complete run_eval argparse.Namespace with CLI defaults, overridable per test."""
+    base = dict(
+        golden_set="evals/golden_set.jsonl", config=None, output_dir="evals/results/",
+        stages="full", parallelism=None, include_unreviewed=False, dry_run=False,
+        tag=None, no_cache=True, sender_type=None, max_threads=None,
+        local_only=False, skip_preflight=False, report=False, compare_to=None,
+        cloud_model=None, local_model=None,
+        cloud_temperature=None, local_temperature=None,
+        cloud_max_tokens=None, local_max_tokens=None,
+        cloud_timeout=None, local_timeout=None,
+        cloud_extra_body=None, local_extra_body=None,
+        cloud_no_think=False, local_no_think=False,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+class TestMainLocalOnlyWiring:
+    def test_local_only_dry_run_filters_to_person_and_defaults_tag(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        monkeypatch.setenv("MLX_MODEL", "qwen/qwen3-test")
+        path = tmp_path / "golden.jsonl"
+        _write_golden_set(path, [
+            _golden("person_thread", reviewed=True, expected_sender_type="person"),
+            _golden("service_thread", reviewed=True, expected_sender_type="service"),
+        ])
+        args = _full_args(golden_set=str(path), local_only=True, dry_run=True)
+
+        asyncio.run(main(args))
+
+        # --local-only resolved the run shape in place...
+        assert args.stages == "stage2_only"
+        assert args.sender_type == "person"
+        # ...the tag defaulted to the (sanitized) local model under test...
+        assert args.tag == "qwen-qwen3-test"
+        # ...and the service thread was filtered out of the dry-run preview.
+        err = capsys.readouterr().err
+        assert "person_thread" in err
+        assert "service_thread" not in err
+
+
+class TestMainPreflightWiring:
+    def test_unreachable_local_endpoint_exits_1_before_evaluating(
+        self, tmp_path, monkeypatch
+    ):
+        async def _never_available(self):
+            return False
+
+        monkeypatch.setattr(run_eval.LLMClient, "is_available", _never_available)
+        path = tmp_path / "golden.jsonl"
+        _write_golden_set(path, [
+            _golden("person_thread", reviewed=True, expected_sender_type="person"),
+        ])
+        # local-only -> only the local endpoint is required; it's "down" -> exit 1.
+        args = _full_args(golden_set=str(path), local_only=True)
+
+        with pytest.raises(SystemExit) as excinfo:
+            asyncio.run(main(args))
+        assert excinfo.value.code == 1
+
+    def test_skip_preflight_bypasses_the_check(self, tmp_path, monkeypatch):
+        # With the endpoint "down" but --skip-preflight, main must get PAST preflight
+        # (and then fail later trying to actually classify — proving preflight was skipped).
+        async def _never_available(self):
+            return False
+
+        async def _boom(*a, **k):
+            raise RuntimeError("reached evaluation")
+
+        monkeypatch.setattr(run_eval.LLMClient, "is_available", _never_available)
+        monkeypatch.setattr(run_eval, "run_evaluation", _boom)
+        path = tmp_path / "golden.jsonl"
+        _write_golden_set(path, [
+            _golden("person_thread", reviewed=True, expected_sender_type="person"),
+        ])
+        args = _full_args(golden_set=str(path), local_only=True, skip_preflight=True)
+
+        with pytest.raises(RuntimeError, match="reached evaluation"):
+            asyncio.run(main(args))

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -302,9 +302,11 @@ class _FakeClient:
         self.base_url = base_url
         self._available = available
         self.checked = False
+        self.last_timeout = "unset"
 
-    async def is_available(self):
+    async def is_available(self, timeout=None):
         self.checked = True
+        self.last_timeout = timeout
         return self._available
 
 
@@ -338,6 +340,13 @@ class TestPreflightCheck:
         errors = _run(preflight_check(cloud, local, False, True))
         assert errors == []
         assert cloud.checked is False  # never probed
+
+    def test_forwards_timeout_to_is_available(self):
+        cloud = _FakeClient("c", "http://cloud", True)
+        local = _FakeClient("m", "http://local", True)
+        _run(preflight_check(cloud, local, True, True, timeout=77))
+        assert local.last_timeout == 77
+        assert cloud.last_timeout == 77
 
 
 def _meta(**overrides):
@@ -386,7 +395,8 @@ def _full_args(**kw):
         golden_set="evals/golden_set.jsonl", config=None, output_dir="evals/results/",
         stages="full", parallelism=None, include_unreviewed=False, dry_run=False,
         tag=None, no_cache=True, sender_type=None, max_threads=None,
-        local_only=False, skip_preflight=False, report=False, compare_to=None,
+        local_only=False, skip_preflight=False, preflight_timeout=None,
+        report=False, compare_to=None,
         cloud_model=None, local_model=None,
         cloud_temperature=None, local_temperature=None,
         cloud_max_tokens=None, local_max_tokens=None,
@@ -427,7 +437,7 @@ class TestMainPreflightWiring:
     def test_unreachable_local_endpoint_exits_1_before_evaluating(
         self, tmp_path, monkeypatch
     ):
-        async def _never_available(self):
+        async def _never_available(self, timeout=None):
             return False
 
         monkeypatch.setattr(run_eval.LLMClient, "is_available", _never_available)
@@ -445,7 +455,7 @@ class TestMainPreflightWiring:
     def test_skip_preflight_bypasses_the_check(self, tmp_path, monkeypatch):
         # With the endpoint "down" but --skip-preflight, main must get PAST preflight
         # (and then fail later trying to actually classify — proving preflight was skipped).
-        async def _never_available(self):
+        async def _never_available(self, timeout=None):
             return False
 
         async def _boom(*a, **k):
@@ -461,3 +471,43 @@ class TestMainPreflightWiring:
 
         with pytest.raises(RuntimeError, match="reached evaluation"):
             asyncio.run(main(args))
+
+
+class TestMainPreflightTimeoutWiring:
+    def _capture_and_stop(self, monkeypatch):
+        """Patch preflight_check to capture its timeout and run_evaluation to stop main."""
+        captured = {}
+
+        async def fake_preflight(cloud, local, need_cloud, need_local, timeout=None):
+            captured["timeout"] = timeout
+            return []  # reachable
+
+        async def boom(*a, **k):
+            raise RuntimeError("reached evaluation")
+
+        monkeypatch.setattr(run_eval, "preflight_check", fake_preflight)
+        monkeypatch.setattr(run_eval, "run_evaluation", boom)
+        return captured
+
+    def test_explicit_preflight_timeout_is_forwarded(self, tmp_path, monkeypatch):
+        captured = self._capture_and_stop(monkeypatch)
+        path = tmp_path / "golden.jsonl"
+        _write_golden_set(path, [_golden("p", reviewed=True, expected_sender_type="person")])
+        args = _full_args(golden_set=str(path), local_only=True, preflight_timeout=99.0)
+
+        with pytest.raises(RuntimeError, match="reached evaluation"):
+            asyncio.run(main(args))
+        assert captured["timeout"] == 99.0
+
+    def test_preflight_timeout_defaults_to_local_request_timeout(self, tmp_path, monkeypatch):
+        captured = self._capture_and_stop(monkeypatch)
+        path = tmp_path / "golden.jsonl"
+        _write_golden_set(path, [_golden("p", reviewed=True, expected_sender_type="person")])
+        args = _full_args(golden_set=str(path), local_only=True, preflight_timeout=None)
+
+        with pytest.raises(RuntimeError, match="reached evaluation"):
+            asyncio.run(main(args))
+        # Defaults to the local model's configured request timeout (well over 10s),
+        # so a cold on-demand model load isn't read as "unreachable".
+        assert captured["timeout"] == load_config()["llm"]["local"]["timeout"]
+        assert captured["timeout"] > 10

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -278,7 +278,9 @@ class TestDefaultTag:
 
 
 class TestRequiredEndpoints:
-    """Which LLM endpoints a run actually touches, so preflight only checks those."""
+    """Endpoints WITHOUT which a run produces no results at all, so preflight
+    only hard-aborts when the whole run would be useless (not when one endpoint
+    is down but the other half of the work could still succeed)."""
 
     def test_stage1_only_needs_cloud_only(self):
         assert required_endpoints("stage1_only", None) == (True, False)
@@ -289,11 +291,16 @@ class TestRequiredEndpoints:
     def test_stage2_only_service_needs_cloud_only(self):
         assert required_endpoints("stage2_only", "service") == (True, False)
 
-    def test_stage2_only_mixed_needs_both(self):
-        assert required_endpoints("stage2_only", None) == (True, True)
+    def test_stage2_only_mixed_requires_neither(self):
+        # person->local, service->cloud: a down endpoint loses half the work,
+        # not all of it, so neither is wholly required.
+        assert required_endpoints("stage2_only", None) == (False, False)
 
-    def test_full_needs_both(self):
-        assert required_endpoints("full", "person") == (True, True)
+    def test_full_requires_cloud_only(self):
+        # Stage 1 (cloud) gates every thread, so cloud-down means zero results;
+        # local-down only fails person Stage 2b, leaving partial cloud results.
+        assert required_endpoints("full", "person") == (True, False)
+        assert required_endpoints("full", None) == (True, False)
 
 
 class _FakeClient:
@@ -341,12 +348,14 @@ class TestPreflightCheck:
         assert errors == []
         assert cloud.checked is False  # never probed
 
-    def test_forwards_timeout_to_is_available(self):
+    def test_forwards_per_endpoint_timeouts_to_is_available(self):
+        # Cloud and local get their own probe timeouts (cloud need not wait out
+        # the long local cold-load budget).
         cloud = _FakeClient("c", "http://cloud", True)
         local = _FakeClient("m", "http://local", True)
-        _run(preflight_check(cloud, local, True, True, timeout=77))
-        assert local.last_timeout == 77
-        assert cloud.last_timeout == 77
+        _run(preflight_check(cloud, local, True, True, cloud_timeout=30, local_timeout=180))
+        assert cloud.last_timeout == 30
+        assert local.last_timeout == 180
 
 
 def _meta(**overrides):
@@ -387,6 +396,37 @@ class TestMaybeReport:
         maybe_report(_meta(), [_result()], report_enabled=False, compare_to=str(missing))
         err = capsys.readouterr().err
         assert "not found" in err
+
+    def test_baseline_is_run_a_so_delta_reads_new_minus_baseline(self, capsys, tmp_path):
+        prior = tmp_path / "20250101_000000_stage2_only_base_aaaa1111.jsonl"
+        write_results(prior, _meta(run_id="prior999", tag="base"), [_result()])
+        maybe_report(_meta(run_id="new00000", tag="new"), [_result()],
+                     report_enabled=False, compare_to=str(prior))
+        out = capsys.readouterr().out
+        a_line = next(ln for ln in out.splitlines() if ln.strip().startswith("Run A:"))
+        b_line = next(ln for ln in out.splitlines() if ln.strip().startswith("Run B:"))
+        assert "base" in a_line  # baseline is A
+        assert "new" in b_line   # this run is B -> Delta = new - baseline
+
+    def test_compare_shows_per_thread_differences(self, capsys, tmp_path):
+        prior = tmp_path / "20250101_000000_stage2_only_base_aaaa1111.jsonl"
+        write_results(prior, _meta(tag="base"), [_result(predicted_label="fyi")])
+        maybe_report(_meta(tag="new"), [_result(predicted_label="low_priority")],
+                     report_enabled=False, compare_to=str(prior))
+        assert "Prediction Differences" in capsys.readouterr().out
+
+    def test_malformed_compare_file_errors_without_raising(self, capsys, tmp_path):
+        bad = tmp_path / "20250101_000000_stage2_only_base_aaaa1111.jsonl"
+        bad.write_text('{"type": "thinking", "thread_id": "t1"}\n')  # no run_meta line
+        maybe_report(_meta(), [_result()], report_enabled=False, compare_to=str(bad))
+        assert "Error" in capsys.readouterr().err
+
+    def test_population_mismatch_warns(self, capsys, tmp_path):
+        prior = tmp_path / "20250101_000000_full_base_aaaa1111.jsonl"
+        write_results(prior, _meta(tag="base", stages="full"), [_result()])
+        maybe_report(_meta(tag="new", stages="stage2_only"), [_result()],
+                     report_enabled=False, compare_to=str(prior))
+        assert "stages" in capsys.readouterr().err.lower()
 
 
 def _full_args(**kw):
@@ -475,11 +515,13 @@ class TestMainPreflightWiring:
 
 class TestMainPreflightTimeoutWiring:
     def _capture_and_stop(self, monkeypatch):
-        """Patch preflight_check to capture its timeout and run_evaluation to stop main."""
+        """Patch preflight_check to capture its timeouts and run_evaluation to stop main."""
         captured = {}
 
-        async def fake_preflight(cloud, local, need_cloud, need_local, timeout=None):
-            captured["timeout"] = timeout
+        async def fake_preflight(cloud, local, need_cloud, need_local,
+                                 cloud_timeout=None, local_timeout=None):
+            captured["cloud_timeout"] = cloud_timeout
+            captured["local_timeout"] = local_timeout
             return []  # reachable
 
         async def boom(*a, **k):
@@ -489,7 +531,7 @@ class TestMainPreflightTimeoutWiring:
         monkeypatch.setattr(run_eval, "run_evaluation", boom)
         return captured
 
-    def test_explicit_preflight_timeout_is_forwarded(self, tmp_path, monkeypatch):
+    def test_explicit_preflight_timeout_overrides_both(self, tmp_path, monkeypatch):
         captured = self._capture_and_stop(monkeypatch)
         path = tmp_path / "golden.jsonl"
         _write_golden_set(path, [_golden("p", reviewed=True, expected_sender_type="person")])
@@ -497,9 +539,10 @@ class TestMainPreflightTimeoutWiring:
 
         with pytest.raises(RuntimeError, match="reached evaluation"):
             asyncio.run(main(args))
-        assert captured["timeout"] == 99.0
+        assert captured["local_timeout"] == 99.0
+        assert captured["cloud_timeout"] == 99.0
 
-    def test_preflight_timeout_defaults_to_local_request_timeout(self, tmp_path, monkeypatch):
+    def test_preflight_timeouts_default_to_per_endpoint_request_timeouts(self, tmp_path, monkeypatch):
         captured = self._capture_and_stop(monkeypatch)
         path = tmp_path / "golden.jsonl"
         _write_golden_set(path, [_golden("p", reviewed=True, expected_sender_type="person")])
@@ -507,7 +550,9 @@ class TestMainPreflightTimeoutWiring:
 
         with pytest.raises(RuntimeError, match="reached evaluation"):
             asyncio.run(main(args))
-        # Defaults to the local model's configured request timeout (well over 10s),
+        cfg = load_config()
+        # Each endpoint defaults to its own request timeout; local is well over 10s
         # so a cold on-demand model load isn't read as "unreachable".
-        assert captured["timeout"] == load_config()["llm"]["local"]["timeout"]
-        assert captured["timeout"] > 10
+        assert captured["local_timeout"] == cfg["llm"]["local"]["timeout"]
+        assert captured["cloud_timeout"] == cfg["llm"]["cloud"]["timeout"]
+        assert captured["local_timeout"] > 10

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -440,3 +440,11 @@ class TestIsAvailable:
 
         assert await cached.is_available() is True
         inner.is_available.assert_awaited_once()
+
+    async def test_forwards_timeout_to_inner(self, tmp_path: Path):
+        inner = _make_inner()
+        inner.is_available.return_value = True
+        cached = CachedLLMClient(inner, tmp_path / "cache.jsonl")
+
+        await cached.is_available(timeout=42)
+        inner.is_available.assert_awaited_once_with(42)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from llm_client import LLMClient, LLMUnavailableError
+from llm_client import DEFAULT_AVAILABILITY_TIMEOUT, LLMClient, LLMUnavailableError
 
 
 @pytest.fixture
@@ -435,6 +435,33 @@ class TestIsAvailable:
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
             assert await local_client.is_available() is False
+
+    async def test_default_availability_timeout_is_longer_than_10s(self, local_client):
+        """The ping timeout defaults to DEFAULT_AVAILABILITY_TIMEOUT (>10s) so a
+        cold on-demand model load is not mistaken for an unreachable server."""
+        assert DEFAULT_AVAILABILITY_TIMEOUT > 10
+        mock_response = _mock_response(json_data={"choices": [{"message": {"content": "ok"}}]})
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await local_client.is_available()
+
+            assert mock_client_cls.call_args.kwargs["timeout"] == DEFAULT_AVAILABILITY_TIMEOUT
+
+    async def test_explicit_timeout_is_honored(self, local_client):
+        mock_response = _mock_response(json_data={"choices": [{"message": {"content": "ok"}}]})
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await local_client.is_available(timeout=123)
+
+            assert mock_client_cls.call_args.kwargs["timeout"] == 123
 
 
 class TestExtraBody:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -436,6 +436,17 @@ class TestIsAvailable:
 
             assert await local_client.is_available() is False
 
+    async def test_unavailable_on_unsupported_protocol(self, local_client):
+        """An unset/schemeless URL makes httpx raise UnsupportedProtocol; the
+        preflight relies on this being caught (returns False), not propagated."""
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.UnsupportedProtocol("missing scheme")
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            assert await local_client.is_available() is False
+
     async def test_default_availability_timeout_is_longer_than_10s(self, local_client):
         """The ping timeout defaults to DEFAULT_AVAILABILITY_TIMEOUT (>10s) so a
         cold on-demand model load is not mistaken for an unreachable server."""


### PR DESCRIPTION
## Summary

Cuts the manual work of evaluating a new model as the local person-email classifier from ~6 steps to two: start the server, then one wrapper command. Comes out of the eval-pipeline analysis — the local model only runs in Stage 2b on person bodies, so the friction was all in the glue around `run_eval`/`report`, not the run itself.

## What's included

**Streamlined eval path (`run_eval` + a wrapper):**
- **`--local-only`** — shorthand for `--stages stage2_only --sender-type person`, the only config that exercises *just* the local classifier (no cloud creds needed). Errors on a conflicting `--stages`/`--sender-type`.
- **Endpoint preflight** — probes only the endpoints a run will hit and fails fast on an unreachable / name-mismatched (404) endpoint, instead of a whole run of per-thread errors. `--skip-preflight` bypasses it.
- **Default `--tag`** — derives from the model under test, so result files and the report trend table self-identify.
- **`--report` / `--compare-to`** — print metrics (and an optional comparison) inline after a run, reusing `report.py`.
- **`scripts/eval_model.py`** — one command per model that chains the above (auto-tag + preflight + report, optional compare-by-tag).

**Cold-load-safe preflight timeout:**
- The `is_available()` ping no longer hardcodes 10s (which a cold on-demand model load routinely exceeds, causing a false "unreachable"). New `DEFAULT_AVAILABILITY_TIMEOUT` (60s) + a `timeout` param; the eval preflight defaults to the local model's request timeout (180s) and is tunable via **`--preflight-timeout`**. Both `--preflight-timeout` and `--skip-preflight` are forwarded through `scripts/eval_model.py`.

## Resulting workflow

```bash
mlx_lm.server --model <hf-id> --host 0.0.0.0 --port 8080 --temp 0 --prompt-cache-size 2   # inherently manual
python scripts/eval_model.py <hf-id> <baseline-tag>   # local-only + preflight + auto-tag + report + compare
```

## Notes / behavior change
- `--tag` now **defaults** to the model name (was empty). Explicit `--tag` still wins, so existing commands are unaffected; new result filenames just carry the model name.
- Not changed: the cache key already includes the model name, so switching models never returns stale hits — no cache-clearing added (it would only throw away valid cloud Stage-1 hits).

## Testing
- TDD throughout (failing test → minimal code); after-the-fact `main()` wiring tests verified by mutation.
- New `run_eval` flags documented in `evals/README-technical.md` (enforced by the CLI-docs test); fast-path workflow + cold-load note added to `evals/README.md`.
- **526 → 574 tests**, all passing; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)