### PR TITLE
Mark max-priority threads processed; fix give-up to cover full thread

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,27 @@ Hotkeys: `e/g/f/p` filter by tier, `1-5` filter by theme, `s` filter by sender, 
 
 ## Testing
 
+**Always build using red/green TDD.** Every behavior change — new feature, bug fix,
+or refactor — starts with a failing test:
+
+1. **RED** — Write one minimal test for the new behavior. Run it and *watch it fail
+   for the expected reason* (behavior missing, not a typo/import error). A test you
+   never saw fail proves nothing.
+2. **GREEN** — Write the minimal production code to make it pass. Run the test; confirm
+   it passes and the rest of the suite stays green.
+3. **REFACTOR** — Clean up with the tests green. Add no behavior without a new failing
+   test first.
+
+**No production code without a failing test first.** If you wrote code before the test,
+delete it and start over from the test.
+
+**Proving after-the-fact tests with mutation.** When a test is written *after* the code
+(e.g. covering a fix already applied, or legacy code), it can't be red/green-verified —
+so prove it instead: deliberately break the production behavior it targets (a "mutation")
+and confirm the test fails, then revert. A test that stays green when you break the code
+under it is not testing that code. Prefer the mutation that reproduces the exact bug the
+test guards against.
+
 **Always run the full test suite before declaring any task complete.**
 
 ```bash

--- a/daemon.py
+++ b/daemon.py
@@ -392,8 +392,16 @@ async def process_single_thread(
         # Check priority — skip if already classified at max priority
         existing_priority = label_manager.get_existing_priority(messages)
         if existing_priority is not None and existing_priority >= _get_priority(EmailLabel.NEEDS_RESPONSE):
-            log.info("Thread %s already at max priority, skipping", thread_id)
-            return False
+            # Already at max priority, so there's nothing to classify — but mark it
+            # processed so it drops out of the unprocessed query. Otherwise the thread
+            # has no agent/processed label and re-matches every cycle forever, costing
+            # a full get_thread round-trip per thread per poll (same retry-loop reasoning
+            # as the no-downgrade branch below).
+            all_msg_ids = [msg["id"] for msg in messages]
+            async with (write_sem or nullcontext()):
+                await label_manager.mark_processed(all_msg_ids)
+            log.info("Thread %s already at max priority, marking processed", thread_id)
+            return True
 
         # Collect all message IDs (thread may have more messages than query returned)
         all_msg_ids = [msg["id"] for msg in messages]

--- a/daemon.py
+++ b/daemon.py
@@ -328,11 +328,17 @@ async def process_single_thread(
         # Sort chronologically
         messages.sort(key=lambda m: int(m.get("internalDate", "0")))
 
+        # Full message list — the thread may carry more messages than the query
+        # returned. Upgrade the give-up target from the query stubs to every message
+        # id now (see the ids_to_mark note above), so any give-up or skip-and-mark
+        # path below marks the whole thread and it stops re-matching the query.
+        # Every post-fetch branch shares this single computation.
+        all_msg_ids = [msg["id"] for msg in messages]
+        ids_to_mark = all_msg_ids
+
         # Newsletter detection — route to newsletter pipeline if applicable
         if newsletter_classifier and newsletter_recipient:
             if is_newsletter(messages, newsletter_recipient):
-                all_msg_ids = [msg["id"] for msg in messages]
-                ids_to_mark = all_msg_ids
                 first_headers = messages[0]["payload"]["headers"]
                 subject = get_header(first_headers, "Subject")
                 sender = get_header(first_headers, "From")
@@ -396,16 +402,13 @@ async def process_single_thread(
             # processed so it drops out of the unprocessed query. Otherwise the thread
             # has no agent/processed label and re-matches every cycle forever, costing
             # a full get_thread round-trip per thread per poll (same retry-loop reasoning
-            # as the no-downgrade branch below).
-            all_msg_ids = [msg["id"] for msg in messages]
+            # as the no-downgrade branch below). ids_to_mark was upgraded to all_msg_ids
+            # above the priority check, so a failed write here gives up on the whole
+            # thread, not just the query stubs.
             async with (write_sem or nullcontext()):
                 await label_manager.mark_processed(all_msg_ids)
             log.info("Thread %s already at max priority, marking processed", thread_id)
             return True
-
-        # Collect all message IDs (thread may have more messages than query returned)
-        all_msg_ids = [msg["id"] for msg in messages]
-        ids_to_mark = all_msg_ids
 
         # Extract unique senders (preserve order)
         senders = []

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -237,6 +237,47 @@ class TestProcessSingleThread:
         mock_label_manager.apply_classification.assert_not_called()
         mock_label_manager.mark_processed.assert_called_once_with(["msg_001", "msg_002"])
 
+    async def test_already_at_max_priority_marks_processed(
+        self,
+        mock_proxy,
+        mock_classifier,
+        mock_label_manager,
+        cloud_sem,
+        local_sem,
+        mock_thread_response,
+    ):
+        """A thread already at max priority is marked processed (not re-fetched forever).
+
+        Without the mark_processed, the thread keeps no agent/processed label and
+        re-matches the unprocessed query every poll cycle, burning a get_thread
+        round-trip per thread per cycle. It should be skipped from classification but
+        still marked processed so it drops out of the query.
+        """
+        mock_proxy.get_thread.return_value = mock_thread_response
+        # Already at the top priority -> no classification needed.
+        mock_label_manager.get_existing_priority.return_value = _get_priority(
+            EmailLabel.NEEDS_RESPONSE
+        )
+
+        result = await process_single_thread(
+            "thread_001",
+            ["msg_001", "msg_002"],
+            mock_proxy,
+            mock_classifier,
+            mock_label_manager,
+            cloud_sem,
+            local_sem,
+            max_thread_chars=50000,
+        )
+
+        assert result is True
+        # No (re)classification, but the thread is marked processed so it stops
+        # re-matching the unprocessed query.
+        mock_classifier.classify_sender.assert_not_called()
+        mock_classifier.classify.assert_not_called()
+        mock_label_manager.apply_classification.assert_not_called()
+        mock_label_manager.mark_processed.assert_called_once_with(["msg_001", "msg_002"])
+
     async def test_allows_upgrade(
         self,
         mock_proxy,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -252,6 +252,12 @@ class TestProcessSingleThread:
         re-matches the unprocessed query every poll cycle, burning a get_thread
         round-trip per thread per cycle. It should be skipped from classification but
         still marked processed so it drops out of the query.
+
+        The query surfaced only msg_001, but the fetched thread holds msg_001 +
+        msg_002. mark_processed must cover the FULL thread (all_msg_ids), not just the
+        query stub — otherwise the unmarked sibling keeps re-matching the query, the
+        exact loop this branch exists to break. Passing a strict subset as the stubs
+        makes the assertion sensitive to that distinction.
         """
         mock_proxy.get_thread.return_value = mock_thread_response
         # Already at the top priority -> no classification needed.
@@ -261,7 +267,7 @@ class TestProcessSingleThread:
 
         result = await process_single_thread(
             "thread_001",
-            ["msg_001", "msg_002"],
+            ["msg_001"],  # query stub is a strict subset of the fetched thread
             mock_proxy,
             mock_classifier,
             mock_label_manager,
@@ -276,6 +282,7 @@ class TestProcessSingleThread:
         mock_classifier.classify_sender.assert_not_called()
         mock_classifier.classify.assert_not_called()
         mock_label_manager.apply_classification.assert_not_called()
+        # Full thread, not just the query stub.
         mock_label_manager.mark_processed.assert_called_once_with(["msg_001", "msg_002"])
 
     async def test_allows_upgrade(
@@ -528,6 +535,42 @@ class TestProcessSingleThread:
 
         assert results[0] is False  # first failure: retry
         assert results[1] is True   # threshold hit: give up
+        mock_label_manager.mark_attempted.assert_called_once_with(["msg_001", "msg_002"])
+
+    async def test_already_at_max_priority_give_up_marks_all_thread_messages(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+        mock_thread_response,
+    ):
+        """The max-priority skip now writes a marker, so a failed write is give-up-eligible.
+
+        The branch calls mark_processed inside the try; a give-up-eligible failure
+        there routes to _give_up_if_stuck. ids_to_mark must already be the full thread
+        (all_msg_ids), not the query stub — otherwise the abandoned-but-findable marker
+        lands on a subset and the unmarked sibling keeps re-surfacing the thread, the
+        very loop the give-up mechanism exists to break. The query surfaced only
+        msg_001 while the thread holds msg_001 + msg_002.
+        """
+        mock_proxy.get_thread.return_value = mock_thread_response
+        mock_label_manager.get_existing_priority.return_value = _get_priority(
+            EmailLabel.NEEDS_RESPONSE
+        )
+        # The mark_processed write fails deterministically (e.g. a per-thread proxy 5xx).
+        mock_label_manager.mark_processed.side_effect = ProxyUnavailableError("proxy 500 on write")
+        tracker = FailureTracker(max_failures=2)
+
+        results = [
+            await process_single_thread(
+                "thread_001", ["msg_001"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, failure_tracker=tracker,
+            )
+            for _ in range(2)
+        ]
+
+        assert results[0] is False  # first failure: retry
+        assert results[1] is True   # threshold hit: give up
+        # No classification was ever attempted (it's the max-priority skip path)...
+        mock_classifier.classify_sender.assert_not_called()
+        # ...and give-up marks the FULL thread, not just the query stub.
         mock_label_manager.mark_attempted.assert_called_once_with(["msg_001", "msg_002"])
 
     async def test_get_thread_is_bounded_by_fetch_sem(


### PR DESCRIPTION
## Summary

A thread already classified at max priority (`agent/needs-response`) was being skipped *without* being marked processed. Because `gmail_query` excludes `agent/processed`, such a thread re-matched the unprocessed query on **every** poll cycle, burning a full `get_thread` round-trip per thread per cycle — forever. This branch makes the skip path mark-then-return, and hardens the give-up target so a write failure there can't reintroduce the same loop.

## Commits

- **`a725008`** — Mark max-priority threads processed so they stop re-matching the query (the core fix: `return False` → `mark_processed(...)` + `return True`).
- **`991f69e`** — Address code-review findings on that branch (correctness + test hardening + docs).

## Code-review findings addressed (xhigh review)

- **Correctness** — The new skip branch wrote `mark_processed` *inside the `try`* but never upgraded `ids_to_mark` from the query stubs to the full thread list (`all_msg_ids`); that upgrade only ran after the branch's early `return`. So a give-up-eligible write failure (per-thread proxy 5xx, timeout) abandoned only the stub subset, leaving unmarked sibling messages to re-surface the thread forever — the exact loop this branch exists to break. Fixed by hoisting `all_msg_ids`/`ids_to_mark` to a single site right after the fetch, so every post-fetch path (newsletter, max-priority, main) shares the full-thread give-up target. Collapses three duplicate id-comprehensions into one.
- **Test (insensitive fixture)** — `test_already_at_max_priority_marks_processed` used a fixture whose full thread list equalled the query stubs, so it couldn't distinguish "marked full thread" from "marked stubs." Now uses a strict-subset stub.
- **Test (missing failure path)** — Added `test_already_at_max_priority_give_up_marks_all_thread_messages` for the newly give-up-eligible write-failure path.

Both tests are **mutation-proven**: reverting each behavior (the `True` return, the full-list write, the `ids_to_mark` upgrade) makes the targeted test fail; the fixed code keeps them green.

## Docs

`CLAUDE.md` now mandates red/green TDD and documents the mutation-proof fallback for after-the-fact tests.

## Verification

- `uv run --extra dev pytest tests/` → **596 passed, 63 subtests passed**
- `uv run --extra dev ruff check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)