### PR TITLE
Newsletter classification evaluation system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,3 +167,4 @@ All tests use mocks — no external services needed. Test files mirror source fi
 - `test_eval_newsletter_run.py` — `prompt_hash`, cache reuse, extraction vs quality/theme modes
 - `test_eval_newsletter_report.py` — `match_stories`, tier/dimension/theme metrics, comparison deltas
 - `test_eval_newsletter_cli_docs.py` — Every newsletter eval `--flag` documented in `README-technical.md`
+- `test_newsletter_eval_docs.py` — Newsletter eval modules/tests listed in `README-technical.md` structure + coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,19 @@ python -m newsletter_review --file path/to/file.jsonl  # Custom JSONL path
 
 Hotkeys: `e/g/f/p` filter by tier, `1-5` filter by theme, `s` filter by sender, `c` clear filters, `q` quit.
 
+### Newsletter evaluation
+
+Distinct from the read-only `newsletter_review/` package (which only *browses*
+production assessments), the newsletter eval harness under `evals/` *measures* the
+grading pipeline against hand-labeled ground truth so the prompts can be iterated.
+It mirrors the email eval's 4 stages with `newsletter_`-prefixed modules:
+`newsletter_harvest → newsletter_label → newsletter_run → newsletter_report`
+(schemas in `evals/newsletter_schemas.py`). Quality/theme scoring uses **fixed
+golden stories** so it is decoupled from extraction variability; the shared cache
+(`evals/cache/llm_cache.jsonl`) and each run's `prompt_hash` make prompt A/Bs
+cheap and self-identifying. See `evals/README.md` (workflows) and
+`evals/README-technical.md` (every CLI flag, cache/prompt_hash details).
+
 ## Key Design Decisions
 
 1. **Two-tier classification**: Stage 1 (cloud) determines person vs service. Stage 2 routes person bodies to local LLM only.
@@ -148,3 +161,9 @@ All tests use mocks — no external services needed. Test files mirror source fi
 - `test_labeler.py` — Label verification + application actions
 - `test_daemon.py` — Processing pipeline + config loading
 - `test_newsletter_review.py` — TUI data loading, filtering, formatting, detail view
+- `test_eval_newsletter_schemas.py` — Golden-set dataclass round-trip + missing-key tolerance
+- `test_eval_newsletter_harvest.py` — Newsletter harvest filtering, body build, dedup
+- `test_eval_newsletter_label.py` — Story curation + per-story scoring/theme pure functions
+- `test_eval_newsletter_run.py` — `prompt_hash`, cache reuse, extraction vs quality/theme modes
+- `test_eval_newsletter_report.py` — `match_stories`, tier/dimension/theme metrics, comparison deltas
+- `test_eval_newsletter_cli_docs.py` — Every newsletter eval `--flag` documented in `README-technical.md`

--- a/README-technical.md
+++ b/README-technical.md
@@ -24,6 +24,11 @@ email-labeler/
 │   ├── review.py       Interactive CLI for label review and correction
 │   ├── run_eval.py     Replay golden set through real classifier
 │   ├── report.py       Metrics: accuracy, confusion matrix, P/R/F1, privacy
+│   ├── newsletter_schemas.py  Newsletter golden-set and result dataclasses
+│   ├── newsletter_harvest.py  Pull candidate newsletters → golden set (unlabeled)
+│   ├── newsletter_label.py    Hand-label story quality scores and themes
+│   ├── newsletter_run.py      Replay golden stories through the newsletter classifier
+│   ├── newsletter_report.py   Newsletter tier/dimension/theme/extraction metrics
 │   └── results/        Timestamped result files from evaluation runs
 └── tests/
     ├── conftest.py          Shared fixtures and sample Gmail data
@@ -225,3 +230,8 @@ docker inspect --format='{{.State.Health.Status}}' agent-stack-email-labeler-1
 | `test_eval_schemas.py` | `evals/schemas.py` | GoldenThread/PredictionResult/RunMeta serialization round-trips |
 | `test_eval_harvest.py` | `evals/harvest.py` | Ground truth inference from labels, deduplication |
 | `test_eval_report.py` | `evals/report.py` | Confusion matrix, precision/recall/F1, accuracy, privacy violation metrics |
+| `test_eval_newsletter_schemas.py` | `evals/newsletter_schemas.py` | Golden-set/result dataclass round-trips, missing-key tolerance |
+| `test_eval_newsletter_harvest.py` | `evals/newsletter_harvest.py` | Newsletter filtering, body build, dedup, no ground-truth inference |
+| `test_eval_newsletter_label.py` | `evals/newsletter_label.py` | Story curation + per-story scoring/theme pure functions, tier derivation, undo |
+| `test_eval_newsletter_run.py` | `evals/newsletter_run.py` | `prompt_hash`, cache reuse, extraction vs quality/theme modes |
+| `test_eval_newsletter_report.py` | `evals/newsletter_report.py` | `match_stories`, tier/dimension/theme metrics, comparison deltas |

--- a/docs/plans/2026-07-01-newsletter-eval-plan.md
+++ b/docs/plans/2026-07-01-newsletter-eval-plan.md
@@ -1,0 +1,116 @@
+# Newsletter-Classification Evaluation System
+
+## Context
+
+The daemon's newsletter pipeline (`newsletter.py`, active under `NEWSLETTER_ONLY=1`) grades ministry-newsletter stories: it **extracts stories** from a body, **scores** each on 4 quality dimensions (simple/concrete/personal/dynamic, 1–5) → a **tier** (excellent/good/fair/poor), and tags **themes** (scripture/christlikeness/church/vocation-family/disciple-making). Today there is **no way to measure whether this grading is any good** — assessments are written to JSONL and browsed read-only via the `newsletter_review/` TUI, but never scored against ground truth.
+
+A mature eval harness already exists for the *email* classifier (`evals/`: harvest → review → run_eval → report, with a disk LLM cache, golden set, chain-of-thought sidecars, metrics, comparison). This plan builds the parallel harness for **newsletter** grading so we can **iterate on the prompts** (the stated purpose) and measure the effect of each change.
+
+**Decisions (from the user):** evaluate all three outputs (tier/dimension scores, themes, extraction); build a **human labeling tool** for ground truth (no auto-labels exist — quality is subjective); use **fixed golden stories** so quality/theme scoring is decoupled from extraction variability; optimize the tooling for **prompt iteration** (per-run comparison + cache reuse).
+
+**Key reconciliation** of "evaluate extraction" + "fixed golden stories": one golden set holds both. Extraction is scored at the **newsletter-body level** (feed raw body → predicted stories → match against the newsletter's golden story list). Quality + themes are scored on the **fixed golden `(title, text)`** inputs, independent of what extraction produced.
+
+## Approach
+
+Mirror the email eval's 4-stage shape with newsletter-specific modules under `evals/` (prefixed `newsletter_` to avoid clashing with the top-level read-only `newsletter_review/` package). Reuse everything reusable — the LLM cache, metric primitives, curses scaffolding, transcript builder — and only write what's genuinely new.
+
+### New modules (all under `evals/`)
+
+| File | Responsibility | Entry point | Key flags |
+|---|---|---|---|
+| `newsletter_schemas.py` | `GoldenStory`, `GoldenNewsletter`, `NewsletterRunMeta`, `NewsletterPrediction`, `NewsletterThinkingEntry` dataclasses with `to_dict`/`from_dict` (missing-key tolerant) | — | — |
+| `newsletter_harvest.py` | Pull candidate newsletters from Gmail, seed golden set (no ground truth) | `python -m evals.newsletter_harvest` | `--output`, `--max-threads`, `--recipient`, `--config`, `--proxy-url` |
+| `newsletter_label.py` | Curses/CLI tool: curate story list, then per-story scores + themes | `python -m evals.newsletter_label` | `--golden-set`, `--edit`, `--unreviewed-only` |
+| `newsletter_run.py` | Replay golden set through real `NewsletterClassifier` (cached); write results + cot + meta | `python -m evals.newsletter_run` | `--golden-set`, `--config`, `--mode {extraction,quality,themes,all}`, `--tag`, `--no-cache`, `--parallelism`, `--prompts`, `--model`, `--report`, `--compare-to`, `--skip-preflight` |
+| `newsletter_report.py` | Tier/dimension/theme/extraction metrics + two-run comparison + trend | `python -m evals.newsletter_report` | `--results`, `--compare`, `--results-dir`, `--verbose`, `--format {table,json}`, `--match-threshold` |
+
+**Reuse (import, do not fork):** `evals.llm_cache.CachedLLMClient`, `evals.__init__.format_network_error`, `evals.report.{compute_confusion_matrix, compute_precision_recall_f1, compute_accuracy, format_pct, format_table_row, format_confusion_matrix, format_per_class_table, print_trend}`, `newsletter.{NewsletterClassifier, parse_stories, compute_tier, is_newsletter, NewsletterTier}`, `daemon.{resolve_newsletter_llm_endpoint, format_thread_transcript}`, `gmail_utils.get_header`, the `GmailProxyClient` + preflight patterns from `evals/harvest.py`/`evals/run_eval.py`, and the curses/atomic-save scaffolding from `evals/review.py` + `evals/edit_tui.py`.
+
+### Golden-set schema (`evals/newsletter_schemas.py`)
+
+One `GoldenNewsletter` per JSONL line in **`evals/newsletter_golden_set.jsonl`**; it owns its list of `GoldenStory`. Nesting stories mirrors how `newsletter.write_assessment()` already nests `stories:[...]`.
+
+```python
+@dataclass
+class GoldenStory:
+    story_id: str                                   # stable, f"{thread_id}:{index}"
+    title: str
+    text: str
+    expected_scores: dict[str, int] | None = None   # simple/concrete/personal/dynamic, 1-5
+    expected_tier: str | None = None                # derived from scores via compute_tier
+    expected_themes: list[str] = field(default_factory=list)
+    reviewed: bool = False
+    notes: str = ""
+    excluded: bool = False                          # drop from quality/theme scoring, keep as extraction truth
+
+@dataclass
+class GoldenNewsletter:
+    thread_id: str; message_id: str; sender: str; subject: str
+    body: str                                       # raw body fed verbatim to extract_stories
+    stories: list[GoldenStory]
+    source: str = "harvested"; harvested_at: str = ""
+    reviewed: bool = False                          # story list confirmed = authoritative extraction truth
+    notes: str = ""; excluded: bool = False
+```
+
+- **Extraction ground truth** = the confirmed `stories[*].(title,text)` of a `reviewed` newsletter.
+- **Quality/theme ground truth** = each reviewed story's `expected_scores`/`expected_tier`/`expected_themes`.
+
+### Stage details
+
+**Harvest** — follows `evals/harvest.py`: `GmailProxyClient` + network-error handling; query by newsletter recipient (`to:<recipient>`, default from `config["newsletter"]["recipient"]`, mirroring `daemon.py`'s `gmail_query += f" to:{...}"`); per thread run `is_newsletter(...)` as the guard, build `body` with `daemon.format_thread_transcript(...)` (identical to production input at `daemon.py:348`), capture message_id/sender/subject. **No ground truth inferred** — seed `stories=[]`, `reviewed=False`. Dedup by `thread_id`, always-append (never truncate).
+
+**Label** — reuses `review.py`/`edit_tui.py` patterns; two phases per newsletter:
+- *Phase A — curate stories / set boundaries (extraction truth):* **Seed candidates by running the production `parse_stories` extractor once on the body** (a cheap one-time LLM call, cached), so the story list starts pre-populated. The reviewer then confirms/fixes every boundary: `[s]` split an over-merged candidate, `[m]` merge two candidates, `[e]` edit a title/text span, `[a]` add a missed story, `[d]` delete a non-story. `[Enter]` confirms the list → `newsletter.reviewed=True`; each confirmed story gets a stable `story_id`. The confirmed spans (not the raw seed) are what's stored, so the human always has the final say — but see risk #7 (mild extraction-recall bias from seeding with the system under test; mitigated by mandatory per-boundary confirmation, and `NewsletterRunMeta`/report note the seed source).
+- *Phase B — per-story labels:* step the 4 dimensions (hotkeys `1`–`5`), then multi-select themes (`1`–`5` toggling the five themes, matching `newsletter_review`'s convention); `expected_tier` auto-derived via `compute_tier` on save; `[n]` notes, `[z]` undo, `story.reviewed=True`.
+- Atomic temp-file+rename save; queue selection excludes `excluded`, honors `--unreviewed-only`. Because boundaries are fuzzy-matched (≥0.6) at eval time, they need to be recognizably-the-same-story, not character-perfect.
+
+**Run** — like `run_eval.py`: load config (`tomllib` + env substitution), resolve endpoint via `resolve_newsletter_llm_endpoint()`, build one `LLMClient` from `[newsletter.llm]`, wrap in `CachedLLMClient(evals/cache/llm_cache.jsonl)` unless `--no-cache`, preflight via `is_available()`. **No cache changes needed** — `NewsletterClassifier` only calls `complete(system, user, include_thinking=True)`, and the cache key `[model, temperature, max_tokens, extra_body, system_prompt, user_content]` already **separates prompt variants by content**. Two modes under `--mode all`:
+- *Extraction:* `extract_stories(body)` → predicted list; store predicted + golden story sets per newsletter.
+- *Quality+theme (fixed golden stories):* per reviewed, non-excluded `GoldenStory`, `assess_quality(title,text)` and `classify_themes(title,text)`; derive predicted tier via `compute_tier`.
+
+  Concurrency via `asyncio.Semaphore(parallelism)`. Outputs under `evals/newsletter_results/`: timestamped `<ts>_<mode>_<tag>_<runid8>.jsonl` (`NewsletterRunMeta` first line, then `NewsletterPrediction` rows) + `.cot.jsonl` sidecar (non-empty only). **`NewsletterRunMeta` records a `prompt_hash`** = `sha256(json.dumps(config["newsletter"]["prompts"], sort_keys=True))[:16]` plus model/temperature/max_tokens/extra_body/tag/counts + the three system prompts verbatim — so prompt A/Bs are self-identifying and comparable. `--prompts alt.toml` deep-merges alternate `[newsletter.prompts.*]`; `--model` overrides the model. Cache reuses unchanged stages, cleanly separates changed ones.
+
+**Report** — reuses `report.py` helpers with new class lists + a few new computations:
+- *Tier (4-class):* accuracy + confusion matrix + P/R/F1 over `["excellent","good","fair","poor"]` (reuse existing helpers). Parse-failure rows (`scores is None`) counted as errors, excluded from the matrix.
+- *Per-dimension:* MAE and exact-match (and within-1) agreement per dimension — new `compute_dimension_mae` / `compute_dimension_exact_match`.
+- *Themes (multi-label):* per-theme P/R/F1 (each theme an independent binary label), micro-F1, macro-F1, exact-set-match — new `compute_multilabel_metrics`.
+- *Extraction:* per newsletter, greedy one-to-one match of predicted→golden via `difflib.SequenceMatcher` ratio on normalized title-or-text, default threshold `0.6` (`--match-threshold`); precision=matched/predicted, recall=matched/golden; micro + macro aggregate — new `match_stories` (**most test-worthy function**).
+- Two-run `--compare` reuses the Run A/Run B/Delta table (tier acc/F1, per-dimension MAE with decrease=improvement, theme micro/macro F1, extraction F1); header prints both `prompt_hash`+`tag`. `--verbose` lists per-story flips and per-newsletter extraction diffs. `--results-dir` trend table.
+
+### Critical files to create
+- `evals/newsletter_schemas.py`, `evals/newsletter_harvest.py`, `evals/newsletter_label.py`, `evals/newsletter_run.py`, `evals/newsletter_report.py`
+- Tests: `tests/test_eval_newsletter_{schemas,harvest,label,run,report,cli_docs}.py`
+
+### Docs to update
+- `evals/README.md` — human "Newsletter evaluation" section (4 stages, fixed-golden-stories concept, workflows: build golden set / iterate a prompt variant / compare two runs).
+- `evals/README-technical.md` — `### newsletter_harvest|label|run|report` sections listing **every** backticked CLI flag (required by the CLI-docs sync test); note the shared cache + content-hash prompt separation + `prompt_hash`.
+- `CLAUDE.md` — "Newsletter Classification" gets a short "Newsletter evaluation" subsection clarifying the distinction from read-only `newsletter_review/`; add new test files to the Testing list.
+
+## TDD plan (strict red/green per CLAUDE.md — failing test first, watch it fail, then minimal code)
+
+Write tests first, one behavior at a time:
+- **schemas:** round-trip + defaults for `GoldenStory`/`GoldenNewsletter` (nested stories survive `json.dumps`); `NewsletterRunMeta` round-trip incl. `prompt_hash`/model; backward-compat missing keys.
+- **harvest:** `is_newsletter` filter accepts/rejects; harvested newsletter has empty `stories` + `reviewed=False`; `body` equals `format_thread_transcript` output; dedup drops seen `thread_id` and tolerates malformed lines.
+- **label:** add-story appends with stable `story_id`; confirm sets `newsletter.reviewed`; scoring 4 dims + themes sets `story.reviewed` and auto-derives tier; undo restores snapshot; exclude skips in queue selector. (Test the pure functions, not curses.)
+- **report:** `match_stories` (exact, fuzzy≥threshold, below-threshold no-match, one-to-one greedy, extra→precision drop, missing→recall drop); tier confusion + P/R/F1; per-dimension MAE + exact-match; theme per-theme/micro/macro F1 + exact-set-match; parse-failure counted as error; comparison delta sign correct.
+- **run:** `prompt_hash` changes iff a prompt string changes (mutation-style); second identical run records cache hits (fake inner client); extraction vs quality/theme modes record the right fields; `--prompts` override changes `prompt_hash`.
+- **cli_docs:** mirror `tests/test_eval_cli_docs.py` — assert every new `--flag` appears in `README-technical.md`.
+
+Run the full suite (`uv run --extra dev pytest tests/ -v`) before declaring done.
+
+## Verification (end-to-end)
+
+1. `uv run --extra dev pytest tests/ -v` — all green.
+2. **Harvest** a few newsletters into `evals/newsletter_golden_set.jsonl` (against the api-proxy).
+3. **Label** them — curate stories, assign scores + themes for a small golden set.
+4. **Run** `python -m evals.newsletter_run --mode all --tag baseline`, then `--report`.
+5. **Iterate:** edit a `[newsletter.prompts.*]` block (or `--prompts alt.toml`), re-run with `--tag variant`; confirm the cache reuses unchanged stages and `prompt_hash` differs.
+6. **Compare:** `python -m evals.newsletter_report --compare <baseline>.jsonl <variant>.jsonl --verbose` — tier/dimension/theme/extraction deltas render, prompt hashes shown.
+
+## Notes / defaults chosen (revisitable in implementation)
+- **Tier is derived** from dimension scores via `compute_tier`, not hand-labeled separately (avoids conflict; add `--label-tier` later if holistic judgment is wanted).
+- **`excluded` story** = "keep as extraction truth but skip quality/theme scoring"; a *wrongly extracted* candidate is **deleted** in Phase A, not excluded.
+- **Extraction matcher**: `SequenceMatcher` ratio ≥ 0.6, one-to-one greedy, `--match-threshold` configurable; `--verbose` shows unmatched pairs to calibrate. Merges/splits are a known imperfection surfaced in verbose output.
+- Small hand-labeled sets make 1–5 MAE noisy — report within-1 agreement alongside exact-match, keep `golden_set_count` in the header.
+- **Risk #7 — extraction-recall bias from seeding.** Phase A seeds boundaries from the production `parse_stories`, so the extraction ground truth is influenced by the system under test and recall may read slightly high. Mitigations: the reviewer must actively confirm/split/merge every boundary (rubber-stamping is the failure mode to watch); record the seed source (`seeded_from: "parse_stories"`) in the golden set and surface it in the report header so results aren't read as fully-independent. If bias proves material, switch specific newsletters to a stronger seed model or hand-label them (the schema is identical either way).

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -161,6 +161,7 @@ exits 1 with a one-line message instead of a traceback.
 | `--golden-set` | Path to newsletter golden set JSONL (default: `evals/newsletter_golden_set.jsonl`) |
 | `--edit` | Disable LLM seeding — manual curation only. Same curses TUI, but `Space` is inert and no LLM endpoint is needed |
 | `--unreviewed-only` | Show only newsletters not yet reviewed |
+| `--include-excluded` | Also queue excluded newsletters, so they can be inspected or restored with the `X` hotkey (default: excluded newsletters are skipped) |
 | `--config` | Path to config.toml (default: the repo-root `config.toml`, regardless of CWD) |
 
 Both modes open the same curses TUI; `--edit` only removes the Phase-A LLM
@@ -194,6 +195,14 @@ auto-derived via `compute_tier` on save and `story.reviewed` is set. Saves are
 atomic (temp-file + rename). `excluded` stories are kept as extraction truth but
 skipped from quality/theme scoring.
 
+A **whole newsletter** can be excluded with `X` in the detail view: it is
+dropped from the labeling queue and from eval runs entirely (the run's load
+summary counts it under "excluded"). `X` toggles, the change is undoable (`z`),
+and `reviewed` is left untouched — a confirmed story list stays valid if the
+newsletter is later restored. Excluded newsletters vanish from the default
+queue on the next launch; relaunch with `--include-excluded` to see them
+(marked `X` in the list's flag column) and press `X` again to restore.
+
 TUI details:
 
 - **Undo** (`z`) is a multi-level stack (up to 100 snapshots per newsletter). A
@@ -212,7 +221,8 @@ TUI details:
   indicator sits on the status line; the help footer wraps on narrow terminals
   and lists `Space:seed` and `PgUp/PgDn`.
 - **List view**: columns are `R Lbl Sender Subject` where `Lbl` is
-  labeled/total stories; the list supports `PgUp`/`PgDn`.
+  labeled/total stories and the flag column shows `Y` (reviewed) or `X`
+  (excluded, which takes precedence); the list supports `PgUp`/`PgDn`.
 
 `seed_from_extractor()` returns `(stories, raw)` — the raw extractor output is
 kept so the caller can distinguish a `NO_STORIES` verdict from unparseable

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -145,8 +145,11 @@ resolved URL and which env var supplied it.
 Harvest guards each candidate with `is_newsletter(...)`, builds `body` via
 `daemon.format_thread_transcript(...)` (identical to production input), and seeds
 each `GoldenNewsletter` with `stories=[]` and `reviewed=False` — **no ground truth
-is inferred**. It always appends, deduplicating by `thread_id`, and tolerates
-malformed existing lines. To rebuild from scratch, delete the file manually.
+is inferred**. It always appends, deduplicating by `thread_id` — threads already
+present in `--output` are skipped **before** fetching (no `get_thread` call), with
+a post-fetch dedup as backstop, so re-runs don't re-download known threads. It
+tolerates malformed existing lines. To rebuild from scratch, delete the file
+manually.
 
 A successful run ends with a next-step hint pointing at
 `uv run python -m evals.newsletter_label --golden-set <output>`. Per-request
@@ -185,8 +188,14 @@ rendered body (body lines already covered by a story are **dimmed**, so omitted
 paragraphs stand out), press `s`/`e` to set the selection start/end line and
 `Enter` to make a story from that inclusive span — plus `a`dd/`E`dit/`d`elete.
 Deleting a story that carries labels asks `y/N` confirmation, and deletes echo
-what was removed. Confirming (`c`) sets `newsletter.reviewed=True`, assigns each
-story a stable `story_id`, and warns how many stories are still unlabeled.
+what was removed. Confirming (`c`) sets `newsletter.reviewed=True` and warns how
+many stories are still unlabeled. Story ids are **stable**: they are assigned at
+creation (max existing numeric suffix + 1, so delete-then-add never collides) and
+confirm preserves them, only repairing duplicates — deleting a story leaves an id
+gap by design, so cross-run comparisons keyed on `story_id` stay valid.
+Re-seeding with `Space` resets `newsletter.reviewed=False` — a reseeded
+newsletter must be re-confirmed before it counts for reviewed-only runs (undo
+restores the prior state).
 Pressing `k` skips the newsletter without marking it reviewed, so it resurfaces
 in a later pass (and the list view jumps straight to the next queued newsletter).
 **Phase B** labels each story: the 4 dimensions (simple, concrete, personal,
@@ -254,8 +263,11 @@ Extraction mode feeds each `body` through `extract_stories`; quality/theme mode
 scores the **fixed golden `(title, text)`** of every reviewed, non-excluded story
 (independent of what extraction produced) and derives the predicted tier via
 `compute_tier`. Story modes skip stories with `reviewed=False` (Phase-A-confirmed
-but never Phase-B-labeled) and print a skip count; `meta.story_count` counts only
-labeled, non-excluded stories. In a results row, `scores_raw`/`themes_raw = null`
+but never Phase-B-labeled) and print a skip count; `meta.story_count` counts what
+the run actually evaluated — labeled, non-excluded stories in story modes, but
+**all** golden stories of the evaluated newsletters in `--mode extraction`
+(extraction matches against the full confirmed story list). `--parallelism`
+must be ≥ 1 (validated at the CLI). In a results row, `scores_raw`/`themes_raw = null`
 means that call was **never attempted** (mode skipped it), while a captured raw
 string with a `null` parsed field means **attempted but unparsed**. Outputs are
 timestamped `<ts>_<mode>_<tag>_<runid8>.jsonl` (`NewsletterRunMeta` first line,
@@ -307,9 +319,12 @@ Metric semantics:
   from theme P/R/F1 or exact-set match.
 - **Tier metrics** count a row as a parse error only when quality was actually
   attempted (an error, or `scores_raw` captured) and `predicted_scores` is
-  `None`. Rows where quality was never attempted (`--mode themes`:
-  `error=None, scores_raw=None`) are skipped entirely — a themes-only results
-  file does not render a tier section full of fake errors.
+  `None`. The run's `RunMeta.mode` disambiguates errored rows: in a
+  `--mode themes` results file an errored row is a *theme*-call failure, so it
+  never counts as a quality/tier error and no tier section is rendered — a
+  themes-only results file cannot resurrect a tier section full of fake errors.
+- The report's theme list is derived from `newsletter._VALID_THEMES` (single
+  source) — themes added or removed upstream propagate automatically.
 - Aggregates (theme micro/macro F1, exact-set match, extraction micro/macro
   P/R/F1) are `None`/`N/A` when a run has zero scored rows, never a fake `0.0%`.
   Single-run reports omit the Quality Dimensions and Themes sections entirely
@@ -320,9 +335,16 @@ Single-run report output: the header shows `Golden set:`; the tier section
 pluralizes correctly and lists `Failed stories (quality parse/network): <ids>`;
 the themes section shows a `Parse anomalies: N` line when theme responses
 contained invalid tokens or unparseable output; the extraction section shows
-`(<N> newsletters, match threshold <t>)`.
+`(<N> newsletters, <M> errors, match threshold <t>)` and renders even when every
+extraction call errored (count 0), listing the failed newsletters — extraction
+metrics carry `errors`/`error_threads` alongside the scored counts. Bad
+`--results`/`--compare` paths (missing file, a directory, permission denied —
+any `OSError`) exit with a one-line error instead of a traceback.
 
-`--verbose` detail: Story Disagreements lines append story titles (best-effort
+`--verbose` detail: per-story flips in `--compare` gate the tier diff on both
+runs having quality scores but compare theme sets whenever both rows' theme call
+succeeded — two `--mode themes` runs show their theme flips. Story
+Disagreements lines append story titles (best-effort
 lookup from the run's recorded `golden_set_path`; degrades to bare ids if the
 file moved) and include stories whose quality parse failed but whose themes
 disagree; a `Parse/Network Failures` section prints each failed story with its

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -112,14 +112,34 @@ scores the newsletter grading pipeline (story extraction, per-story quality
 scores/tier, and themes). Its modules live under `evals/` prefixed `newsletter_`
 to avoid colliding with the top-level read-only `newsletter_review/` package.
 
+**Path defaults are CWD-relative** (except `--config`): the default `--output` /
+`--golden-set` / `--output-dir` strings (`evals/newsletter_golden_set.jsonl`,
+`evals/newsletter_results/`) are resolved against the current working directory,
+so the four tools only chain on their defaults when run from the repo root. The
+one exception is `--config`, whose default is the **repo-root** `config.toml`
+regardless of CWD.
+
+**Environment variables.** The tools run outside Docker and read the same env as
+the daemon (see the `.env` symlink note in [README.md](README.md)):
+
+| Variable | Used by | Purpose |
+|---|---|---|
+| `NEWSLETTER_LLM_URL` / `NEWSLETTER_LLM_API_KEY` | `newsletter_label` (Phase-A seeding), `newsletter_run` | The `[newsletter.llm]` endpoint. The override is atomic: once the URL is set, the key comes only from `NEWSLETTER_LLM_API_KEY` |
+| `CLOUD_LLM_URL` / `CLOUD_LLM_API_KEY` | same | Fallback endpoint when `NEWSLETTER_LLM_URL` is unset |
+| `PROXY_URL` / `PROXY_API_KEY` | `newsletter_harvest` | Gmail api-proxy address + auth. `PROXY_API_KEY` must be non-empty; harvest exits with a one-line error when it is missing |
+
+`newsletter_label` (without `--edit`) and `newsletter_run` fail fast before doing
+any work when no LLM endpoint is configured, and their error messages name the
+resolved URL and which env var supplied it.
+
 ### newsletter_harvest
 
 | Flag | Description |
 |---|---|
-| `--output` | Output golden-set JSONL path (default: `evals/newsletter_golden_set.jsonl`) |
+| `--output` | Output golden-set JSONL path (default: `evals/newsletter_golden_set.jsonl`, CWD-relative — run from the repo root so it chains with the other tools) |
 | `--max-threads` | Max threads to fetch (default: `50`) |
 | `--recipient` | Newsletter recipient to query (`to:<recipient>`); default from `config["newsletter"]["recipient"]` |
-| `--config` | Path to config.toml (default: `./config.toml`) |
+| `--config` | Path to config.toml (default: the repo-root `config.toml`, regardless of CWD) |
 | `--proxy-url` | API proxy URL (overrides `PROXY_URL` env var) |
 
 Harvest guards each candidate with `is_newsletter(...)`, builds `body` via
@@ -128,38 +148,84 @@ each `GoldenNewsletter` with `stories=[]` and `reviewed=False` — **no ground t
 is inferred**. It always appends, deduplicating by `thread_id`, and tolerates
 malformed existing lines. To rebuild from scratch, delete the file manually.
 
+A successful run ends with a next-step hint pointing at
+`uv run python -m evals.newsletter_label --golden-set <output>`. Per-request
+httpx/httpcore INFO logs are silenced (public helper
+`evals.newsletter_harvest.quiet_http_logging()`), and a missing `PROXY_API_KEY`
+exits 1 with a one-line message instead of a traceback.
+
 ### newsletter_label
 
 | Flag | Description |
 |---|---|
 | `--golden-set` | Path to newsletter golden set JSONL (default: `evals/newsletter_golden_set.jsonl`) |
-| `--edit` | Curses TUI for editing already-reviewed newsletters |
+| `--edit` | Disable LLM seeding — manual curation only. Same curses TUI, but `Space` is inert and no LLM endpoint is needed |
 | `--unreviewed-only` | Show only newsletters not yet reviewed |
-| `--config` | Path to config.toml (default: `./config.toml`) |
+| `--config` | Path to config.toml (default: the repo-root `config.toml`, regardless of CWD) |
 
-Two phases per newsletter. **Phase A** curates the story list (extraction truth):
-the list is seeded once by running the production `parse_stories` extractor (a
-cached LLM call) as a deletable starting point, then the reviewer builds the
-authoritative list by marking body segments — move the cursor over the rendered
-body, press `s`/`e` to set the selection start/end line and `Enter` to make a
-story from that inclusive span — plus `a`dd/`E`dit/`d`elete. Confirming sets
-`newsletter.reviewed=True` and assigns each story a stable `story_id`. Pressing
-`k` skips the newsletter without marking it reviewed, so it resurfaces in a later
-pass (and the list view jumps straight to the next queued newsletter).
-**Phase B** labels each story: the 4 dimensions (simple,
-concrete, personal, dynamic; `1`–`5`), multi-select themes, notes, undo;
-`expected_tier` is auto-derived via `compute_tier` on save and `story.reviewed`
-is set. Saves are atomic (temp-file + rename). `excluded` stories are kept as
-extraction truth but skipped from quality/theme scoring.
+Both modes open the same curses TUI; `--edit` only removes the Phase-A LLM
+seeding (it does **not** filter to reviewed newsletters — combine with
+`--unreviewed-only` or not as needed). Without `--edit`, a missing
+`NEWSLETTER_LLM_URL`/`CLOUD_LLM_URL` exits immediately at startup with an
+actionable message instead of failing later inside the TUI when `Space` is
+pressed.
+
+Two phases per newsletter. **Phase A** curates the story list (extraction
+truth). Press `Space` to seed candidate stories by running the production
+`parse_stories` extractor over a **fresh, uncached** LLM extraction of the body
+(every press re-runs the call). Re-seeding over a non-empty list asks
+`Replace N stories (M labeled) with a fresh seed? y/N`; a `Seeding…` indicator
+shows during the call, and the outcome is reported on the status line
+(`Seeded N stories.` / `Extractor returned NO_STORIES.` / `Extractor output had
+no parseable story blocks.`). Under `--edit`, `Space` shows an explanatory
+"seeding disabled" message. The seed is a deletable starting point; the reviewer
+builds the authoritative list by marking body segments — move the cursor over the
+rendered body (body lines already covered by a story are **dimmed**, so omitted
+paragraphs stand out), press `s`/`e` to set the selection start/end line and
+`Enter` to make a story from that inclusive span — plus `a`dd/`E`dit/`d`elete.
+Deleting a story that carries labels asks `y/N` confirmation, and deletes echo
+what was removed. Confirming (`c`) sets `newsletter.reviewed=True`, assigns each
+story a stable `story_id`, and warns how many stories are still unlabeled.
+Pressing `k` skips the newsletter without marking it reviewed, so it resurfaces
+in a later pass (and the list view jumps straight to the next queued newsletter).
+**Phase B** labels each story: the 4 dimensions (simple, concrete, personal,
+dynamic; `1`–`5`), multi-select themes, notes, undo; `expected_tier` is
+auto-derived via `compute_tier` on save and `story.reviewed` is set. Saves are
+atomic (temp-file + rename). `excluded` stories are kept as extraction truth but
+skipped from quality/theme scoring.
+
+TUI details:
+
+- **Undo** (`z`) is a multi-level stack (up to 100 snapshots per newsletter). A
+  snapshot is pushed only when a mutation actually happens — cancelled prompts
+  never consume an undo level.
+- **Esc** cancels any prompt (title/text/notes/story #), clears an active
+  `s`/`e` selection before acting as "back", and `ESCDELAY` defaults to 25 ms so
+  it feels instant.
+- **Prompts prefill current values**: `E` prefills the title and (single-line)
+  text with blank=keep semantics (multi-line text remains blank=keep — body-span
+  selection is the intended paragraph-level repair path); `n` prefills existing
+  notes; `l` shows current scores ("now X") and prefills current themes. Prompt
+  input scrolls horizontally (no width truncation) and rejects control
+  characters.
+- **Detail view**: labeled stories show `scores: a/b/c/d`; a `row X/Y` position
+  indicator sits on the status line; the help footer wraps on narrow terminals
+  and lists `Space:seed` and `PgUp/PgDn`.
+- **List view**: columns are `R Lbl Sender Subject` where `Lbl` is
+  labeled/total stories; the list supports `PgUp`/`PgDn`.
+
+`seed_from_extractor()` returns `(stories, raw)` — the raw extractor output is
+kept so the caller can distinguish a `NO_STORIES` verdict from unparseable
+output.
 
 ### newsletter_run
 
 | Flag | Description |
 |---|---|
 | `--golden-set` | Path to newsletter golden set JSONL (default: `evals/newsletter_golden_set.jsonl`) |
-| `--config` | Path to config.toml (default: `./config.toml`) |
+| `--config` | Path to config.toml (default: the repo-root `config.toml`, regardless of CWD) |
 | `--output-dir` | Output directory for results (default: `evals/newsletter_results/`) |
-| `--mode` | Which outputs to evaluate: `extraction`, `quality`, `themes`, or `all` (default: `all`) |
+| `--mode` | Which outputs to evaluate: `extraction`, `quality`, `themes`, or `all` (default: `all`). `quality` and `themes` fire **only their own** LLM calls; the skipped side's fields are `null` in the results rows |
 | `--tag` | Tag for the results filename (e.g. `baseline`) |
 | `--no-cache` | Disable the LLM response cache (default: cache enabled) |
 | `--parallelism` | Concurrent evaluations (default: `1`) |
@@ -167,7 +233,9 @@ extraction truth but skipped from quality/theme scoring.
 | `--prompts` | Path to a TOML file whose `[newsletter.prompts.*]` blocks are deep-merged over the base config (changes `prompt_hash`) |
 | `--model` | Override the newsletter LLM model name from config |
 | `--report` | Print a metrics report for this run after it completes |
-| `--compare-to` | After the run, print a comparison against this prior results JSONL file |
+| `--compare-to` | After the run, print a comparison against this prior results JSONL file. No longer always-verbose: per-story detail follows `--verbose` |
+| `--verbose` | With `--report`/`--compare-to`: per-story diffs, parse-failure raws, extraction detail |
+| `--match-threshold` | With `--report`/`--compare-to`: `SequenceMatcher` ratio threshold forwarded to the embedded report/comparison (default: `0.6`) |
 | `--skip-preflight` | Skip the endpoint reachability check before evaluating |
 
 Run replays the golden set through the real `NewsletterClassifier` using the
@@ -175,34 +243,105 @@ Run replays the golden set through the real `NewsletterClassifier` using the
 Extraction mode feeds each `body` through `extract_stories`; quality/theme mode
 scores the **fixed golden `(title, text)`** of every reviewed, non-excluded story
 (independent of what extraction produced) and derives the predicted tier via
-`compute_tier`. Outputs are timestamped `<ts>_<mode>_<tag>_<runid8>.jsonl`
-(`NewsletterRunMeta` first line, then `StoryPrediction` rows in quality/theme
-mode and `ExtractionPrediction` rows in extraction mode) plus a non-empty
-`.cot.jsonl` sidecar of `NewsletterThinkingEntry` rows.
+`compute_tier`. Story modes skip stories with `reviewed=False` (Phase-A-confirmed
+but never Phase-B-labeled) and print a skip count; `meta.story_count` counts only
+labeled, non-excluded stories. In a results row, `scores_raw`/`themes_raw = null`
+means that call was **never attempted** (mode skipped it), while a captured raw
+string with a `null` parsed field means **attempted but unparsed**. Outputs are
+timestamped `<ts>_<mode>_<tag>_<runid8>.jsonl` (`NewsletterRunMeta` first line,
+then `StoryPrediction` rows in quality/theme mode and `ExtractionPrediction` rows
+in extraction mode) plus a `.cot.jsonl` sidecar of `NewsletterThinkingEntry` rows
+(written only when at least one entry captured thinking). The sidecar holds two
+row shapes: story-level rows (`story_id` + `quality_cot`/`theme_cot`) and
+newsletter-level extraction rows (`thread_id` + `extraction_cot`) capturing the
+extractor's segmentation reasoning per newsletter — `story_id` is optional in the
+schema.
+
+Run output: the golden-set load prints a kept/unreviewed/excluded breakdown (with
+actionable hints when nothing is evaluable); `[k/N]` progress lines print during
+evaluation; the end-of-run summary line is
+`Rows: N (X errors, Y quality parse failures, Z theme parse failures)` plus
+optional clamped-score and dropped-theme-token lines; a
+`Chain-of-thought written to <path>.cot.jsonl` line appears when the sidecar is
+written; httpx request logging is quieted to WARNING. Missing/malformed config,
+`--prompts`, and golden-set files exit 1 with one-line errors, and preflight and
+per-row LLM errors name the resolved endpoint URL and its source env var.
 
 ### newsletter_report
 
 | Flag | Description |
 |---|---|
 | `--results` | Path to a single results JSONL file |
-| `--compare` | Two result file paths for side-by-side comparison |
-| `--results-dir` | Directory of results for trend view |
-| `--verbose` | Show per-story flips and per-newsletter extraction diffs |
-| `--format` | `table` (default) or `json` |
-| `--match-threshold` | `SequenceMatcher` ratio threshold for the extraction one-to-one match (default: `0.6`) |
+| `--compare` | Two result file paths for side-by-side comparison. `.cot.jsonl` sidecars matched by a glob are ignored (with a stderr note), so `*<tag>*.jsonl` globs work |
+| `--results-dir` | Directory of results for trend view (`.cot.jsonl` sidecars skipped) |
+| `--verbose` | Show per-story flips and per-newsletter extraction diffs (no effect with `--results-dir`; a stderr note says so) |
+| `--format` | `table` (default) or `json`. JSON works in all three modes: single run (`{meta, metrics}`), `--compare` (`{"run_a": {meta, metrics}, "run_b": {...}}`), and `--results-dir` (array of summary rows: file, run_id, timestamp, mode, tag, prompt_hash, tier_accuracy, theme_micro_f1, mae_simple, extraction_micro_f1 — `null` for absent sections) |
+| `--match-threshold` | `SequenceMatcher` ratio threshold for the extraction one-to-one match (default: `0.6`). Applies to **text** similarity (see below) |
 
 Report computes tier accuracy + confusion matrix + P/R/F1 (excellent/good/fair/
 poor), per-dimension MAE and exact/within-1 agreement, per-theme + micro/macro
 multi-label F1 + exact-set-match, and extraction precision/recall/F1 from a greedy
-one-to-one `SequenceMatcher` match. `--compare` prints a Run A/Run B/Delta table
-and shows each run's `prompt_hash` + `tag` in the header; `--results-dir` renders a
-trend table. Parse-failure rows (`scores is None`) are counted as errors and
-excluded from the tier matrix.
+one-to-one `SequenceMatcher` match.
+
+Metric semantics:
+
+- **Extraction matching compares story text** (whitespace-collapsed, lowercased),
+  falling back to title only when a story has no text — golden text is the
+  curated ground truth, titles are model-invented wording. `--match-threshold`
+  applies to that text similarity.
+- A newsletter with 0 predicted and 0 golden stories scores
+  precision = recall = 1.0 (correct abstention), not 0.0.
+- **Theme metrics** include a story iff its own theme call succeeded (row has no
+  error and `themes_raw` is present, or — for legacy rows without `themes_raw` —
+  a non-empty parsed prediction). A quality-parse failure does not drop a story
+  from theme P/R/F1 or exact-set match.
+- **Tier metrics** count a row as a parse error only when quality was actually
+  attempted (an error, or `scores_raw` captured) and `predicted_scores` is
+  `None`. Rows where quality was never attempted (`--mode themes`:
+  `error=None, scores_raw=None`) are skipped entirely — a themes-only results
+  file does not render a tier section full of fake errors.
+- Aggregates (theme micro/macro F1, exact-set match, extraction micro/macro
+  P/R/F1) are `None`/`N/A` when a run has zero scored rows, never a fake `0.0%`.
+  Single-run reports omit the Quality Dimensions and Themes sections entirely
+  when the run contains no story predictions (mirroring the tier section); JSON
+  output serializes these as `null`.
+
+Single-run report output: the header shows `Golden set:`; the tier section
+pluralizes correctly and lists `Failed stories (quality parse/network): <ids>`;
+the themes section shows a `Parse anomalies: N` line when theme responses
+contained invalid tokens or unparseable output; the extraction section shows
+`(<N> newsletters, match threshold <t>)`.
+
+`--verbose` detail: Story Disagreements lines append story titles (best-effort
+lookup from the run's recorded `golden_set_path`; degrades to bare ids if the
+file moved) and include stories whose quality parse failed but whose themes
+disagree; a `Parse/Network Failures` section prints each failed story with its
+raw quality response (`scores_raw`) or error; a `Theme Parse Anomalies` section
+prints `themes_raw` for stories whose theme output was invalid
+(`invalid tokens dropped: ...`) or unparseable (`parsed to []`); Extraction Diffs
+honor `--match-threshold` (header says `threshold <t>`) and, for any newsletter
+that isn't a perfect match, list matched pairs with their `SequenceMatcher` ratio
+plus each unmatched predicted / unmatched golden story by title (text excerpt
+when untitled).
+
+`--compare` prints a Run A/Run B/Delta table; the header shows each run's
+`prompt_hash` + `tag` + `mode=...`, and a WARNING line prints when the two runs'
+modes differ. Sections absent from one run render `N/A`, never `-100%` deltas.
+`--results-dir` renders a trend table with Run ID, Timestamp, Mode, Tag, Prompt
+(`prompt_hash[:8]`), TierAcc, ThemeF1, MAE(simple), and ExtractF1 columns; rows
+are sorted chronologically by `run_meta.timestamp` (not filename), and the Tag
+column shows `-` when a run has no tag.
+
+Nonexistent or meta-less results files produce a one-line `Error: ...` on stderr
+and exit code 1 (all three modes) — and when the offending path is a
+`.cot.jsonl`, a hint points at the main results file. Public helpers:
+`match_stories_detailed()`, `theme_parse_anomalies()`, `load_story_titles()`,
+`build_trend_rows()`, `comparison_as_json()`.
 
 ### Newsletter shared cache & prompt separation
 
 The newsletter runner reuses the **same** disk cache as the email eval —
-`evals/cache/llm_cache.jsonl` via `CachedLLMClient` — with no cache changes. The
+`evals/cache/llm_cache.jsonl` via `CachedLLMClient`. The
 cache key `[model, temperature, max_tokens, extra_body, system_prompt,
 user_content]` already **separates prompt variants by content**: editing a
 `[newsletter.prompts.*]` string changes the `system_prompt` (and thus the key), so
@@ -231,7 +370,12 @@ Changing any of these — the model name, temperature, inference parameters, `ex
 **Behavior:**
 
 - On startup, the entire cache file is loaded into memory.
-- Cache hits return instantly without contacting the LLM.
+- Cache hits return instantly without contacting the LLM. An entry whose stored
+  `thinking` is `""` means the model was called and emitted no `<think>` block —
+  it is a normal hit, not re-fetched.
+- Legacy entries written before thinking capture (no `thinking` key at all) are
+  backfilled with one LLM call the first time chain-of-thought is requested for
+  them, then cached permanently.
 - Cache misses call the real LLM, then store the response in memory.
 - New entries are appended to disk when `flush()` is called (at the end of each run).
 - Hit/miss statistics are printed at the end of every evaluation run.

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -171,8 +171,9 @@ Extraction mode feeds each `body` through `extract_stories`; quality/theme mode
 scores the **fixed golden `(title, text)`** of every reviewed, non-excluded story
 (independent of what extraction produced) and derives the predicted tier via
 `compute_tier`. Outputs are timestamped `<ts>_<mode>_<tag>_<runid8>.jsonl`
-(`NewsletterRunMeta` first line, then `NewsletterPrediction` rows) plus a
-non-empty `.cot.jsonl` sidecar.
+(`NewsletterRunMeta` first line, then `StoryPrediction` rows in quality/theme
+mode and `ExtractionPrediction` rows in extraction mode) plus a non-empty
+`.cot.jsonl` sidecar of `NewsletterThinkingEntry` rows.
 
 ### newsletter_report
 

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -139,9 +139,14 @@ malformed existing lines. To rebuild from scratch, delete the file manually.
 
 Two phases per newsletter. **Phase A** curates the story list (extraction truth):
 the list is seeded once by running the production `parse_stories` extractor (a
-cached LLM call), then the reviewer confirms/splits/merges/edits/adds/deletes each
-boundary. Confirming sets `newsletter.reviewed=True` and assigns each story a
-stable `story_id`. **Phase B** labels each story: the 4 dimensions (simple,
+cached LLM call) as a deletable starting point, then the reviewer builds the
+authoritative list by marking body segments — move the cursor over the rendered
+body, press `s`/`e` to set the selection start/end line and `Enter` to make a
+story from that inclusive span — plus `a`dd/`E`dit/`d`elete. Confirming sets
+`newsletter.reviewed=True` and assigns each story a stable `story_id`. Pressing
+`k` skips the newsletter without marking it reviewed, so it resurfaces in a later
+pass (and the list view jumps straight to the next queued newsletter).
+**Phase B** labels each story: the 4 dimensions (simple,
 concrete, personal, dynamic; `1`–`5`), multi-select themes, notes, undo;
 `expected_tier` is auto-derived via `compute_tier` on save and `story.reviewed`
 is set. Saves are atomic (temp-file + rename). `excluded` stories are kept as

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -104,6 +104,110 @@ explicitly, e.g. `--local-extra-body '{"enable_thinking": false}'`.
 | `--host` | Host to bind to (default: `127.0.0.1`) |
 | `--port` | Port to bind to (default: `5000`) |
 
+## Newsletter Evaluation CLI Reference
+
+The newsletter eval harness mirrors the email eval's 4-stage shape
+(`newsletter_harvest → newsletter_label → newsletter_run → newsletter_report`) but
+scores the newsletter grading pipeline (story extraction, per-story quality
+scores/tier, and themes). Its modules live under `evals/` prefixed `newsletter_`
+to avoid colliding with the top-level read-only `newsletter_review/` package.
+
+### newsletter_harvest
+
+| Flag | Description |
+|---|---|
+| `--output` | Output golden-set JSONL path (default: `evals/newsletter_golden_set.jsonl`) |
+| `--max-threads` | Max threads to fetch (default: `50`) |
+| `--recipient` | Newsletter recipient to query (`to:<recipient>`); default from `config["newsletter"]["recipient"]` |
+| `--config` | Path to config.toml (default: `./config.toml`) |
+| `--proxy-url` | API proxy URL (overrides `PROXY_URL` env var) |
+
+Harvest guards each candidate with `is_newsletter(...)`, builds `body` via
+`daemon.format_thread_transcript(...)` (identical to production input), and seeds
+each `GoldenNewsletter` with `stories=[]` and `reviewed=False` — **no ground truth
+is inferred**. It always appends, deduplicating by `thread_id`, and tolerates
+malformed existing lines. To rebuild from scratch, delete the file manually.
+
+### newsletter_label
+
+| Flag | Description |
+|---|---|
+| `--golden-set` | Path to newsletter golden set JSONL (default: `evals/newsletter_golden_set.jsonl`) |
+| `--edit` | Curses TUI for editing already-reviewed newsletters |
+| `--unreviewed-only` | Show only newsletters not yet reviewed |
+| `--config` | Path to config.toml (default: `./config.toml`) |
+
+Two phases per newsletter. **Phase A** curates the story list (extraction truth):
+the list is seeded once by running the production `parse_stories` extractor (a
+cached LLM call), then the reviewer confirms/splits/merges/edits/adds/deletes each
+boundary. Confirming sets `newsletter.reviewed=True` and assigns each story a
+stable `story_id`. **Phase B** labels each story: the 4 dimensions (simple,
+concrete, personal, dynamic; `1`–`5`), multi-select themes, notes, undo;
+`expected_tier` is auto-derived via `compute_tier` on save and `story.reviewed`
+is set. Saves are atomic (temp-file + rename). `excluded` stories are kept as
+extraction truth but skipped from quality/theme scoring.
+
+### newsletter_run
+
+| Flag | Description |
+|---|---|
+| `--golden-set` | Path to newsletter golden set JSONL (default: `evals/newsletter_golden_set.jsonl`) |
+| `--config` | Path to config.toml (default: `./config.toml`) |
+| `--output-dir` | Output directory for results (default: `evals/newsletter_results/`) |
+| `--mode` | Which outputs to evaluate: `extraction`, `quality`, `themes`, or `all` (default: `all`) |
+| `--tag` | Tag for the results filename (e.g. `baseline`) |
+| `--no-cache` | Disable the LLM response cache (default: cache enabled) |
+| `--parallelism` | Concurrent evaluations (default: `1`) |
+| `--include-unreviewed` | Also evaluate newsletters not yet reviewed (default: reviewed only) |
+| `--prompts` | Path to a TOML file whose `[newsletter.prompts.*]` blocks are deep-merged over the base config (changes `prompt_hash`) |
+| `--model` | Override the newsletter LLM model name from config |
+| `--report` | Print a metrics report for this run after it completes |
+| `--compare-to` | After the run, print a comparison against this prior results JSONL file |
+| `--skip-preflight` | Skip the endpoint reachability check before evaluating |
+
+Run replays the golden set through the real `NewsletterClassifier` using the
+`[newsletter.llm]` endpoint (resolved via `resolve_newsletter_llm_endpoint()`).
+Extraction mode feeds each `body` through `extract_stories`; quality/theme mode
+scores the **fixed golden `(title, text)`** of every reviewed, non-excluded story
+(independent of what extraction produced) and derives the predicted tier via
+`compute_tier`. Outputs are timestamped `<ts>_<mode>_<tag>_<runid8>.jsonl`
+(`NewsletterRunMeta` first line, then `NewsletterPrediction` rows) plus a
+non-empty `.cot.jsonl` sidecar.
+
+### newsletter_report
+
+| Flag | Description |
+|---|---|
+| `--results` | Path to a single results JSONL file |
+| `--compare` | Two result file paths for side-by-side comparison |
+| `--results-dir` | Directory of results for trend view |
+| `--verbose` | Show per-story flips and per-newsletter extraction diffs |
+| `--format` | `table` (default) or `json` |
+| `--match-threshold` | `SequenceMatcher` ratio threshold for the extraction one-to-one match (default: `0.6`) |
+
+Report computes tier accuracy + confusion matrix + P/R/F1 (excellent/good/fair/
+poor), per-dimension MAE and exact/within-1 agreement, per-theme + micro/macro
+multi-label F1 + exact-set-match, and extraction precision/recall/F1 from a greedy
+one-to-one `SequenceMatcher` match. `--compare` prints a Run A/Run B/Delta table
+and shows each run's `prompt_hash` + `tag` in the header; `--results-dir` renders a
+trend table. Parse-failure rows (`scores is None`) are counted as errors and
+excluded from the tier matrix.
+
+### Newsletter shared cache & prompt separation
+
+The newsletter runner reuses the **same** disk cache as the email eval —
+`evals/cache/llm_cache.jsonl` via `CachedLLMClient` — with no cache changes. The
+cache key `[model, temperature, max_tokens, extra_body, system_prompt,
+user_content]` already **separates prompt variants by content**: editing a
+`[newsletter.prompts.*]` string changes the `system_prompt` (and thus the key), so
+A/B runs are cached independently and unchanged stages are reused. Each run's
+`NewsletterRunMeta` records a **`prompt_hash`** =
+`sha256(json.dumps(config["newsletter"]["prompts"], sort_keys=True))[:16]` plus the
+model/temperature/max_tokens/extra_body/tag/counts and the three system prompts
+verbatim, so prompt A/Bs are self-identifying and comparable. `--prompts` (and
+`--model`) are applied **before** `prompt_hash` is computed, so an override yields a
+distinct hash.
+
 ## LLM Response Cache
 
 The eval suite includes a disk-backed LLM response cache that avoids redundant LLM calls across repeated evaluation runs. This is especially useful during prompt A/B testing or model swaps — once a thread has been evaluated with a given configuration, re-running produces instant results from cache.

--- a/evals/README.md
+++ b/evals/README.md
@@ -154,7 +154,9 @@ newsletter_harvest → newsletter_label → newsletter_run → newsletter_report
   newsletters land unlabeled with an empty story list.
 - **label** — A curses/CLI tool to build ground truth by hand (quality is
   subjective, so there are no auto-labels). Phase A curates the story list
-  (seeded from the production extractor, then confirmed/split/merged); Phase B
+  (seeded from the production extractor as a starting point, then the reviewer
+  marks body segments — `s`/`e` to set the span, `Enter` to make a story — plus
+  add/edit/delete, or `k` to skip the newsletter for a later pass); Phase B
   assigns per-story dimension scores + themes. The tier is auto-derived from scores.
 - **run** — Replay the golden set through the real classifier (LLM-cached) and
   write timestamped results.

--- a/evals/README.md
+++ b/evals/README.md
@@ -152,16 +152,28 @@ newsletter_harvest → newsletter_label → newsletter_run → newsletter_report
   `evals/newsletter_golden_set.jsonl`. Each is guarded by `is_newsletter(...)` and
   its `body` is built exactly like production input. **No ground truth is inferred** —
   newsletters land unlabeled with an empty story list.
-- **label** — A curses/CLI tool to build ground truth by hand (quality is
-  subjective, so there are no auto-labels). Phase A curates the story list
-  (seeded from the production extractor as a starting point, then the reviewer
-  marks body segments — `s`/`e` to set the span, `Enter` to make a story — plus
-  add/edit/delete, or `k` to skip the newsletter for a later pass); Phase B
-  assigns per-story dimension scores + themes. The tier is auto-derived from scores.
+- **label** — A curses tool to build ground truth by hand (quality is
+  subjective, so there are no auto-labels). Phase A curates the story list:
+  press `Space` to seed candidates from the production extractor (a fresh LLM
+  call each press — re-seeding over an existing list asks for confirmation),
+  then the reviewer marks body segments — `s`/`e` to set the span, `Enter` to
+  make a story (already-covered body lines are dimmed so gaps stand out) — plus
+  add/edit/delete, multi-level undo (`z`), or `k` to skip the newsletter for a
+  later pass. Phase B assigns per-story dimension scores + themes. The tier is
+  auto-derived from scores. `--edit` disables the LLM seeding for manual-only
+  curation (no LLM endpoint needed).
 - **run** — Replay the golden set through the real classifier (LLM-cached) and
   write timestamped results.
 - **report** — Compute tier/dimension/theme/extraction metrics, compare two runs,
   or show a trend across runs.
+
+**Environment.** `newsletter_label` (Phase-A seeding) and `newsletter_run` call
+the `[newsletter.llm]` endpoint resolved from `NEWSLETTER_LLM_URL` /
+`NEWSLETTER_LLM_API_KEY`, falling back to `CLOUD_LLM_URL` / `CLOUD_LLM_API_KEY`;
+`newsletter_harvest` needs `PROXY_API_KEY` (and `PROXY_URL` or `--proxy-url`).
+Both tools fail fast with a message naming the missing variable. Default data
+paths are CWD-relative, so run the tools from the repo root (only `--config`
+defaults to the repo-root `config.toml` regardless of CWD).
 
 **Fixed golden stories.** Extraction is inherently variable, so quality and theme
 scoring is *decoupled* from it: one golden set holds both. Extraction is scored at
@@ -177,7 +189,7 @@ uv run python -m evals.newsletter_harvest --proxy-url http://localhost:8000 --ma
 # 2. Label them: curate stories, then score dimensions + themes
 uv run python -m evals.newsletter_label
 uv run python -m evals.newsletter_label --unreviewed-only   # only unlabeled
-uv run python -m evals.newsletter_label --edit              # revisit reviewed ones
+uv run python -m evals.newsletter_label --edit              # manual-only (no LLM seeding)
 
 # 3. Run the whole pipeline and print a report
 uv run python -m evals.newsletter_run --mode all --tag baseline --report
@@ -213,9 +225,12 @@ uv run python -m evals.newsletter_report \
     --compare evals/newsletter_results/*baseline*.jsonl evals/newsletter_results/*variant*.jsonl --verbose
 ```
 
-The comparison renders tier/dimension/theme/extraction deltas and prints each run's
-`prompt_hash` + tag; `--verbose` lists per-story flips and per-newsletter extraction
-diffs.
+The globs may also match each run's `.cot.jsonl` chain-of-thought sidecar —
+`--compare` ignores sidecars (with a stderr note), so this works as long as each
+glob matches exactly one real results file. The comparison renders
+tier/dimension/theme/extraction deltas and prints each run's `prompt_hash` + tag
++ mode (warning when the modes differ); `--verbose` lists per-story flips and
+per-newsletter extraction diffs.
 
 ## Typical Workflows
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -132,6 +132,89 @@ Navigate to `http://localhost:5000`. Features:
 - **Run detail**: Metrics, confusion matrices, per-class P/R/F1, per-thread results with chain-of-thought.
 - **Compare**: Select a baseline and comparison runs to see side-by-side accuracy deltas.
 
+## Newsletter evaluation
+
+The daemon's newsletter pipeline (active under `NEWSLETTER_ONLY=1`) grades
+ministry-newsletter stories: it **extracts** stories from a body, **scores** each
+on 4 quality dimensions (simple/concrete/personal/dynamic, 1–5) → a **tier**
+(excellent/good/fair/poor), and tags **themes** (scripture/christlikeness/church/
+vocation-family/disciple-making). This harness measures whether that grading is any
+good, so you can **iterate on the prompts** and see the effect of each change.
+
+It mirrors the email eval's 4 stages, with newsletter-specific modules prefixed
+`newsletter_` (distinct from the top-level read-only `newsletter_review/` TUI):
+
+```
+newsletter_harvest → newsletter_label → newsletter_run → newsletter_report
+```
+
+- **harvest** — Pull candidate newsletters from Gmail into
+  `evals/newsletter_golden_set.jsonl`. Each is guarded by `is_newsletter(...)` and
+  its `body` is built exactly like production input. **No ground truth is inferred** —
+  newsletters land unlabeled with an empty story list.
+- **label** — A curses/CLI tool to build ground truth by hand (quality is
+  subjective, so there are no auto-labels). Phase A curates the story list
+  (seeded from the production extractor, then confirmed/split/merged); Phase B
+  assigns per-story dimension scores + themes. The tier is auto-derived from scores.
+- **run** — Replay the golden set through the real classifier (LLM-cached) and
+  write timestamped results.
+- **report** — Compute tier/dimension/theme/extraction metrics, compare two runs,
+  or show a trend across runs.
+
+**Fixed golden stories.** Extraction is inherently variable, so quality and theme
+scoring is *decoupled* from it: one golden set holds both. Extraction is scored at
+the newsletter-body level (raw body → predicted stories → matched against the
+newsletter's golden story list). Quality + themes are scored on the **fixed golden
+`(title, text)`** of each reviewed story, independent of what extraction produced —
+so a prompt tweak that only affects scoring is measured cleanly.
+
+```bash
+# 1. Harvest a few newsletters (no ground truth yet)
+uv run python -m evals.newsletter_harvest --proxy-url http://localhost:8000 --max-threads 50
+
+# 2. Label them: curate stories, then score dimensions + themes
+uv run python -m evals.newsletter_label
+uv run python -m evals.newsletter_label --unreviewed-only   # only unlabeled
+uv run python -m evals.newsletter_label --edit              # revisit reviewed ones
+
+# 3. Run the whole pipeline and print a report
+uv run python -m evals.newsletter_run --mode all --tag baseline --report
+
+# 4. Report on a single run, or a trend
+uv run python -m evals.newsletter_report --results evals/newsletter_results/<run>.jsonl
+uv run python -m evals.newsletter_report --results-dir evals/newsletter_results/
+```
+
+**Build a golden set:**
+
+```bash
+uv run python -m evals.newsletter_harvest --proxy-url http://localhost:8000
+uv run python -m evals.newsletter_label --unreviewed-only
+```
+
+**Iterate a prompt variant:**
+
+```bash
+uv run python -m evals.newsletter_run --tag baseline
+# Edit a [newsletter.prompts.*] block in config.toml (or use --prompts alt.toml), then:
+uv run python -m evals.newsletter_run --prompts alt.toml --tag variant
+```
+
+The shared cache (`evals/cache/llm_cache.jsonl`) is keyed by prompt content, so
+unchanged stages are reused and only the changed prompt is re-run. Each run records
+a `prompt_hash`, so variants are self-identifying.
+
+**Compare two runs:**
+
+```bash
+uv run python -m evals.newsletter_report \
+    --compare evals/newsletter_results/*baseline*.jsonl evals/newsletter_results/*variant*.jsonl --verbose
+```
+
+The comparison renders tier/dimension/theme/extraction deltas and prints each run's
+`prompt_hash` + tag; `--verbose` lists per-story flips and per-newsletter extraction
+diffs.
+
 ## Typical Workflows
 
 **Evaluate a new local model (fast path):**

--- a/evals/README.md
+++ b/evals/README.md
@@ -160,8 +160,10 @@ newsletter_harvest → newsletter_label → newsletter_run → newsletter_report
   make a story (already-covered body lines are dimmed so gaps stand out) — plus
   add/edit/delete, multi-level undo (`z`), or `k` to skip the newsletter for a
   later pass. Phase B assigns per-story dimension scores + themes. The tier is
-  auto-derived from scores. `--edit` disables the LLM seeding for manual-only
-  curation (no LLM endpoint needed).
+  auto-derived from scores. `X` excludes a whole newsletter from the queue and
+  eval runs (toggle; relaunch with `--include-excluded` to see and restore
+  excluded ones). `--edit` disables the LLM seeding for manual-only curation
+  (no LLM endpoint needed).
 - **run** — Replay the golden set through the real classifier (LLM-cached) and
   write timestamped results.
 - **report** — Compute tier/dimension/theme/extraction metrics, compare two runs,

--- a/evals/README.md
+++ b/evals/README.md
@@ -151,7 +151,8 @@ newsletter_harvest → newsletter_label → newsletter_run → newsletter_report
 - **harvest** — Pull candidate newsletters from Gmail into
   `evals/newsletter_golden_set.jsonl`. Each is guarded by `is_newsletter(...)` and
   its `body` is built exactly like production input. **No ground truth is inferred** —
-  newsletters land unlabeled with an empty story list.
+  newsletters land unlabeled with an empty story list. Re-runs skip
+  already-harvested threads instead of re-fetching them.
 - **label** — A curses tool to build ground truth by hand (quality is
   subjective, so there are no auto-labels). Phase A curates the story list:
   press `Space` to seed candidates from the production extractor (a fresh LLM

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -5,6 +5,17 @@ import httpx
 from proxy_client import ProxyAuthError, ProxyError, ProxyForbiddenError
 
 
+def plural(n: int, singular: str, plural_form: str | None = None) -> str:
+    """'1 story' / 'N stories' — the one pluralizer for eval status lines.
+
+    Defaults the plural form to ``singular + "s"``; pass *plural_form* for
+    irregulars ("story"/"stories").
+    """
+    if n == 1:
+        return f"1 {singular}"
+    return f"{n} {plural_form or singular + 's'}"
+
+
 def format_network_error(exc: Exception, service: str = "service") -> str:
     """Format a network exception into a human-readable error message.
 

--- a/evals/llm_cache.py
+++ b/evals/llm_cache.py
@@ -30,7 +30,9 @@ class CachedLLMClient:
         self._pending: list[dict] = []  # new entries to flush to disk
         self.hits = 0
         self.misses = 0
-        self._llm_seconds = 0.0  # accumulated LLM call time (misses only)
+        # per-task accumulated LLM call time (misses only), keyed like
+        # _thinking_buffers so concurrent rows don't absorb each other's time
+        self._llm_seconds: dict[int, float] = {}
         self._thinking_buffers: dict[int, list[str]] = {}  # per-task thinking buffers
         self._load()
 
@@ -92,7 +94,9 @@ class CachedLLMClient:
                 _, thinking = await self.inner.complete(
                     system_prompt, user_content, include_thinking=True,
                 )
-                self._llm_seconds += time.monotonic() - start
+                self._llm_seconds[tk] = (
+                    self._llm_seconds.get(tk, 0.0) + time.monotonic() - start
+                )
                 self._cache[key] = (response, thinking)
                 self._pending.append({
                     "key": key,
@@ -113,7 +117,7 @@ class CachedLLMClient:
         response, thinking = await self.inner.complete(
             system_prompt, user_content, include_thinking=True,
         )
-        self._llm_seconds += time.monotonic() - start
+        self._llm_seconds[tk] = self._llm_seconds.get(tk, 0.0) + time.monotonic() - start
 
         if thinking:
             self._thinking_buffers.setdefault(tk, []).append(thinking)
@@ -139,10 +143,13 @@ class CachedLLMClient:
         return "\n\n".join(t for t in buf if t)
 
     def take_llm_seconds(self) -> float:
-        """Return accumulated LLM call time and reset to zero."""
-        elapsed = self._llm_seconds
-        self._llm_seconds = 0.0
-        return elapsed
+        """Return the current task's accumulated LLM call time and reset its bucket.
+
+        Keyed per asyncio task (like take_thinking) so that under
+        parallelism > 1 each row drains only its own miss time instead of
+        absorbing every concurrent row's.
+        """
+        return self._llm_seconds.pop(self._task_key(), 0.0)
 
     async def is_available(self, timeout: float | None = None) -> bool:
         """Delegate to inner client."""

--- a/evals/llm_cache.py
+++ b/evals/llm_cache.py
@@ -23,7 +23,10 @@ class CachedLLMClient:
     def __init__(self, inner: LLMClient, cache_path: Path):
         self.inner = inner
         self.cache_path = cache_path
-        self._cache: dict[str, tuple[str, str]] = {}  # key -> (response, thinking)
+        # key -> (response, thinking). thinking is None for legacy entries
+        # written before thinking capture (unknown, backfillable); "" means the
+        # model was called and legitimately emitted no thinking (do NOT re-fetch).
+        self._cache: dict[str, tuple[str, str | None]] = {}
         self._pending: list[dict] = []  # new entries to flush to disk
         self.hits = 0
         self.misses = 0
@@ -43,7 +46,11 @@ class CachedLLMClient:
                 try:
                     entry = json.loads(line)
                     response = entry["response"]
-                    thinking = entry.get("thinking", "")
+                    # A present "thinking" key (even "") means the entry was
+                    # written by thinking-aware code: "" is a real "no thinking
+                    # emitted", not a gap to backfill. Only entries missing the
+                    # key entirely are legacy (thinking unknown -> None).
+                    thinking = entry["thinking"] if "thinking" in entry else None
                     # Normalize old entries that may contain unstripped think tags
                     extra_thinking = LLMClient._extract_thinking(response)
                     response = LLMClient._strip_thinking(response)
@@ -76,8 +83,10 @@ class CachedLLMClient:
 
         if key in self._cache:
             response, thinking = self._cache[key]
-            # Backfill thinking for old cache entries that lack it
-            if include_thinking and not thinking:
+            # Backfill thinking only for legacy entries where it is unknown
+            # (None). An empty string means the model emitted no thinking —
+            # re-fetching those would re-bill every terse response forever.
+            if include_thinking and thinking is None:
                 self.misses += 1
                 start = time.monotonic()
                 _, thinking = await self.inner.complete(
@@ -96,7 +105,7 @@ class CachedLLMClient:
             if thinking:
                 self._thinking_buffers.setdefault(tk, []).append(thinking)
             if include_thinking:
-                return response, thinking
+                return response, thinking or ""
             return response
 
         self.misses += 1

--- a/evals/newsletter_harvest.py
+++ b/evals/newsletter_harvest.py
@@ -20,15 +20,14 @@ import asyncio
 import json
 import logging
 import sys
-import tomllib
 from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
 
-from config_utils import substitute_env_vars
 from daemon import DEFAULT_MAX_THREAD_CHARS, format_thread_transcript
 from evals import format_network_error
+from evals.harvest import load_eval_config
 from evals.newsletter_schemas import GoldenNewsletter
 from gmail_utils import get_header
 from newsletter import is_newsletter
@@ -39,26 +38,8 @@ _NETWORK_ERRORS = (
 )
 
 
-def load_eval_config(config_path: str | None = None) -> dict:
-    """Load and preprocess config.toml from the given path."""
-    path = Path(config_path) if config_path else Path(__file__).parent.parent / "config.toml"
-    with open(path, "rb") as f:
-        config = tomllib.load(f)
-    return substitute_env_vars(config)
-
-
-def deduplicate(
-    new_newsletters: list[GoldenNewsletter], existing_path: Path
-) -> list[GoldenNewsletter]:
-    """Remove newsletters already present in the existing golden set file.
-
-    Args:
-        new_newsletters: Newly harvested newsletters.
-        existing_path: Path to existing golden set JSONL file.
-
-    Returns:
-        Newsletters not already in the file.
-    """
+def load_existing_thread_ids(existing_path: Path) -> set[str]:
+    """Collect thread IDs already present in the golden set JSONL file."""
     existing_ids: set[str] = set()
     if existing_path.exists():
         with open(existing_path) as f:
@@ -78,7 +59,22 @@ def deduplicate(
                 thread_id = entry.get("thread_id")
                 if thread_id:
                     existing_ids.add(thread_id)
+    return existing_ids
 
+
+def deduplicate(
+    new_newsletters: list[GoldenNewsletter], existing_path: Path
+) -> list[GoldenNewsletter]:
+    """Remove newsletters already present in the existing golden set file.
+
+    Args:
+        new_newsletters: Newly harvested newsletters.
+        existing_path: Path to existing golden set JSONL file.
+
+    Returns:
+        Newsletters not already in the file.
+    """
+    existing_ids = load_existing_thread_ids(existing_path)
     return [n for n in new_newsletters if n.thread_id not in existing_ids]
 
 
@@ -87,6 +83,7 @@ async def harvest_newsletters(
     config: dict,
     max_threads: int = 50,
     recipient: str | None = None,
+    skip_thread_ids: set[str] | None = None,
 ) -> list[GoldenNewsletter]:
     """Fetch newsletter threads and seed golden-set entries (no ground truth).
 
@@ -95,6 +92,8 @@ async def harvest_newsletters(
         config: Full parsed config dict.
         max_threads: Maximum threads to fetch.
         recipient: Newsletter recipient; defaults to config["newsletter"]["recipient"].
+        skip_thread_ids: Thread IDs already in the golden set — skipped before
+            get_thread so re-runs don't re-download them.
 
     Returns:
         List of seeded GoldenNewsletter objects (empty stories, reviewed=False).
@@ -128,8 +127,12 @@ async def harvest_newsletters(
 
     print(f"Found {len(thread_ids)} unique threads from {len(msg_stubs)} messages", file=sys.stderr)
 
+    skip_thread_ids = skip_thread_ids or set()
     results: list[GoldenNewsletter] = []
     for i, tid in enumerate(list(thread_ids.keys())[:max_threads]):
+        if tid in skip_thread_ids:
+            print(f"  Skipping thread {tid}: already in golden set", file=sys.stderr)
+            continue
         try:
             thread_data = await proxy.get_thread(tid)
             messages = thread_data.get("messages", [])
@@ -217,18 +220,21 @@ async def main(args: argparse.Namespace) -> None:
               "and re-run.", file=sys.stderr)
         sys.exit(1)
 
+    output_path = Path(args.output)
     newsletters = await harvest_newsletters(
         proxy=proxy,
         config=config,
         max_threads=args.max_threads,
         recipient=args.recipient,
+        skip_thread_ids=load_existing_thread_ids(output_path),
     )
 
     if not newsletters:
         print("No newsletters to write.", file=sys.stderr)
         return
 
-    output_path = Path(args.output)
+    # Backstop: the pre-fetch skip already avoids re-downloading known threads,
+    # but re-dedup against the file in case it changed during the harvest.
     newsletters = deduplicate(newsletters, output_path)
     if not newsletters:
         print("All newsletters already in golden set.", file=sys.stderr)

--- a/evals/newsletter_harvest.py
+++ b/evals/newsletter_harvest.py
@@ -18,6 +18,7 @@ Usage:
 import argparse
 import asyncio
 import json
+import logging
 import sys
 import tomllib
 from datetime import datetime, timezone
@@ -191,9 +192,30 @@ def write_golden_set(newsletters: list[GoldenNewsletter], output_path: Path) -> 
             f.write(json.dumps(newsletter.to_dict()) + "\n")
 
 
+def quiet_http_logging() -> None:
+    """Silence httpx/httpcore per-request INFO logs.
+
+    Importing daemon (for format_thread_transcript) runs its module-level
+    logging.basicConfig(level=INFO), which makes httpx print a timestamped
+    'HTTP Request: ...' line for every proxy call — noise that drowns out the
+    harvest's own progress messages.
+    """
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
 async def main(args: argparse.Namespace) -> None:
+    quiet_http_logging()
     config = load_eval_config(args.config)
-    proxy = GmailProxyClient(proxy_url=args.proxy_url)
+    try:
+        proxy = GmailProxyClient(proxy_url=args.proxy_url)
+    except ProxyAuthError as exc:
+        # Raised at construction when PROXY_API_KEY is unset — a traceback here
+        # buries the one env var the user needs to set.
+        print(f"Error: {exc}", file=sys.stderr)
+        print("Set PROXY_API_KEY (e.g. via the .env symlink to agent-stack/.env) "
+              "and re-run.", file=sys.stderr)
+        sys.exit(1)
 
     newsletters = await harvest_newsletters(
         proxy=proxy,
@@ -215,18 +237,32 @@ async def main(args: argparse.Namespace) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     write_golden_set(newsletters, output_path)
     print(f"Appended {len(newsletters)} newsletters to {output_path}", file=sys.stderr)
+    print(
+        "Next: add ground truth with "
+        f"`uv run python -m evals.newsletter_label --golden-set {output_path}`",
+        file=sys.stderr,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Harvest candidate newsletters for golden set")
+    parser.add_argument("--output", default="evals/newsletter_golden_set.jsonl",
+                        help="Output JSONL path, relative to the CWD — run from the repo root "
+                             "so the default chains with the other eval tools "
+                             "(default: %(default)s)")
+    parser.add_argument("--max-threads", type=int, default=50,
+                        help="Max threads to fetch (default: %(default)s)")
+    parser.add_argument("--recipient",
+                        help="Newsletter recipient (default: config[newsletter][recipient])")
+    parser.add_argument("--config",
+                        help="Path to config.toml (default: the repo-root config.toml, "
+                             "regardless of CWD)")
+    parser.add_argument("--proxy-url", help="API proxy URL (overrides PROXY_URL env var)")
+    return parser
 
 
 def cli():
-    parser = argparse.ArgumentParser(description="Harvest candidate newsletters for golden set")
-    parser.add_argument("--output", default="evals/newsletter_golden_set.jsonl",
-                        help="Output JSONL path")
-    parser.add_argument("--max-threads", type=int, default=50, help="Max threads to fetch")
-    parser.add_argument("--recipient",
-                        help="Newsletter recipient (default: config[newsletter][recipient])")
-    parser.add_argument("--config", help="Path to config.toml (default: ./config.toml)")
-    parser.add_argument("--proxy-url", help="API proxy URL (overrides PROXY_URL env var)")
-    args = parser.parse_args()
+    args = build_parser().parse_args()
     asyncio.run(main(args))
 
 

--- a/evals/newsletter_harvest.py
+++ b/evals/newsletter_harvest.py
@@ -1,0 +1,234 @@
+"""Harvest candidate newsletters from Gmail as golden-set seed data.
+
+Queries Gmail for threads addressed to the newsletter recipient, guards each
+thread with newsletter.is_newsletter(), builds the same transcript body the
+production pipeline feeds to story extraction, and seeds a GoldenNewsletter
+with NO ground truth (empty story list, reviewed=False). Ground truth is added
+later by the human labeling tool.
+
+Always appends to the output file, deduplicating by thread ID — it never
+overwrites an existing golden set (that file also holds manual review state).
+To start fresh, delete the file manually.
+
+Usage:
+    python -m evals.newsletter_harvest --output evals/newsletter_golden_set.jsonl --max-threads 50
+    python -m evals.newsletter_harvest --recipient newsletters@dm.org
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+from config_utils import substitute_env_vars
+from daemon import DEFAULT_MAX_THREAD_CHARS, format_thread_transcript
+from evals import format_network_error
+from evals.newsletter_schemas import GoldenNewsletter
+from gmail_utils import get_header
+from newsletter import is_newsletter
+from proxy_client import GmailProxyClient, ProxyAuthError, ProxyError, ProxyForbiddenError
+
+_NETWORK_ERRORS = (
+    httpx.ConnectError, httpx.TimeoutException, ProxyAuthError, ProxyForbiddenError, ProxyError,
+)
+
+
+def load_eval_config(config_path: str | None = None) -> dict:
+    """Load and preprocess config.toml from the given path."""
+    path = Path(config_path) if config_path else Path(__file__).parent.parent / "config.toml"
+    with open(path, "rb") as f:
+        config = tomllib.load(f)
+    return substitute_env_vars(config)
+
+
+def deduplicate(
+    new_newsletters: list[GoldenNewsletter], existing_path: Path
+) -> list[GoldenNewsletter]:
+    """Remove newsletters already present in the existing golden set file.
+
+    Args:
+        new_newsletters: Newly harvested newsletters.
+        existing_path: Path to existing golden set JSONL file.
+
+    Returns:
+        Newsletters not already in the file.
+    """
+    existing_ids: set[str] = set()
+    if existing_path.exists():
+        with open(existing_path) as f:
+            for lineno, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                # Tolerate a corrupt/partial line (e.g. an interrupted append)
+                # so one bad row can't abort every future harvest — the golden
+                # set is hand-editable and append-only.
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    print(f"Warning: skipping malformed line {lineno} in {existing_path}",
+                          file=sys.stderr)
+                    continue
+                thread_id = entry.get("thread_id")
+                if thread_id:
+                    existing_ids.add(thread_id)
+
+    return [n for n in new_newsletters if n.thread_id not in existing_ids]
+
+
+async def harvest_newsletters(
+    proxy: GmailProxyClient,
+    config: dict,
+    max_threads: int = 50,
+    recipient: str | None = None,
+) -> list[GoldenNewsletter]:
+    """Fetch newsletter threads and seed golden-set entries (no ground truth).
+
+    Args:
+        proxy: Gmail proxy client.
+        config: Full parsed config dict.
+        max_threads: Maximum threads to fetch.
+        recipient: Newsletter recipient; defaults to config["newsletter"]["recipient"].
+
+    Returns:
+        List of seeded GoldenNewsletter objects (empty stories, reviewed=False).
+    """
+    if recipient is None:
+        recipient = config["newsletter"]["recipient"]
+    max_thread_chars = config.get("daemon", {}).get("max_thread_chars", DEFAULT_MAX_THREAD_CHARS)
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Mirror daemon.py's newsletter query narrowing: gmail_query += f" to:{...}".
+    query = f"to:{recipient}"
+    try:
+        response = await proxy.list_messages(
+            q=query,
+            max_results=max_threads * 3,  # Over-fetch since we group by thread
+        )
+    except _NETWORK_ERRORS as exc:
+        print(f"Error: {format_network_error(exc, 'api-proxy')}", file=sys.stderr)
+        sys.exit(1)
+    msg_stubs = response.get("messages", [])
+
+    if not msg_stubs:
+        print(f"No messages found for query: {query}", file=sys.stderr)
+        return []
+
+    # Group by threadId
+    thread_ids: dict[str, list[str]] = {}
+    for stub in msg_stubs:
+        tid = stub.get("threadId", stub["id"])
+        thread_ids.setdefault(tid, []).append(stub["id"])
+
+    print(f"Found {len(thread_ids)} unique threads from {len(msg_stubs)} messages", file=sys.stderr)
+
+    results: list[GoldenNewsletter] = []
+    for i, tid in enumerate(list(thread_ids.keys())[:max_threads]):
+        try:
+            thread_data = await proxy.get_thread(tid)
+            messages = thread_data.get("messages", [])
+            if not messages:
+                continue
+
+            # Sort chronologically
+            messages.sort(key=lambda m: int(m.get("internalDate", "0")))
+
+            # Guard: only threads actually addressed to the newsletter recipient.
+            if not is_newsletter(messages, recipient):
+                print(f"  Skipping thread {tid}: not addressed to {recipient}", file=sys.stderr)
+                continue
+
+            # Build the transcript exactly as production does (daemon.py:345).
+            body = format_thread_transcript(messages, max_thread_chars)
+
+            first_headers = messages[0]["payload"]["headers"]
+            subject = get_header(first_headers, "Subject")
+            sender = get_header(first_headers, "From")
+            message_id = messages[-1]["id"]
+
+            golden = GoldenNewsletter(
+                thread_id=tid,
+                message_id=message_id,
+                sender=sender,
+                subject=subject,
+                body=body,
+                stories=[],
+                source="harvested",
+                harvested_at=now,
+                seeded_from="",
+                reviewed=False,
+            )
+            results.append(golden)
+
+            if (i + 1) % 10 == 0:
+                print(f"  Processed {i + 1}/{min(len(thread_ids), max_threads)} threads...",
+                      file=sys.stderr)
+
+        except _NETWORK_ERRORS as exc:
+            print(f"  Error fetching thread {tid}: {format_network_error(exc, 'api-proxy')}",
+                  file=sys.stderr)
+        except Exception as exc:
+            print(f"  Error processing thread {tid}: {exc}", file=sys.stderr)
+
+    print(f"Harvested {len(results)} newsletters", file=sys.stderr)
+    return results
+
+
+def write_golden_set(newsletters: list[GoldenNewsletter], output_path: Path) -> None:
+    """Append golden-set entries to the JSONL file.
+
+    Always appends — harvest never truncates an existing golden set, since that
+    file also holds manual review state (curated stories, scores, themes, notes).
+    To start fresh, delete the file manually.
+    """
+    with open(output_path, "a") as f:
+        for newsletter in newsletters:
+            f.write(json.dumps(newsletter.to_dict()) + "\n")
+
+
+async def main(args: argparse.Namespace) -> None:
+    config = load_eval_config(args.config)
+    proxy = GmailProxyClient(proxy_url=args.proxy_url)
+
+    newsletters = await harvest_newsletters(
+        proxy=proxy,
+        config=config,
+        max_threads=args.max_threads,
+        recipient=args.recipient,
+    )
+
+    if not newsletters:
+        print("No newsletters to write.", file=sys.stderr)
+        return
+
+    output_path = Path(args.output)
+    newsletters = deduplicate(newsletters, output_path)
+    if not newsletters:
+        print("All newsletters already in golden set.", file=sys.stderr)
+        return
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_golden_set(newsletters, output_path)
+    print(f"Appended {len(newsletters)} newsletters to {output_path}", file=sys.stderr)
+
+
+def cli():
+    parser = argparse.ArgumentParser(description="Harvest candidate newsletters for golden set")
+    parser.add_argument("--output", default="evals/newsletter_golden_set.jsonl",
+                        help="Output JSONL path")
+    parser.add_argument("--max-threads", type=int, default=50, help="Max threads to fetch")
+    parser.add_argument("--recipient",
+                        help="Newsletter recipient (default: config[newsletter][recipient])")
+    parser.add_argument("--config", help="Path to config.toml (default: ./config.toml)")
+    parser.add_argument("--proxy-url", help="API proxy URL (overrides PROXY_URL env var)")
+    args = parser.parse_args()
+    asyncio.run(main(args))
+
+
+if __name__ == "__main__":
+    cli()

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -7,9 +7,13 @@ Usage:
 
 Phase A (curate stories / extraction truth): seed candidate stories by running
 the production ``newsletter.parse_stories`` over a one-time LLM extraction of
-the body, then split/merge/edit/add/delete candidates. Confirming the list
-sets ``newsletter.reviewed=True`` and assigns each story a stable
-``story_id = f"{thread_id}:{index}"``.
+the body (a deletable starting point), then build the authoritative story list
+by marking body segments — move the cursor over the rendered body, press ``s``/
+``e`` to set the selection start/end line, and ``Enter`` to make a story from
+that inclusive span — plus add/edit/delete candidates. Confirming the list sets
+``newsletter.reviewed=True`` and assigns each story a stable
+``story_id = f"{thread_id}:{index}"``. A newsletter can also be skipped (``k``)
+without marking it reviewed, so it resurfaces in a later pass.
 
 Phase B (per-story labels): assign the 4 dimension scores
 (simple/concrete/personal/dynamic, 1-5) and multi-select themes; on save the
@@ -28,6 +32,7 @@ import json
 import os
 import sys
 import tempfile
+import textwrap
 from pathlib import Path
 
 from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
@@ -128,40 +133,30 @@ def add_story(newsletter, title, text):
     return story
 
 
-def split_story(newsletter, index, split_at):
-    """Split an over-merged candidate into two at the first occurrence of
-    *split_at* within its text.
+def create_story_from_body(newsletter, start_line, end_line, title):
+    """Build a candidate story from an inclusive span of body lines.
 
-    The second story begins at *split_at* (marker kept in the tail). Both
-    halves inherit the original title; ids are reindexed on confirm.
+    *start_line* / *end_line* are indices into ``newsletter.body.splitlines()``;
+    they are normalized (min/max) and clamped to the valid range, so order and
+    out-of-range values are tolerated. The span text is the inclusive
+    ``lo..hi`` slice joined with newlines. A falsy *title* is auto-derived from
+    the first ~8 words of the segment. Appends the story with a stable
+    ``story_id``; ``newsletter.reviewed`` is left untouched.
     """
-    story = newsletter.stories[index]
-    pos = story.text.find(split_at)
-    if pos < 0:
-        return  # marker not found — leave unchanged
-    head = story.text[:pos].strip()
-    tail = story.text[pos:].strip()
-    story.text = head
-    new_story = GoldenStory(
-        story_id=f"{newsletter.thread_id}:{index + 1}",
-        title=story.title,
-        text=tail,
+    body_lines = newsletter.body.splitlines()
+    last = max(0, len(body_lines) - 1)
+    lo = max(0, min(start_line, end_line))
+    hi = min(last, max(start_line, end_line))
+    text = "\n".join(body_lines[lo:hi + 1])
+    if not title:
+        title = " ".join(text.split()[:8]).strip() or "(untitled)"
+    story = GoldenStory(
+        story_id=f"{newsletter.thread_id}:{len(newsletter.stories)}",
+        title=title,
+        text=text,
     )
-    newsletter.stories.insert(index + 1, new_story)
-    return new_story
-
-
-def merge_stories(newsletter, index):
-    """Merge the candidate at *index* with its immediate successor.
-
-    Texts are joined with a newline; the merged story keeps the first story's
-    title. Ids are reindexed on confirm.
-    """
-    if index + 1 >= len(newsletter.stories):
-        return
-    first = newsletter.stories[index]
-    second = newsletter.stories.pop(index + 1)
-    first.text = f"{first.text}\n{second.text}"
+    newsletter.stories.append(story)
+    return story
 
 
 def edit_story(newsletter, index, *, title=None, text=None):
@@ -303,6 +298,71 @@ def build_extractor(config: dict):
 
 
 # ---------------------------------------------------------------------------
+# Pure rendering helpers (no curses; fully testable)
+# ---------------------------------------------------------------------------
+
+def wrap_text(text: str, width: int) -> list[str]:
+    """Wrap *text* to *width*, preserving existing newlines.
+
+    Mirrors ``newsletter_review.tui.wrap_text``: ``width <= 0`` disables
+    wrapping and empty *text* yields ``[""]``.
+    """
+    if not text:
+        return [""]
+    lines = []
+    for paragraph in text.splitlines():
+        if width <= 0:
+            lines.append(paragraph)
+        else:
+            wrapped = textwrap.wrap(paragraph, width) or [""]
+            lines.extend(wrapped)
+    return lines
+
+
+def build_detail_rows(newsletter, index, total, width) -> list[tuple[str, int | None]]:
+    """Build the wrapped detail-view rows with body-line provenance.
+
+    Each returned row is ``(text, body_line_index_or_None)``. Header/metadata/
+    story-list rows carry ``None``. Each logical body line (from
+    ``body.splitlines()``) is wrapped to *width*, and every resulting physical
+    row carries THAT body line's index — the provenance map the view uses for
+    selection and highlighting.
+    """
+    rows: list[tuple[str, int | None]] = []
+
+    def add_header(text: str) -> None:
+        for line in wrap_text(text, width):
+            rows.append((line, None))
+
+    add_header(f"Newsletter {index + 1}/{total}  (id: {newsletter.thread_id})")
+    add_header("=" * 60)
+    add_header(f"Subject:  {newsletter.subject}")
+    add_header(f"Sender:   {newsletter.sender}")
+    add_header(f"Reviewed: {newsletter.reviewed}")
+    add_header(f"Seeded:   {newsletter.seeded_from or '-'}")
+    if newsletter.notes:
+        add_header(f"Notes:    {newsletter.notes}")
+    add_header("")
+    add_header(f"--- Stories ({len(newsletter.stories)}) ---")
+    for i, s in enumerate(newsletter.stories):
+        flags = []
+        if s.excluded:
+            flags.append("EXCLUDED")
+        if s.reviewed:
+            flags.append(s.expected_tier or "reviewed")
+        flag_str = f"  [{', '.join(flags)}]" if flags else ""
+        add_header(f"[{i}] {s.title}{flag_str}")
+        add_header(f"    themes: {', '.join(s.expected_themes) or '-'}")
+    add_header("")
+    add_header("--- Body ---")
+
+    for body_idx, body_line in enumerate(newsletter.body.splitlines()):
+        for physical in wrap_text(body_line, width):
+            rows.append((physical, body_idx))
+    return rows
+
+
+# ---------------------------------------------------------------------------
 # Curses helpers (mirroring evals.edit_tui)
 # ---------------------------------------------------------------------------
 
@@ -330,34 +390,6 @@ def _prompt_line(stdscr, prompt: str) -> str:
         curses.noecho()
         curses.curs_set(0)
     return raw.decode("utf-8", "replace").strip()
-
-
-def _newsletter_lines(newsletter, index, total) -> list[str]:
-    lines = [
-        f"Newsletter {index + 1}/{total}  (id: {newsletter.thread_id})",
-        "=" * 60,
-        f"Subject:  {newsletter.subject}",
-        f"Sender:   {newsletter.sender}",
-        f"Reviewed: {newsletter.reviewed}",
-        f"Seeded:   {newsletter.seeded_from or '-'}",
-    ]
-    if newsletter.notes:
-        lines.append(f"Notes:    {newsletter.notes}")
-    lines.append("")
-    lines.append(f"--- Stories ({len(newsletter.stories)}) ---")
-    for i, s in enumerate(newsletter.stories):
-        flags = []
-        if s.excluded:
-            flags.append("EXCLUDED")
-        if s.reviewed:
-            flags.append(s.expected_tier or "reviewed")
-        flag_str = f"  [{', '.join(flags)}]" if flags else ""
-        lines.append(f"[{i}] {s.title}{flag_str}")
-        lines.append(f"    themes: {', '.join(s.expected_themes) or '-'}")
-    lines.append("")
-    lines.append("--- Body ---")
-    lines.extend(newsletter.body.splitlines())
-    return lines
 
 
 def _prompt_scores(stdscr) -> dict[str, int] | None:
@@ -404,42 +436,76 @@ def _prompt_themes(stdscr) -> list[str]:
 # ---------------------------------------------------------------------------
 
 def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, extract_fn=None):
-    """Curate + label one newsletter. Returns "back" or "quit"."""
+    """Curate + label one newsletter. Returns "back", "skip", or "quit"."""
     newsletter = newsletters[index]
     total = len(newsletters)
     scroll_y = 0
+    cursor = 0  # index into rendered rows
+    sel_start = None  # selected body-line index
+    sel_end = None
     snapshot = None  # one snapshot per newsletter for undo
 
     def save():
         _auto_save(all_newsletters, path, stdscr)
 
+    def hint(msg):
+        max_y, _ = stdscr.getmaxyx()
+        _safe_addstr(stdscr, max_y - 1, 0, msg, curses.A_REVERSE)
+        stdscr.refresh()
+        stdscr.getch()
+
     while True:
-        lines = _newsletter_lines(newsletter, index, total)
         max_y, max_x = stdscr.getmaxyx()
+        rows = build_detail_rows(newsletter, index, total, max_x - 1)
         content_rows = max(1, max_y - 2)
+        cursor = max(0, min(cursor, len(rows) - 1))
+        # Auto-scroll so the cursor row stays visible.
+        if cursor < scroll_y:
+            scroll_y = cursor
+        elif cursor >= scroll_y + content_rows:
+            scroll_y = cursor - content_rows + 1
+        max_scroll = max(0, len(rows) - content_rows)
+
+        lo = hi = None
+        if sel_start is not None and sel_end is not None:
+            lo, hi = min(sel_start, sel_end), max(sel_start, sel_end)
+        elif sel_start is not None:
+            lo = hi = sel_start
+
         stdscr.clear()
         for row_i in range(content_rows):
-            li = scroll_y + row_i
-            if li >= len(lines):
+            ri = scroll_y + row_i
+            if ri >= len(rows):
                 break
-            _safe_addstr(stdscr, row_i, 0, lines[li])
+            text, body_idx = rows[ri]
+            selected = (
+                body_idx is not None and lo is not None and lo <= body_idx <= hi
+            )
+            if ri == cursor:
+                _safe_addstr(stdscr, row_i, 0, text, curses.A_REVERSE)
+            elif selected:
+                _safe_addstr(stdscr, row_i, 0, "*", curses.A_BOLD)
+                _safe_addstr(stdscr, row_i, 1, text, curses.A_BOLD)
+            else:
+                _safe_addstr(stdscr, row_i, 0, text)
         help_text = (
-            "[Space]seed [a]dd [e]dit [x]split [m]erge [d]el [c]onfirm "
-            "[l]abel [u]nexclude/exclude [n]notes [z]undo Esc:Back q:Quit"
+            "↑/↓ move  s/e select  Enter make-story  [a]dd [E]dit [d]el "
+            "[c]onfirm [l]abel [u]exclude [n]notes [z]undo [k]skip Esc:Back q:Quit"
         )
         _safe_addstr(stdscr, max_y - 2, 0, help_text, curses.A_DIM)
-        max_scroll = max(0, len(lines) - content_rows)
         stdscr.refresh()
 
         key = stdscr.getch()
 
-        if key == curses.KEY_UP and scroll_y > 0:
-            scroll_y -= 1
-        elif key == curses.KEY_DOWN and scroll_y < max_scroll:
-            scroll_y += 1
+        if key == curses.KEY_UP and cursor > 0:
+            cursor -= 1
+        elif key == curses.KEY_DOWN and cursor < len(rows) - 1:
+            cursor += 1
         elif key == curses.KEY_NPAGE:
+            cursor = min(len(rows) - 1, cursor + content_rows)
             scroll_y = min(max_scroll, scroll_y + content_rows)
         elif key == curses.KEY_PPAGE:
+            cursor = max(0, cursor - content_rows)
             scroll_y = max(0, scroll_y - content_rows)
 
         elif key == ord(" "):  # seed via extractor
@@ -449,9 +515,33 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
                     seed_from_extractor(newsletter, extract_fn)
                     save()
                 except Exception as exc:
-                    _safe_addstr(stdscr, max_y - 1, 0, f"Seed failed: {exc}", curses.A_REVERSE)
-                    stdscr.refresh()
-                    stdscr.getch()
+                    hint(f"Seed failed: {exc}")
+
+        elif key == ord("s"):  # set selection start
+            body_idx = rows[cursor][1]
+            if body_idx is None:
+                hint("Move the cursor onto a body line first.")
+            else:
+                sel_start = body_idx
+
+        elif key == ord("e"):  # set selection end
+            body_idx = rows[cursor][1]
+            if body_idx is None:
+                hint("Move the cursor onto a body line first.")
+            else:
+                sel_end = body_idx
+
+        elif key in (curses.KEY_ENTER, ord("\n"), ord("\r")):  # make story
+            if sel_start is None:
+                hint("Set a selection start with 's' first.")
+            else:
+                s_line = sel_start
+                e_line = sel_end if sel_end is not None else sel_start
+                title = _prompt_line(stdscr, "Title (blank=auto):")
+                snapshot = capture_snapshot(newsletter)
+                create_story_from_body(newsletter, s_line, e_line, title)
+                save()
+                sel_start = sel_end = None
 
         elif key == ord("a"):  # add story
             snapshot = capture_snapshot(newsletter)
@@ -461,7 +551,7 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
                 add_story(newsletter, title, text)
                 save()
 
-        elif key == ord("e"):  # edit story
+        elif key == ord("E"):  # edit story
             snapshot = capture_snapshot(newsletter)
             si = _prompt_index(stdscr, newsletter)
             if si is not None:
@@ -472,22 +562,6 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
                     title=title or None,
                     text=text or None,
                 )
-                save()
-
-        elif key == ord("x"):  # split
-            snapshot = capture_snapshot(newsletter)
-            si = _prompt_index(stdscr, newsletter)
-            if si is not None:
-                marker = _prompt_line(stdscr, "Split at text:")
-                if marker:
-                    split_story(newsletter, si, marker)
-                    save()
-
-        elif key == ord("m"):  # merge with successor
-            snapshot = capture_snapshot(newsletter)
-            si = _prompt_index(stdscr, newsletter)
-            if si is not None:
-                merge_stories(newsletter, si)
                 save()
 
         elif key == ord("d"):  # delete
@@ -531,6 +605,8 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
                 snapshot = None
                 save()
 
+        elif key == ord("k"):  # skip this newsletter (never marks reviewed)
+            return "skip"
         elif key == 27:  # Esc
             return "back"
         elif key == ord("q"):
@@ -595,11 +671,21 @@ def _list_view(stdscr, newsletters, all_newsletters, path, *, extract_fn=None):
             if cursor >= scroll_offset + page_size:
                 scroll_offset = cursor - page_size + 1
         elif key in (curses.KEY_ENTER, ord("\n"), ord("\r")):
-            result = _newsletter_detail(
-                stdscr, newsletters, cursor, all_newsletters, path, extract_fn=extract_fn
-            )
-            if result == "quit":
-                return
+            while True:
+                result = _newsletter_detail(
+                    stdscr, newsletters, cursor, all_newsletters, path, extract_fn=extract_fn
+                )
+                if result == "quit":
+                    return
+                if result == "skip" and cursor < len(newsletters) - 1:
+                    # Linear skip-through: advance and immediately open the next
+                    # newsletter. Skipping never marks reviewed, so it resurfaces.
+                    cursor += 1
+                    if cursor >= scroll_offset + page_size:
+                        scroll_offset = cursor - page_size + 1
+                    continue
+                # "back", or "skip" on the last newsletter -> return to list.
+                break
         elif key == ord("q"):
             return
 

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -352,6 +352,9 @@ def build_detail_rows(newsletter, index, total, width) -> list[tuple[str, int | 
             flags.append(s.expected_tier or "reviewed")
         flag_str = f"  [{', '.join(flags)}]" if flags else ""
         add_header(f"[{i}] {s.title}{flag_str}")
+        # Show the full parsed text inline (indented), wrapped to the width.
+        for text_line in wrap_text(s.text, max(1, width - 6)):
+            add_header(f"      {text_line}")
         add_header(f"    themes: {', '.join(s.expected_themes) or '-'}")
     add_header("")
     add_header("--- Body ---")

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -14,8 +14,9 @@ by marking body segments — move the cursor over the rendered body, press ``s``
 ``e`` to set the selection start/end line, and ``Enter`` to make a story from
 that inclusive span — plus add/edit/delete candidates. Body lines already
 covered by a story are dimmed, so paragraphs the seed omitted stand out.
-Confirming the list sets ``newsletter.reviewed=True`` and assigns each story a
-stable ``story_id = f"{thread_id}:{index}"``. A newsletter can also be skipped
+Confirming the list sets ``newsletter.reviewed=True``; every story keeps its
+stable ``story_id`` (``f"{thread_id}:{n}"``) and only missing/duplicate ids are
+repaired with fresh unique ones. A newsletter can also be skipped
 (``k``) without marking it reviewed, so it resurfaces in a later pass.
 
 Phase B (per-story labels): assign the 4 dimension scores
@@ -38,6 +39,7 @@ import tempfile
 import unicodedata
 from pathlib import Path
 
+from evals import plural
 from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
 from newsletter import compute_tier, parse_stories
 
@@ -89,12 +91,6 @@ def save_golden_set(newsletters: list[GoldenNewsletter], path: Path) -> None:
 # Pure state transitions (Phase A — curate stories)
 # ---------------------------------------------------------------------------
 
-def _reindex_story_ids(newsletter):
-    """Reassign every story's id to f"{thread_id}:{index}" for its position."""
-    for i, story in enumerate(newsletter.stories):
-        story.story_id = f"{newsletter.thread_id}:{i}"
-
-
 def seed_from_extractor(newsletter, extract_fn):
     """Seed candidates by running *extract_fn* over the body, then parse_stories.
 
@@ -112,25 +108,46 @@ def seed_stories(newsletter, story_pairs):
     """Populate candidate stories from ``parse_stories`` (title, text) pairs.
 
     Replaces any existing story list, assigns stable ids, and records the seed
-    provenance. Does not confirm the list.
+    provenance. Replacing the list invalidates any prior confirmation, so
+    ``newsletter.reviewed`` is reset to False — the uncurated machine seed must
+    be re-confirmed before it counts as extraction truth (undo still restores
+    the prior state, ``reviewed`` included, via the snapshot).
     """
     newsletter.stories = [
         GoldenStory(story_id=f"{newsletter.thread_id}:{i}", title=title, text=text)
         for i, (title, text) in enumerate(story_pairs)
     ]
     newsletter.seeded_from = "parse_stories"
+    newsletter.reviewed = False
     return newsletter.stories
 
 
+def _next_story_id(newsletter) -> str:
+    """Next unique story id: ``max(existing numeric suffixes) + 1``.
+
+    Deriving from the max — not ``len(stories)`` — means a delete followed by
+    an add can never mint a duplicate id (downstream dicts key on story_id).
+    Falls back to ``len(stories)`` when no story carries a numeric suffix.
+    """
+    prefix = f"{newsletter.thread_id}:"
+    max_suffix = -1
+    for story in newsletter.stories:
+        sid = story.story_id or ""
+        if sid.startswith(prefix) and sid[len(prefix):].isdigit():
+            max_suffix = max(max_suffix, int(sid[len(prefix):]))
+    if max_suffix < 0:
+        return f"{prefix}{len(newsletter.stories)}"
+    return f"{prefix}{max_suffix + 1}"
+
+
 def add_story(newsletter, title, text):
-    """Append a new candidate story with a stable story_id.
+    """Append a new candidate story with a stable, unique story_id.
 
     Does not confirm the list — ``newsletter.reviewed`` is untouched and the
     new story starts unreviewed.
     """
-    index = len(newsletter.stories)
     story = GoldenStory(
-        story_id=f"{newsletter.thread_id}:{index}",
+        story_id=_next_story_id(newsletter),
         title=title,
         text=text,
     )
@@ -145,8 +162,8 @@ def create_story_from_body(newsletter, start_line, end_line, title):
     they are normalized (min/max) and clamped to the valid range, so order and
     out-of-range values are tolerated. The span text is the inclusive
     ``lo..hi`` slice joined with newlines. A falsy *title* is auto-derived from
-    the first ~8 words of the segment. Appends the story with a stable
-    ``story_id``; ``newsletter.reviewed`` is left untouched.
+    the first ~8 words of the segment. Appends via ``add_story`` (stable,
+    unique ``story_id``); ``newsletter.reviewed`` is left untouched.
     """
     body_lines = newsletter.body.splitlines()
     last = max(0, len(body_lines) - 1)
@@ -155,13 +172,7 @@ def create_story_from_body(newsletter, start_line, end_line, title):
     text = "\n".join(body_lines[lo:hi + 1])
     if not title:
         title = " ".join(text.split()[:8]).strip() or "(untitled)"
-    story = GoldenStory(
-        story_id=f"{newsletter.thread_id}:{len(newsletter.stories)}",
-        title=title,
-        text=text,
-    )
-    newsletter.stories.append(story)
-    return story
+    return add_story(newsletter, title, text)
 
 
 def edit_story(newsletter, index, *, title=None, text=None):
@@ -176,7 +187,8 @@ def edit_story(newsletter, index, *, title=None, text=None):
 def delete_story(newsletter, index):
     """Remove a wrongly-extracted candidate entirely (not the same as exclude).
 
-    Leaves ``newsletter.reviewed`` untouched; ids are reindexed on confirm.
+    Leaves ``newsletter.reviewed`` untouched; the remaining stories keep their
+    ids (gaps are fine — ids are stable, never positional).
     """
     newsletter.stories.pop(index)
 
@@ -184,9 +196,15 @@ def delete_story(newsletter, index):
 def confirm_story_list(newsletter):
     """Confirm the curated story list as authoritative extraction truth.
 
-    Reindexes story ids to be contiguous and marks the newsletter reviewed.
+    Existing story ids are PRESERVED (cross-run comparisons key on them); only
+    missing or duplicate ids are repaired with a fresh unique id from
+    ``_next_story_id``. Marks the newsletter reviewed.
     """
-    _reindex_story_ids(newsletter)
+    seen = set()
+    for story in newsletter.stories:
+        if not story.story_id or story.story_id in seen:
+            story.story_id = _next_story_id(newsletter)
+        seen.add(story.story_id)
     newsletter.reviewed = True
 
 
@@ -280,18 +298,13 @@ def seed_confirmation_message(newsletter) -> str | None:
         return None
     labeled = sum(1 for s in newsletter.stories if s.expected_scores is not None)
     detail = f" ({labeled} labeled)" if labeled else ""
-    return f"Replace {_stories(n)}{detail} with a fresh seed? y/N"
-
-
-def _stories(n: int) -> str:
-    """'1 story' / 'N stories' — mirror the run/report modules' _plural."""
-    return "1 story" if n == 1 else f"{n} stories"
+    return f"Replace {plural(n, 'story', 'stories')}{detail} with a fresh seed? y/N"
 
 
 def seed_outcome_message(raw: str, story_count: int) -> str:
     """Status line after a seed: distinguishes NO_STORIES from a parse washout."""
     if story_count:
-        return f"Seeded {_stories(story_count)}."
+        return f"Seeded {plural(story_count, 'story', 'stories')}."
     if raw.strip().upper() == "NO_STORIES":
         return "Extractor returned NO_STORIES."
     return "Extractor output had no parseable story blocks."
@@ -307,7 +320,8 @@ def confirm_status_message(newsletter) -> str:
     status = "Story list confirmed."
     if unlabeled:
         status += (
-            f" {_stories(unlabeled)} still unlabeled — press l to score them."
+            f" {plural(unlabeled, 'story', 'stories')} still unlabeled"
+            " — press l to score them."
         )
     return status
 
@@ -494,12 +508,14 @@ def build_extractor(config: dict):
             "or CLOUD_LLM_URL, or run with --edit to curate without seeding."
         )
     nl_llm = config["newsletter"]["llm"]
+    # Mirror daemon.run_daemon / newsletter_run.build_classifier defaults.
     client = LLMClient(
         base_url=base_url,
         api_key=api_key,
         model=nl_llm["model"],
         temperature=nl_llm.get("temperature", 0.0),
-        max_tokens=nl_llm.get("max_tokens", 2048),
+        max_tokens=nl_llm.get("max_tokens", 1024),
+        timeout=nl_llm.get("timeout", 60),
         extra_body=nl_llm.get("extra_body"),
     )
     classifier = NewsletterClassifier(client, config)
@@ -781,8 +797,17 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
     undo_stack: list[dict] = []  # snapshots, pushed only when a mutation happens
     status = ""  # one-shot feedback line (cleared on the next keypress)
     anchor_body = None  # body line to re-anchor the cursor to after a mutation
+    # Rows + covered-lines are expensive (display-width wrap of the whole body,
+    # substring scan per line); cache them and rebuild only when the newsletter
+    # mutated (every mutating branch calls save()) or the terminal was resized.
+    dirty = True
+    cached_size: tuple[int, int] | None = None
+    rows: list[tuple[str, int | None]] = []
+    covered: set[int] = set()
 
     def save():
+        nonlocal dirty
+        dirty = True
         _auto_save(all_newsletters, path, stdscr)
 
     def push_undo():
@@ -802,7 +827,11 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
 
     while True:
         max_y, max_x = stdscr.getmaxyx()
-        rows = build_detail_rows(newsletter, index, total, max_x - 2)
+        if dirty or (max_y, max_x) != cached_size:
+            rows = build_detail_rows(newsletter, index, total, max_x - 2)
+            covered = covered_body_lines(newsletter)
+            cached_size = (max_y, max_x)
+            dirty = False
         if anchor_body is not None:
             # The story list above the body grew/shrank: keep the cursor on
             # the same BODY line, not the same physical row.
@@ -823,7 +852,6 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
             lo, hi = min(sel_start, sel_end), max(sel_start, sel_end)
         elif sel_start is not None:
             lo = hi = sel_start
-        covered = covered_body_lines(newsletter)
 
         stdscr.clear()
         for row_i in range(content_rows):

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -216,6 +216,28 @@ def exclude_story(story):
     story.excluded = True
 
 
+def toggle_newsletter_excluded(newsletter) -> bool:
+    """Toggle whole-newsletter exclusion; returns the new state.
+
+    An excluded newsletter is dropped from the labeling queue (unless
+    ``--include-excluded``) and from eval runs entirely. ``reviewed`` is left
+    untouched — it records that the story list is confirmed extraction truth,
+    which stays valid if the newsletter is later restored.
+    """
+    newsletter.excluded = not newsletter.excluded
+    return newsletter.excluded
+
+
+def newsletter_exclude_status(newsletter) -> str:
+    """Status line after ``X`` toggles newsletter-level exclusion."""
+    if newsletter.excluded:
+        return (
+            "Newsletter excluded from the queue and eval runs "
+            "(X to restore; relaunch with --include-excluded to see it again)."
+        )
+    return "Newsletter restored to the queue and eval runs."
+
+
 # ---------------------------------------------------------------------------
 # Pure helpers for the TUI (no curses; fully testable)
 # ---------------------------------------------------------------------------
@@ -223,7 +245,7 @@ def exclude_story(story):
 _HELP_ITEMS = (
     "↑/↓:move", "PgUp/PgDn:page", "s/e:select", "Enter:make-story", "Space:seed",
     "[a]dd", "[E]dit", "[d]el", "[c]onfirm", "[l]abel", "[u]exclude", "[n]otes",
-    "[z]undo", "[k]skip", "Esc:back", "q:quit",
+    "[z]undo", "[k]skip", "[X]exclude-nl", "Esc:back", "q:quit",
 )
 
 
@@ -336,8 +358,13 @@ def format_list_header() -> str:
 
 
 def format_list_row(newsletter) -> str:
-    """One list-view row: reviewed flag, labeled/total, sender, subject."""
-    r = "Y" if newsletter.reviewed else " "
+    """One list-view row: reviewed/excluded flag, labeled/total, sender, subject.
+
+    ``X`` (excluded) takes precedence over ``Y`` (reviewed) in the flag column
+    so an excluded newsletter is unmistakable when queued via
+    ``--include-excluded``.
+    """
+    r = "X" if newsletter.excluded else ("Y" if newsletter.reviewed else " ")
     labeled, total = label_progress(newsletter)
     sender = (newsletter.sender or "")[:24]
     return f"{r:<2} {f'{labeled}/{total}':<6} {sender:<24} {newsletter.subject}"
@@ -427,13 +454,16 @@ def restore_snapshot(newsletter, snapshot):
 # Queue selection
 # ---------------------------------------------------------------------------
 
-def select_label_newsletters(newsletters, *, unreviewed_only=False):
+def select_label_newsletters(newsletters, *, unreviewed_only=False, include_excluded=False):
     """Newsletters to queue for labeling.
 
-    Excluded newsletters are permanently set aside and never queued, regardless
-    of *unreviewed_only*.
+    Excluded newsletters are set aside and not queued, regardless of
+    *unreviewed_only* — unless *include_excluded*, which queues them so they
+    can be inspected and restored (``X`` toggles exclusion in the detail view).
     """
-    result = [n for n in newsletters if not n.excluded]
+    result = list(newsletters)
+    if not include_excluded:
+        result = [n for n in result if not n.excluded]
     if unreviewed_only:
         result = [n for n in result if not n.reviewed]
     return result
@@ -574,6 +604,8 @@ def build_detail_rows(newsletter, index, total, width) -> list[tuple[str, int | 
     add_header(f"Subject:  {newsletter.subject}")
     add_header(f"Sender:   {newsletter.sender}")
     add_header(f"Reviewed: {newsletter.reviewed}")
+    if newsletter.excluded:
+        add_header("Excluded: True — skipped by the queue and eval runs (X to restore)")
     add_header(f"Seeded:   {newsletter.seeded_from or '-'}")
     if newsletter.notes:
         add_header(f"Notes:    {newsletter.notes}")
@@ -1003,6 +1035,12 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
             else:
                 status = "Nothing to undo."
 
+        elif key == ord("X"):  # toggle whole-newsletter exclusion
+            push_undo()
+            toggle_newsletter_excluded(newsletter)
+            save()
+            status = newsletter_exclude_status(newsletter)
+
         elif key == ord("k"):  # skip this newsletter (never marks reviewed)
             return "skip"
         elif key == 27:  # Esc: clear an active selection first, then go back
@@ -1127,6 +1165,9 @@ def cli():
                         help="Edit mode: no LLM seeding (curate/label existing stories)")
     parser.add_argument("--unreviewed-only", action="store_true",
                         help="Queue only unreviewed newsletters")
+    parser.add_argument("--include-excluded", action="store_true",
+                        help="Also queue excluded newsletters (to inspect or restore "
+                             "them with the X hotkey; default: excluded are skipped)")
     parser.add_argument("--config",
                         help="Path to config.toml (default: the repo-root config.toml, "
                              "regardless of CWD)")
@@ -1147,7 +1188,11 @@ def cli():
         print("Golden set is empty.", file=sys.stderr)
         sys.exit(1)
 
-    newsletters = select_label_newsletters(all_newsletters, unreviewed_only=args.unreviewed_only)
+    newsletters = select_label_newsletters(
+        all_newsletters,
+        unreviewed_only=args.unreviewed_only,
+        include_excluded=args.include_excluded,
+    )
     if not newsletters:
         print("No newsletters match the filters.", file=sys.stderr)
         sys.exit(0)

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -2,18 +2,21 @@
 
 Usage:
     python -m evals.newsletter_label                     # curate + label
-    python -m evals.newsletter_label --edit              # curses edit TUI
+    python -m evals.newsletter_label --edit              # manual-only (no LLM seeding)
     python -m evals.newsletter_label --unreviewed-only
 
-Phase A (curate stories / extraction truth): seed candidate stories by running
-the production ``newsletter.parse_stories`` over a one-time LLM extraction of
-the body (a deletable starting point), then build the authoritative story list
+Phase A (curate stories / extraction truth): press ``Space`` to seed candidate
+stories by running the production ``newsletter.parse_stories`` over a fresh
+LLM extraction of the body (an uncached call on every press; the seed is a
+deletable starting point, and re-seeding over an existing list asks for
+confirmation), then build the authoritative story list
 by marking body segments — move the cursor over the rendered body, press ``s``/
 ``e`` to set the selection start/end line, and ``Enter`` to make a story from
-that inclusive span — plus add/edit/delete candidates. Confirming the list sets
-``newsletter.reviewed=True`` and assigns each story a stable
-``story_id = f"{thread_id}:{index}"``. A newsletter can also be skipped (``k``)
-without marking it reviewed, so it resurfaces in a later pass.
+that inclusive span — plus add/edit/delete candidates. Body lines already
+covered by a story are dimmed, so paragraphs the seed omitted stand out.
+Confirming the list sets ``newsletter.reviewed=True`` and assigns each story a
+stable ``story_id = f"{thread_id}:{index}"``. A newsletter can also be skipped
+(``k``) without marking it reviewed, so it resurfaces in a later pass.
 
 Phase B (per-story labels): assign the 4 dimension scores
 (simple/concrete/personal/dynamic, 1-5) and multi-select themes; on save the
@@ -32,7 +35,7 @@ import json
 import os
 import sys
 import tempfile
-import textwrap
+import unicodedata
 from pathlib import Path
 
 from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
@@ -97,10 +100,12 @@ def seed_from_extractor(newsletter, extract_fn):
 
     *extract_fn* takes the raw body and returns the raw LLM extraction string
     (kept injectable so tests never touch a network). The production
-    ``parse_stories`` turns that into (title, text) pairs.
+    ``parse_stories`` turns that into (title, text) pairs. Returns
+    ``(stories, raw)`` so the caller can report the outcome (e.g. distinguish
+    a NO_STORIES verdict from unparseable output — see ``seed_outcome_message``).
     """
     raw = extract_fn(newsletter.body)
-    return seed_stories(newsletter, parse_stories(raw))
+    return seed_stories(newsletter, parse_stories(raw)), raw
 
 
 def seed_stories(newsletter, story_pairs):
@@ -212,6 +217,185 @@ def exclude_story(story):
 
 
 # ---------------------------------------------------------------------------
+# Pure helpers for the TUI (no curses; fully testable)
+# ---------------------------------------------------------------------------
+
+_HELP_ITEMS = (
+    "↑/↓:move", "PgUp/PgDn:page", "s/e:select", "Enter:make-story", "Space:seed",
+    "[a]dd", "[E]dit", "[d]el", "[c]onfirm", "[l]abel", "[u]exclude", "[n]otes",
+    "[z]undo", "[k]skip", "Esc:back", "q:quit",
+)
+
+
+def format_help_lines(width: int) -> list[str]:
+    """Pack the detail-view hotkey help into lines of at most *width* chars.
+
+    Wide terminals get one line; narrow ones wrap so no hotkey is ever hidden.
+    """
+    lines: list[str] = []
+    current = ""
+    for item in _HELP_ITEMS:
+        candidate = f"{current}  {item}" if current else item
+        if current and len(candidate) > max(1, width):
+            lines.append(current)
+            current = item
+        else:
+            current = candidate
+    if current:
+        lines.append(current)
+    return lines
+
+
+def seed_confirmation_message(newsletter) -> str | None:
+    """Confirmation to show before Space re-seeds over existing stories.
+
+    Returns None when seeding is safe (empty story list); otherwise a y/N
+    question stating how many stories — and how many carrying Phase-B labels —
+    would be discarded.
+    """
+    n = len(newsletter.stories)
+    if n == 0:
+        return None
+    labeled = sum(1 for s in newsletter.stories if s.expected_scores is not None)
+    detail = f" ({labeled} labeled)" if labeled else ""
+    return f"Replace {_stories(n)}{detail} with a fresh seed? y/N"
+
+
+def _stories(n: int) -> str:
+    """'1 story' / 'N stories' — mirror the run/report modules' _plural."""
+    return "1 story" if n == 1 else f"{n} stories"
+
+
+def seed_outcome_message(raw: str, story_count: int) -> str:
+    """Status line after a seed: distinguishes NO_STORIES from a parse washout."""
+    if story_count:
+        return f"Seeded {_stories(story_count)}."
+    if raw.strip().upper() == "NO_STORIES":
+        return "Extractor returned NO_STORIES."
+    return "Extractor output had no parseable story blocks."
+
+
+def confirm_status_message(newsletter) -> str:
+    """Status line after ``c`` confirms the story list (Phase A done).
+
+    Mentions how many stories still lack Phase-B labels so a user doesn't quit
+    thinking the newsletter is fully done.
+    """
+    unlabeled = unlabeled_story_count(newsletter)
+    status = "Story list confirmed."
+    if unlabeled:
+        status += (
+            f" {_stories(unlabeled)} still unlabeled — press l to score them."
+        )
+    return status
+
+
+def row_for_body_line(rows, body_idx) -> int:
+    """First rendered-row index carrying *body_idx* (see ``build_detail_rows``).
+
+    Used to re-anchor the cursor to the body line it was on after the story
+    list above the body grows/shrinks. Falls back to the last row (or 0).
+    """
+    for ri, (_, bi) in enumerate(rows):
+        if bi == body_idx:
+            return ri
+    return max(0, len(rows) - 1)
+
+
+def covered_body_lines(newsletter) -> set[int]:
+    """Body-line indices whose text already appears in some story.
+
+    Good seeds are verbatim spans of the body, so substring matching of each
+    non-blank body line against the story texts marks what is covered — the
+    view dims covered lines so OMITTED paragraphs stand out.
+    """
+    texts = [s.text for s in newsletter.stories]
+    covered = set()
+    for i, line in enumerate(newsletter.body.splitlines()):
+        stripped = line.strip()
+        if stripped and any(stripped in t for t in texts):
+            covered.add(i)
+    return covered
+
+
+def label_progress(newsletter) -> tuple[int, int]:
+    """(labeled, total) over the newsletter's non-excluded stories."""
+    stories = [s for s in newsletter.stories if not s.excluded]
+    labeled = sum(1 for s in stories if s.expected_scores is not None)
+    return labeled, len(stories)
+
+
+def unlabeled_story_count(newsletter) -> int:
+    """Non-excluded stories still missing Phase-B scores."""
+    labeled, total = label_progress(newsletter)
+    return total - labeled
+
+
+def format_list_header() -> str:
+    return f"{'R':<2} {'Lbl':<6} {'Sender':<24} Subject"
+
+
+def format_list_row(newsletter) -> str:
+    """One list-view row: reviewed flag, labeled/total, sender, subject."""
+    r = "Y" if newsletter.reviewed else " "
+    labeled, total = label_progress(newsletter)
+    sender = (newsletter.sender or "")[:24]
+    return f"{r:<2} {f'{labeled}/{total}':<6} {sender:<24} {newsletter.subject}"
+
+
+class LineBuffer:
+    """Pure single-line editor state for prompts (no curses).
+
+    Supports prefilling with the current value (so edits are incremental, not
+    blind retyping), horizontal scrolling via ``visible`` (so input longer than
+    the terminal is never silently truncated), and rejects control characters
+    (so a stray Esc can never end up as a literal ``\\x1b`` in the golden set).
+    """
+
+    def __init__(self, initial: str = ""):
+        self._chars = [c for c in str(initial) if c.isprintable()]
+        self._pos = len(self._chars)
+
+    def text(self) -> str:
+        return "".join(self._chars)
+
+    def insert(self, ch: str) -> None:
+        if len(ch) == 1 and ch.isprintable():
+            self._chars.insert(self._pos, ch)
+            self._pos += 1
+
+    def backspace(self) -> None:
+        if self._pos > 0:
+            self._pos -= 1
+            self._chars.pop(self._pos)
+
+    def left(self) -> None:
+        self._pos = max(0, self._pos - 1)
+
+    def right(self) -> None:
+        self._pos = min(len(self._chars), self._pos + 1)
+
+    def visible(self, width: int) -> tuple[str, int]:
+        """(visible slice, cursor column) for a window of *width* cells."""
+        width = max(1, width)
+        start = self._pos - width + 1 if self._pos >= width else 0
+        return "".join(self._chars[start:start + width]), self._pos - start
+
+
+def format_theme_legend(selected, width: int) -> str:
+    """Theme-picker prompt line; falls back to a compact form on narrow screens."""
+    full_legend = "  ".join(f"[{k}]{v}" for k, v in _THEME_KEYS.items())
+    full = f"Themes {sorted(selected)}: {full_legend}  Enter=done"
+    if len(full) <= width:
+        return full
+    compact_legend = " ".join(f"[{k}]{v[:3]}" for k, v in _THEME_KEYS.items())
+    compact = f"Themes {','.join(selected) or '-'}: {compact_legend} Enter=done"
+    if len(compact) <= width:
+        return compact
+    return f"Themes({len(selected)}): {compact_legend} Enter=done"
+
+
+# ---------------------------------------------------------------------------
 # Undo
 # ---------------------------------------------------------------------------
 
@@ -222,8 +406,9 @@ _NL_SNAPSHOT_FIELDS = ("seeded_from", "reviewed", "notes", "excluded")
 def capture_snapshot(newsletter):
     """Deep-copy a newsletter's mutable state so a later edit can be undone.
 
-    One snapshot per newsletter; captures the full story list plus the
-    newsletter-level mutable fields.
+    Captures the full story list plus the newsletter-level mutable fields.
+    The TUI keeps a STACK of these per newsletter, pushed only when a mutation
+    actually happens — cancelled prompts never consume an undo level.
     """
     return {
         "stories": [copy.deepcopy(s) for s in newsletter.stories],
@@ -271,6 +456,13 @@ def build_extractor(config: dict):
     from newsletter import NewsletterClassifier
 
     base_url, api_key = resolve_newsletter_llm_endpoint()
+    if not base_url:
+        # Fail fast, before curses starts — otherwise the missing endpoint only
+        # surfaces as a truncated error when Space is pressed deep in the TUI.
+        raise SystemExit(
+            "No LLM endpoint configured for Phase-A seeding: set NEWSLETTER_LLM_URL "
+            "or CLOUD_LLM_URL, or run with --edit to curate without seeding."
+        )
     nl_llm = config["newsletter"]["llm"]
     client = LLMClient(
         base_url=base_url,
@@ -301,11 +493,55 @@ def build_extractor(config: dict):
 # Pure rendering helpers (no curses; fully testable)
 # ---------------------------------------------------------------------------
 
-def wrap_text(text: str, width: int) -> list[str]:
-    """Wrap *text* to *width*, preserving existing newlines.
+def display_width(text: str) -> int:
+    """Terminal cell width of *text* (east-asian wide chars & emoji count 2)."""
+    total = 0
+    for ch in text:
+        if unicodedata.combining(ch):
+            continue
+        total += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+    return total
 
-    Mirrors ``newsletter_review.tui.wrap_text``: ``width <= 0`` disables
-    wrapping and empty *text* yields ``[""]``.
+
+def _wrap_paragraph(paragraph: str, width: int) -> list[str]:
+    """Greedy word-wrap by DISPLAY width so wide chars never overflow the row."""
+    lines: list[str] = []
+    cur_words: list[str] = []
+    cur_w = 0
+    for word in paragraph.split():
+        w = display_width(word)
+        if cur_words and cur_w + 1 + w <= width:
+            cur_words.append(word)
+            cur_w += 1 + w
+            continue
+        if cur_words:
+            lines.append(" ".join(cur_words))
+            cur_words = []
+        # Word starts a fresh line; break it if wider than the screen.
+        while display_width(word) > width:
+            prefix = ""
+            prefix_w = 0
+            for ch in word:
+                ch_w = display_width(ch)
+                if prefix and prefix_w + ch_w > width:
+                    break
+                prefix += ch
+                prefix_w += ch_w
+            lines.append(prefix)
+            word = word[len(prefix):]
+        cur_words = [word] if word else []
+        cur_w = display_width(word)
+    if cur_words:
+        lines.append(" ".join(cur_words))
+    return lines or [""]
+
+
+def wrap_text(text: str, width: int) -> list[str]:
+    """Wrap *text* to *width* terminal cells, preserving existing newlines.
+
+    Mirrors ``newsletter_review.tui.wrap_text`` (``width <= 0`` disables
+    wrapping and empty *text* yields ``[""]``) but wraps by display width, so
+    emoji/wide characters are never clipped at the screen edge.
     """
     if not text:
         return [""]
@@ -314,8 +550,7 @@ def wrap_text(text: str, width: int) -> list[str]:
         if width <= 0:
             lines.append(paragraph)
         else:
-            wrapped = textwrap.wrap(paragraph, width) or [""]
-            lines.extend(wrapped)
+            lines.extend(_wrap_paragraph(paragraph, width))
     return lines
 
 
@@ -335,7 +570,7 @@ def build_detail_rows(newsletter, index, total, width) -> list[tuple[str, int | 
             rows.append((line, None))
 
     add_header(f"Newsletter {index + 1}/{total}  (id: {newsletter.thread_id})")
-    add_header("=" * 60)
+    add_header("=" * max(1, min(60, width)))
     add_header(f"Subject:  {newsletter.subject}")
     add_header(f"Sender:   {newsletter.sender}")
     add_header(f"Reviewed: {newsletter.reviewed}")
@@ -355,7 +590,12 @@ def build_detail_rows(newsletter, index, total, width) -> list[tuple[str, int | 
         # Show the full parsed text inline (indented), wrapped to the width.
         for text_line in wrap_text(s.text, max(1, width - 6)):
             add_header(f"      {text_line}")
-        add_header(f"    themes: {', '.join(s.expected_themes) or '-'}")
+        label_bits = []
+        if s.expected_scores is not None:
+            dims = "/".join(str(s.expected_scores.get(d, "?")) for d in _DIMENSIONS)
+            label_bits.append(f"scores: {dims}")
+        label_bits.append(f"themes: {', '.join(s.expected_themes) or '-'}")
+        add_header("    " + "   ".join(label_bits))
     add_header("")
     add_header("--- Body ---")
 
@@ -379,28 +619,82 @@ def _safe_addstr(win, y, x, text, attr=curses.A_NORMAL):
     win.addnstr(y, x, text, available, attr)
 
 
-def _prompt_line(stdscr, prompt: str) -> str:
-    """Read a line of text at the bottom of the screen (Enter-terminated)."""
+def _set_cursor_visibility(visible: bool) -> None:
+    try:
+        curses.curs_set(1 if visible else 0)
+    except curses.error:
+        pass
+
+
+def _prompt_line(stdscr, prompt: str, initial: str = "") -> str | None:
+    """Line editor at the bottom of the screen. Returns None on Esc (cancel).
+
+    Prefills with *initial* (edit the current value instead of retyping it
+    blind), scrolls horizontally so long input is never silently truncated,
+    and rejects control characters (a stray Esc can't pollute the golden set).
+    """
+    buf = LineBuffer(initial)
+    _set_cursor_visibility(True)
+    try:
+        while True:
+            max_y, max_x = stdscr.getmaxyx()
+            avail = max(1, max_x - len(prompt) - 2)
+            text, cur = buf.visible(avail)
+            _safe_addstr(stdscr, max_y - 1, 0, " " * (max_x - 1))
+            _safe_addstr(stdscr, max_y - 1, 0, prompt, curses.A_REVERSE)
+            _safe_addstr(stdscr, max_y - 1, len(prompt) + 1, text)
+            try:
+                stdscr.move(max_y - 1, min(max_x - 1, len(prompt) + 1 + cur))
+            except curses.error:
+                pass
+            stdscr.refresh()
+            try:
+                key = stdscr.get_wch()
+            except curses.error:
+                continue
+            if isinstance(key, str):
+                if key in ("\n", "\r"):
+                    return buf.text().strip()
+                if key == "\x1b":
+                    return None
+                if key in ("\x7f", "\x08"):
+                    buf.backspace()
+                else:
+                    buf.insert(key)
+            elif key == curses.KEY_ENTER:
+                return buf.text().strip()
+            elif key == curses.KEY_BACKSPACE:
+                buf.backspace()
+            elif key == curses.KEY_LEFT:
+                buf.left()
+            elif key == curses.KEY_RIGHT:
+                buf.right()
+    finally:
+        _set_cursor_visibility(False)
+
+
+def _confirm(stdscr, message: str) -> bool:
+    """Bottom-line y/N confirmation; only y/Y confirms."""
     max_y, max_x = stdscr.getmaxyx()
     _safe_addstr(stdscr, max_y - 1, 0, " " * (max_x - 1))
-    _safe_addstr(stdscr, max_y - 1, 0, prompt, curses.A_REVERSE)
+    _safe_addstr(stdscr, max_y - 1, 0, message, curses.A_REVERSE)
     stdscr.refresh()
-    curses.echo()
-    curses.curs_set(1)
-    try:
-        raw = stdscr.getstr(max_y - 1, len(prompt) + 1)
-    finally:
-        curses.noecho()
-        curses.curs_set(0)
-    return raw.decode("utf-8", "replace").strip()
+    return stdscr.getch() in (ord("y"), ord("Y"))
 
 
-def _prompt_scores(stdscr) -> dict[str, int] | None:
-    """Prompt for the 4 dimension scores 1-5. Returns None on cancel."""
+def _prompt_scores(stdscr, current=None) -> dict[str, int] | None:
+    """Prompt for the 4 dimension scores 1-5. Returns None on cancel.
+
+    When re-labeling, *current* shows the value already assigned per dimension;
+    accepted digits are echoed in the prompt so entry is verifiable.
+    """
     scores = {}
     for dim in _DIMENSIONS:
         max_y, max_x = stdscr.getmaxyx()
-        prompt = f"{dim} [1-5] (other cancels): "
+        now = f" (now {current[dim]})" if current and dim in current else ""
+        entered = "/".join(str(scores[d]) for d in _DIMENSIONS if d in scores)
+        so_far = f"[{entered}] " if entered else ""
+        prompt = f"{so_far}{dim}{now} [1-5] (other cancels): "
         _safe_addstr(stdscr, max_y - 1, 0, " " * (max_x - 1))
         _safe_addstr(stdscr, max_y - 1, 0, prompt, curses.A_REVERSE)
         stdscr.refresh()
@@ -412,13 +706,16 @@ def _prompt_scores(stdscr) -> dict[str, int] | None:
     return scores
 
 
-def _prompt_themes(stdscr) -> list[str]:
-    """Multi-select themes by toggling s/c/h/v/d; Enter to finish."""
-    selected: list[str] = []
+def _prompt_themes(stdscr, initial=None) -> list[str]:
+    """Multi-select themes by toggling s/c/h/v/d; Enter to finish.
+
+    Starts from *initial* (the story's current themes) so re-labeling edits
+    rather than restarts. The legend compacts on narrow terminals.
+    """
+    selected: list[str] = list(initial or [])
     while True:
         max_y, max_x = stdscr.getmaxyx()
-        legend = "  ".join(f"[{k}]{v}" for k, v in _THEME_KEYS.items())
-        prompt = f"Themes {selected}: {legend}  Enter=done"
+        prompt = format_theme_legend(selected, max_x - 1)
         _safe_addstr(stdscr, max_y - 1, 0, " " * (max_x - 1))
         _safe_addstr(stdscr, max_y - 1, 0, prompt, curses.A_REVERSE)
         stdscr.refresh()
@@ -438,6 +735,9 @@ def _prompt_themes(stdscr) -> list[str]:
 # Detail view — Phase A (curate) then Phase B (label) for one newsletter
 # ---------------------------------------------------------------------------
 
+_MAX_UNDO = 100  # bound the per-newsletter undo stack
+
+
 def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, extract_fn=None):
     """Curate + label one newsletter. Returns "back", "skip", or "quit"."""
     newsletter = newsletters[index]
@@ -446,21 +746,38 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
     cursor = 0  # index into rendered rows
     sel_start = None  # selected body-line index
     sel_end = None
-    snapshot = None  # one snapshot per newsletter for undo
+    undo_stack: list[dict] = []  # snapshots, pushed only when a mutation happens
+    status = ""  # one-shot feedback line (cleared on the next keypress)
+    anchor_body = None  # body line to re-anchor the cursor to after a mutation
 
     def save():
         _auto_save(all_newsletters, path, stdscr)
 
+    def push_undo():
+        undo_stack.append(capture_snapshot(newsletter))
+        del undo_stack[:-_MAX_UNDO]
+
     def hint(msg):
-        max_y, _ = stdscr.getmaxyx()
-        _safe_addstr(stdscr, max_y - 1, 0, msg, curses.A_REVERSE)
+        # Blocking notice (used for errors): wrapped so nothing truncates.
+        max_y, max_x = stdscr.getmaxyx()
+        lines = wrap_text(f"{msg}  (press any key)", max_x - 1)
+        start = max(0, max_y - len(lines))
+        for i, line in enumerate(lines[:max_y]):
+            _safe_addstr(stdscr, start + i, 0, " " * (max_x - 1))
+            _safe_addstr(stdscr, start + i, 0, line, curses.A_REVERSE)
         stdscr.refresh()
         stdscr.getch()
 
     while True:
         max_y, max_x = stdscr.getmaxyx()
-        rows = build_detail_rows(newsletter, index, total, max_x - 1)
-        content_rows = max(1, max_y - 2)
+        rows = build_detail_rows(newsletter, index, total, max_x - 2)
+        if anchor_body is not None:
+            # The story list above the body grew/shrank: keep the cursor on
+            # the same BODY line, not the same physical row.
+            cursor = row_for_body_line(rows, anchor_body)
+            anchor_body = None
+        help_lines = format_help_lines(max_x - 1)
+        content_rows = max(1, max_y - len(help_lines) - 1)
         cursor = max(0, min(cursor, len(rows) - 1))
         # Auto-scroll so the cursor row stays visible.
         if cursor < scroll_y:
@@ -474,6 +791,7 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
             lo, hi = min(sel_start, sel_end), max(sel_start, sel_end)
         elif sel_start is not None:
             lo = hi = sel_start
+        covered = covered_body_lines(newsletter)
 
         stdscr.clear()
         for row_i in range(content_rows):
@@ -484,21 +802,31 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
             selected = (
                 body_idx is not None and lo is not None and lo <= body_idx <= hi
             )
-            if ri == cursor:
-                _safe_addstr(stdscr, row_i, 0, text, curses.A_REVERSE)
-            elif selected:
+            # Column 0 is reserved for the selection marker on EVERY row, so
+            # text never shifts when a selection appears.
+            if selected:
                 _safe_addstr(stdscr, row_i, 0, "*", curses.A_BOLD)
+            if ri == cursor:
+                # `or " "` keeps the cursor visible on blank body lines.
+                _safe_addstr(stdscr, row_i, 1, text or " ", curses.A_REVERSE)
+            elif selected:
                 _safe_addstr(stdscr, row_i, 1, text, curses.A_BOLD)
+            elif body_idx is not None and body_idx in covered:
+                # Dim body lines already captured by a story, so paragraphs
+                # the seed OMITTED stand out at normal brightness.
+                _safe_addstr(stdscr, row_i, 1, text, curses.A_DIM)
             else:
-                _safe_addstr(stdscr, row_i, 0, text)
-        help_text = (
-            "↑/↓ move  s/e select  Enter make-story  [a]dd [E]dit [d]el "
-            "[c]onfirm [l]abel [u]exclude [n]notes [z]undo [k]skip Esc:Back q:Quit"
-        )
-        _safe_addstr(stdscr, max_y - 2, 0, help_text, curses.A_DIM)
+                _safe_addstr(stdscr, row_i, 1, text)
+        for i, help_line in enumerate(help_lines):
+            _safe_addstr(stdscr, max_y - 1 - len(help_lines) + i, 0, help_line, curses.A_DIM)
+        if status:
+            _safe_addstr(stdscr, max_y - 1, 0, status, curses.A_REVERSE)
+        else:
+            _safe_addstr(stdscr, max_y - 1, 0, f"row {cursor + 1}/{len(rows)}", curses.A_DIM)
         stdscr.refresh()
 
         key = stdscr.getch()
+        status = ""
 
         if key == curses.KEY_UP and cursor > 0:
             cursor -= 1
@@ -512,114 +840,185 @@ def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, ext
             scroll_y = max(0, scroll_y - content_rows)
 
         elif key == ord(" "):  # seed via extractor
-            if extract_fn is not None:
-                snapshot = capture_snapshot(newsletter)
-                try:
-                    seed_from_extractor(newsletter, extract_fn)
-                    save()
-                except Exception as exc:
-                    hint(f"Seed failed: {exc}")
+            if extract_fn is None:
+                status = "Seeding disabled in edit mode (run without --edit to seed)."
+            else:
+                confirm_msg = seed_confirmation_message(newsletter)
+                if confirm_msg is not None and not _confirm(stdscr, confirm_msg):
+                    status = "Seed cancelled — stories kept."
+                else:
+                    _safe_addstr(stdscr, max_y - 1, 0, " " * (max_x - 1))
+                    _safe_addstr(stdscr, max_y - 1, 0, "Seeding…", curses.A_REVERSE)
+                    stdscr.refresh()
+                    push_undo()
+                    try:
+                        stories, raw = seed_from_extractor(newsletter, extract_fn)
+                    except Exception as exc:
+                        undo_stack.pop()  # nothing changed; keep prior undo intact
+                        hint(f"Seed failed: {exc}")
+                    else:
+                        save()
+                        status = seed_outcome_message(raw, len(stories))
 
         elif key == ord("s"):  # set selection start
             body_idx = rows[cursor][1]
             if body_idx is None:
-                hint("Move the cursor onto a body line first.")
+                status = "Move the cursor onto a body line first."
             else:
                 sel_start = body_idx
+                status = f"Selection start = body line {body_idx} (Esc clears)."
 
         elif key == ord("e"):  # set selection end
             body_idx = rows[cursor][1]
             if body_idx is None:
-                hint("Move the cursor onto a body line first.")
+                status = "Move the cursor onto a body line first."
             else:
                 sel_end = body_idx
+                status = f"Selection end = body line {body_idx} (Esc clears)."
 
         elif key in (curses.KEY_ENTER, ord("\n"), ord("\r")):  # make story
             if sel_start is None:
-                hint("Set a selection start with 's' first.")
+                status = "Set a selection start with 's' first."
             else:
                 s_line = sel_start
                 e_line = sel_end if sel_end is not None else sel_start
                 title = _prompt_line(stdscr, "Title (blank=auto):")
-                snapshot = capture_snapshot(newsletter)
-                create_story_from_body(newsletter, s_line, e_line, title)
-                save()
-                sel_start = sel_end = None
+                if title is None:
+                    status = "Story creation cancelled."
+                else:
+                    anchor_body = rows[cursor][1]
+                    push_undo()
+                    story = create_story_from_body(newsletter, s_line, e_line, title)
+                    save()
+                    sel_start = sel_end = None
+                    status = f"Story created: {story.title}"
 
         elif key == ord("a"):  # add story
-            snapshot = capture_snapshot(newsletter)
             title = _prompt_line(stdscr, "New title:")
-            text = _prompt_line(stdscr, "New text:")
+            text = _prompt_line(stdscr, "New text:") if title else None
             if title and text:
+                push_undo()
                 add_story(newsletter, title, text)
                 save()
+                status = f"Story added: {title}"
+            else:
+                status = "Add cancelled — need a title and text."
 
         elif key == ord("E"):  # edit story
-            snapshot = capture_snapshot(newsletter)
             si = _prompt_index(stdscr, newsletter)
-            if si is not None:
-                title = _prompt_line(stdscr, "Title (blank=keep):")
-                text = _prompt_line(stdscr, "Text (blank=keep):")
-                edit_story(
-                    newsletter, si,
-                    title=title or None,
-                    text=text or None,
-                )
-                save()
+            if si is None:
+                status = "No valid story # — nothing edited."
+            else:
+                story = newsletter.stories[si]
+                new_title = _prompt_line(stdscr, "Title (blank=keep):", initial=story.title)
+                if new_title is None:
+                    status = "Edit cancelled."
+                else:
+                    # Multi-line text can't be edited in a one-line prompt;
+                    # fall back to blank=keep for it (body selection is the
+                    # intended repair path for paragraph-level text).
+                    text_initial = story.text if "\n" not in story.text else ""
+                    new_text = _prompt_line(
+                        stdscr, "Text (blank=keep):", initial=text_initial
+                    )
+                    if new_text is None:
+                        status = "Edit cancelled."
+                    else:
+                        new_title = new_title or story.title
+                        new_text = new_text or story.text
+                        if new_title == story.title and new_text == story.text:
+                            status = "No changes."
+                        else:
+                            push_undo()
+                            edit_story(newsletter, si, title=new_title, text=new_text)
+                            save()
+                            status = f"Story [{si}] updated."
 
         elif key == ord("d"):  # delete
-            snapshot = capture_snapshot(newsletter)
             si = _prompt_index(stdscr, newsletter)
-            if si is not None:
-                delete_story(newsletter, si)
-                save()
+            if si is None:
+                status = "No valid story # — nothing deleted."
+            else:
+                story = newsletter.stories[si]
+                if story.expected_scores is not None and not _confirm(
+                    stdscr, f"[{si}] {story.title} has labels — delete anyway? y/N"
+                ):
+                    status = "Delete cancelled."
+                else:
+                    push_undo()
+                    delete_story(newsletter, si)
+                    save()
+                    status = f"Deleted [{si}] {story.title} (z to undo)."
 
         elif key == ord("c"):  # confirm story list (Phase A done)
-            snapshot = capture_snapshot(newsletter)
+            push_undo()
             confirm_story_list(newsletter)
             save()
+            status = confirm_status_message(newsletter)
 
         elif key == ord("l"):  # label a story (Phase B)
             si = _prompt_index(stdscr, newsletter)
-            if si is not None:
-                snapshot = capture_snapshot(newsletter)
-                scores = _prompt_scores(stdscr)
-                if scores is not None:
-                    themes = _prompt_themes(stdscr)
-                    assign_scores_and_themes(newsletter.stories[si], scores, themes)
+            if si is None:
+                status = "No valid story # — nothing labeled."
+            else:
+                story = newsletter.stories[si]
+                scores = _prompt_scores(stdscr, current=story.expected_scores)
+                if scores is None:
+                    status = "Score entry cancelled — no changes saved."
+                else:
+                    themes = _prompt_themes(stdscr, initial=story.expected_themes)
+                    push_undo()
+                    assign_scores_and_themes(story, scores, themes)
                     save()
+                    status = f"Labeled [{si}] {story.expected_tier}."
 
         elif key == ord("u"):  # toggle exclude on a story
             si = _prompt_index(stdscr, newsletter)
-            if si is not None:
-                snapshot = capture_snapshot(newsletter)
+            if si is None:
+                status = "No valid story # — nothing toggled."
+            else:
+                push_undo()
                 story = newsletter.stories[si]
                 story.excluded = not story.excluded
                 save()
+                status = f"[{si}] {'excluded from' if story.excluded else 'included in'} scoring."
 
         elif key == ord("n"):  # newsletter notes
-            snapshot = capture_snapshot(newsletter)
-            newsletter.notes = _prompt_line(stdscr, "Notes:")
-            save()
-
-        elif key == ord("z"):  # undo one snapshot
-            if snapshot is not None:
-                restore_snapshot(newsletter, snapshot)
-                snapshot = None
+            new_notes = _prompt_line(stdscr, "Notes:", initial=newsletter.notes)
+            if new_notes is None:
+                status = "Notes edit cancelled."
+            elif new_notes == newsletter.notes:
+                status = "Notes unchanged."
+            else:
+                push_undo()
+                newsletter.notes = new_notes
                 save()
+                status = "Notes updated."
+
+        elif key == ord("z"):  # undo the last mutation
+            if undo_stack:
+                restore_snapshot(newsletter, undo_stack.pop())
+                save()
+                status = f"Undone ({len(undo_stack)} more undo levels)."
+            else:
+                status = "Nothing to undo."
 
         elif key == ord("k"):  # skip this newsletter (never marks reviewed)
             return "skip"
-        elif key == 27:  # Esc
-            return "back"
+        elif key == 27:  # Esc: clear an active selection first, then go back
+            if sel_start is not None or sel_end is not None:
+                sel_start = sel_end = None
+                status = "Selection cleared."
+            else:
+                return "back"
         elif key == ord("q"):
             return "quit"
 
 
 def _prompt_index(stdscr, newsletter) -> int | None:
-    """Prompt for a story index; return it or None if out of range/blank."""
+    """Prompt for a story index; None if cancelled, non-numeric or out of range."""
     raw = _prompt_line(stdscr, "Story #:")
-    if not raw.isdigit():
+    if raw is None or not raw.isdigit():
         return None
     si = int(raw)
     if 0 <= si < len(newsletter.stories):
@@ -650,18 +1049,15 @@ def _list_view(stdscr, newsletters, all_newsletters, path, *, extract_fn=None):
         stdscr.clear()
         _safe_addstr(stdscr, 0, 0, f"Newsletter Label — {len(newsletters)} newsletters",
                      curses.A_BOLD)
-        _safe_addstr(stdscr, 1, 0, f"{'R':<2}  {'Stories':<8}  Subject", curses.A_UNDERLINE)
+        _safe_addstr(stdscr, 1, 0, format_list_header(), curses.A_UNDERLINE)
         for vi in range(page_size):
             ti = scroll_offset + vi
             if ti >= len(newsletters):
                 break
-            n = newsletters[ti]
-            r = "Y" if n.reviewed else " "
-            row = f"{r:<2}  {len(n.stories):<8}  {n.subject}"
             attr = curses.A_REVERSE if ti == cursor else curses.A_NORMAL
-            _safe_addstr(stdscr, 2 + vi, 0, row, attr)
+            _safe_addstr(stdscr, 2 + vi, 0, format_list_row(newsletters[ti]), attr)
         _safe_addstr(stdscr, max_y - 1, 0,
-                     "↑/↓:Nav  Enter:Open  q:Quit", curses.A_DIM)
+                     "↑/↓ PgUp/PgDn:Nav  Enter:Open  q:Quit", curses.A_DIM)
         stdscr.refresh()
 
         key = stdscr.getch()
@@ -673,6 +1069,14 @@ def _list_view(stdscr, newsletters, all_newsletters, path, *, extract_fn=None):
             cursor += 1
             if cursor >= scroll_offset + page_size:
                 scroll_offset = cursor - page_size + 1
+        elif key == curses.KEY_NPAGE:
+            cursor = min(len(newsletters) - 1, cursor + page_size)
+            if cursor >= scroll_offset + page_size:
+                scroll_offset = cursor - page_size + 1
+        elif key == curses.KEY_PPAGE:
+            cursor = max(0, cursor - page_size)
+            if cursor < scroll_offset:
+                scroll_offset = cursor
         elif key in (curses.KEY_ENTER, ord("\n"), ord("\r")):
             while True:
                 result = _newsletter_detail(
@@ -704,6 +1108,8 @@ def label_loop(newsletters, all_newsletters, path, *, extract_fn=None):
     if not newsletters:
         print("No newsletters to label.")
         return
+    # Esc is the back key; the default ~1s ESCDELAY makes it feel broken.
+    os.environ.setdefault("ESCDELAY", "25")
     curses.wrapper(_curses_main, newsletters, all_newsletters, path, extract_fn)
 
 
@@ -721,13 +1127,19 @@ def cli():
                         help="Edit mode: no LLM seeding (curate/label existing stories)")
     parser.add_argument("--unreviewed-only", action="store_true",
                         help="Queue only unreviewed newsletters")
-    parser.add_argument("--config", help="Path to config.toml (default: ./config.toml)")
+    parser.add_argument("--config",
+                        help="Path to config.toml (default: the repo-root config.toml, "
+                             "regardless of CWD)")
     args = parser.parse_args()
 
     path = Path(args.golden_set)
     if not path.exists():
         print(f"Golden set not found: {path}", file=sys.stderr)
-        print("Run 'python -m evals.newsletter_harvest' first to create it.", file=sys.stderr)
+        print(
+            "Run 'python -m evals.newsletter_harvest' first to create it — its "
+            "--output path must match the --golden-set path passed here.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     all_newsletters = load_golden_set(path)

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -1,0 +1,673 @@
+"""Interactive CLI to build newsletter golden-set labels (two phases).
+
+Usage:
+    python -m evals.newsletter_label                     # curate + label
+    python -m evals.newsletter_label --edit              # curses edit TUI
+    python -m evals.newsletter_label --unreviewed-only
+
+Phase A (curate stories / extraction truth): seed candidate stories by running
+the production ``newsletter.parse_stories`` over a one-time LLM extraction of
+the body, then split/merge/edit/add/delete candidates. Confirming the list
+sets ``newsletter.reviewed=True`` and assigns each story a stable
+``story_id = f"{thread_id}:{index}"``.
+
+Phase B (per-story labels): assign the 4 dimension scores
+(simple/concrete/personal/dynamic, 1-5) and multi-select themes; on save the
+``expected_tier`` is derived via ``newsletter.compute_tier`` and
+``story.reviewed`` is set.
+
+The state transitions are factored into PURE functions (below) so they can be
+unit-tested without curses.
+"""
+
+import argparse
+import asyncio
+import copy
+import curses
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
+from newsletter import compute_tier, parse_stories
+
+_DIMENSIONS = ("simple", "concrete", "personal", "dynamic")
+
+# Theme hotkeys mirror newsletter_review's convention (s/c/h/v/d).
+_THEME_KEYS = {
+    "s": "scripture",
+    "c": "christlikeness",
+    "h": "church",
+    "v": "vocation_family",
+    "d": "disciple_making",
+}
+
+
+# ---------------------------------------------------------------------------
+# Load / save (atomic temp-file + rename, mirroring evals.review)
+# ---------------------------------------------------------------------------
+
+def load_golden_set(path: Path) -> list[GoldenNewsletter]:
+    """Load the newsletter golden set from a JSONL file."""
+    newsletters = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                newsletters.append(GoldenNewsletter.from_dict(json.loads(line)))
+    return newsletters
+
+
+def save_golden_set(newsletters: list[GoldenNewsletter], path: Path) -> None:
+    """Save the golden set atomically (temp file + rename)."""
+    path = Path(path)
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".jsonl.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            for nl in newsletters:
+                f.write(json.dumps(nl.to_dict()) + "\n")
+        os.rename(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Pure state transitions (Phase A — curate stories)
+# ---------------------------------------------------------------------------
+
+def _reindex_story_ids(newsletter):
+    """Reassign every story's id to f"{thread_id}:{index}" for its position."""
+    for i, story in enumerate(newsletter.stories):
+        story.story_id = f"{newsletter.thread_id}:{i}"
+
+
+def seed_from_extractor(newsletter, extract_fn):
+    """Seed candidates by running *extract_fn* over the body, then parse_stories.
+
+    *extract_fn* takes the raw body and returns the raw LLM extraction string
+    (kept injectable so tests never touch a network). The production
+    ``parse_stories`` turns that into (title, text) pairs.
+    """
+    raw = extract_fn(newsletter.body)
+    return seed_stories(newsletter, parse_stories(raw))
+
+
+def seed_stories(newsletter, story_pairs):
+    """Populate candidate stories from ``parse_stories`` (title, text) pairs.
+
+    Replaces any existing story list, assigns stable ids, and records the seed
+    provenance. Does not confirm the list.
+    """
+    newsletter.stories = [
+        GoldenStory(story_id=f"{newsletter.thread_id}:{i}", title=title, text=text)
+        for i, (title, text) in enumerate(story_pairs)
+    ]
+    newsletter.seeded_from = "parse_stories"
+    return newsletter.stories
+
+
+def add_story(newsletter, title, text):
+    """Append a new candidate story with a stable story_id.
+
+    Does not confirm the list — ``newsletter.reviewed`` is untouched and the
+    new story starts unreviewed.
+    """
+    index = len(newsletter.stories)
+    story = GoldenStory(
+        story_id=f"{newsletter.thread_id}:{index}",
+        title=title,
+        text=text,
+    )
+    newsletter.stories.append(story)
+    return story
+
+
+def split_story(newsletter, index, split_at):
+    """Split an over-merged candidate into two at the first occurrence of
+    *split_at* within its text.
+
+    The second story begins at *split_at* (marker kept in the tail). Both
+    halves inherit the original title; ids are reindexed on confirm.
+    """
+    story = newsletter.stories[index]
+    pos = story.text.find(split_at)
+    if pos < 0:
+        return  # marker not found — leave unchanged
+    head = story.text[:pos].strip()
+    tail = story.text[pos:].strip()
+    story.text = head
+    new_story = GoldenStory(
+        story_id=f"{newsletter.thread_id}:{index + 1}",
+        title=story.title,
+        text=tail,
+    )
+    newsletter.stories.insert(index + 1, new_story)
+    return new_story
+
+
+def merge_stories(newsletter, index):
+    """Merge the candidate at *index* with its immediate successor.
+
+    Texts are joined with a newline; the merged story keeps the first story's
+    title. Ids are reindexed on confirm.
+    """
+    if index + 1 >= len(newsletter.stories):
+        return
+    first = newsletter.stories[index]
+    second = newsletter.stories.pop(index + 1)
+    first.text = f"{first.text}\n{second.text}"
+
+
+def edit_story(newsletter, index, *, title=None, text=None):
+    """Edit a candidate's title and/or text span. Unspecified fields are kept."""
+    story = newsletter.stories[index]
+    if title is not None:
+        story.title = title
+    if text is not None:
+        story.text = text
+
+
+def delete_story(newsletter, index):
+    """Remove a wrongly-extracted candidate entirely (not the same as exclude).
+
+    Leaves ``newsletter.reviewed`` untouched; ids are reindexed on confirm.
+    """
+    newsletter.stories.pop(index)
+
+
+def confirm_story_list(newsletter):
+    """Confirm the curated story list as authoritative extraction truth.
+
+    Reindexes story ids to be contiguous and marks the newsletter reviewed.
+    """
+    _reindex_story_ids(newsletter)
+    newsletter.reviewed = True
+
+
+# ---------------------------------------------------------------------------
+# Pure state transitions (Phase B — per-story labels)
+# ---------------------------------------------------------------------------
+
+def assign_scores_and_themes(story, scores, themes):
+    """Assign the 4 dimension scores + themes to a story and confirm it.
+
+    ``expected_tier`` is auto-derived from *scores* via ``compute_tier``; the
+    story is marked reviewed. *scores*/*themes* are copied so later mutation of
+    the caller's objects does not alias into the golden set.
+    """
+    story.expected_scores = dict(scores)
+    story.expected_themes = list(themes)
+    story.expected_tier = compute_tier(scores).value
+    story.reviewed = True
+
+
+def exclude_story(story):
+    """Keep a story as extraction truth but drop it from quality/theme scoring.
+
+    A *wrongly-extracted* candidate should be deleted (``delete_story``); this
+    is for real stories that are simply unsuitable for grading.
+    """
+    story.excluded = True
+
+
+# ---------------------------------------------------------------------------
+# Undo
+# ---------------------------------------------------------------------------
+
+# Mutable newsletter-level fields captured for undo (stories handled separately)
+_NL_SNAPSHOT_FIELDS = ("seeded_from", "reviewed", "notes", "excluded")
+
+
+def capture_snapshot(newsletter):
+    """Deep-copy a newsletter's mutable state so a later edit can be undone.
+
+    One snapshot per newsletter; captures the full story list plus the
+    newsletter-level mutable fields.
+    """
+    return {
+        "stories": [copy.deepcopy(s) for s in newsletter.stories],
+        **{f: getattr(newsletter, f) for f in _NL_SNAPSHOT_FIELDS},
+    }
+
+
+def restore_snapshot(newsletter, snapshot):
+    """Restore a newsletter in place from *snapshot* (see ``capture_snapshot``)."""
+    newsletter.stories = [copy.deepcopy(s) for s in snapshot["stories"]]
+    for f in _NL_SNAPSHOT_FIELDS:
+        setattr(newsletter, f, snapshot[f])
+
+
+# ---------------------------------------------------------------------------
+# Queue selection
+# ---------------------------------------------------------------------------
+
+def select_label_newsletters(newsletters, *, unreviewed_only=False):
+    """Newsletters to queue for labeling.
+
+    Excluded newsletters are permanently set aside and never queued, regardless
+    of *unreviewed_only*.
+    """
+    result = [n for n in newsletters if not n.excluded]
+    if unreviewed_only:
+        result = [n for n in result if not n.reviewed]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Phase-A seed extractor (real LLM; injected for tests)
+# ---------------------------------------------------------------------------
+
+def build_extractor(config: dict):
+    """Build a synchronous ``extract_fn(body) -> raw_str`` for Phase-A seeding.
+
+    Wraps the production newsletter story-extraction LLM call, returning the
+    *raw* extraction string (not parsed) so ``seed_from_extractor`` can run it
+    through ``parse_stories`` exactly like production. Kept separate from the
+    pure functions so tests inject a fake extractor and never hit the network.
+    """
+    from daemon import resolve_newsletter_llm_endpoint
+    from llm_client import LLMClient
+    from newsletter import NewsletterClassifier
+
+    base_url, api_key = resolve_newsletter_llm_endpoint()
+    nl_llm = config["newsletter"]["llm"]
+    client = LLMClient(
+        base_url=base_url,
+        api_key=api_key,
+        model=nl_llm["model"],
+        temperature=nl_llm.get("temperature", 0.0),
+        max_tokens=nl_llm.get("max_tokens", 2048),
+        extra_body=nl_llm.get("extra_body"),
+    )
+    classifier = NewsletterClassifier(client, config)
+    extraction_config = classifier.extraction_config
+
+    def extract_fn(body: str) -> str:
+        user_content = extraction_config["user_template"].format(body=body)
+
+        async def _run():
+            raw, _ = await client.complete(
+                extraction_config["system"], user_content, include_thinking=True
+            )
+            return raw
+
+        return asyncio.run(_run())
+
+    return extract_fn
+
+
+# ---------------------------------------------------------------------------
+# Curses helpers (mirroring evals.edit_tui)
+# ---------------------------------------------------------------------------
+
+def _safe_addstr(win, y, x, text, attr=curses.A_NORMAL):
+    max_y, max_x = win.getmaxyx()
+    if y < 0 or y >= max_y or x >= max_x:
+        return
+    available = max_x - x - 1
+    if available <= 0:
+        return
+    win.addnstr(y, x, text, available, attr)
+
+
+def _prompt_line(stdscr, prompt: str) -> str:
+    """Read a line of text at the bottom of the screen (Enter-terminated)."""
+    max_y, max_x = stdscr.getmaxyx()
+    _safe_addstr(stdscr, max_y - 1, 0, " " * (max_x - 1))
+    _safe_addstr(stdscr, max_y - 1, 0, prompt, curses.A_REVERSE)
+    stdscr.refresh()
+    curses.echo()
+    curses.curs_set(1)
+    try:
+        raw = stdscr.getstr(max_y - 1, len(prompt) + 1)
+    finally:
+        curses.noecho()
+        curses.curs_set(0)
+    return raw.decode("utf-8", "replace").strip()
+
+
+def _newsletter_lines(newsletter, index, total) -> list[str]:
+    lines = [
+        f"Newsletter {index + 1}/{total}  (id: {newsletter.thread_id})",
+        "=" * 60,
+        f"Subject:  {newsletter.subject}",
+        f"Sender:   {newsletter.sender}",
+        f"Reviewed: {newsletter.reviewed}",
+        f"Seeded:   {newsletter.seeded_from or '-'}",
+    ]
+    if newsletter.notes:
+        lines.append(f"Notes:    {newsletter.notes}")
+    lines.append("")
+    lines.append(f"--- Stories ({len(newsletter.stories)}) ---")
+    for i, s in enumerate(newsletter.stories):
+        flags = []
+        if s.excluded:
+            flags.append("EXCLUDED")
+        if s.reviewed:
+            flags.append(s.expected_tier or "reviewed")
+        flag_str = f"  [{', '.join(flags)}]" if flags else ""
+        lines.append(f"[{i}] {s.title}{flag_str}")
+        lines.append(f"    themes: {', '.join(s.expected_themes) or '-'}")
+    lines.append("")
+    lines.append("--- Body ---")
+    lines.extend(newsletter.body.splitlines())
+    return lines
+
+
+def _prompt_scores(stdscr) -> dict[str, int] | None:
+    """Prompt for the 4 dimension scores 1-5. Returns None on cancel."""
+    scores = {}
+    for dim in _DIMENSIONS:
+        max_y, max_x = stdscr.getmaxyx()
+        prompt = f"{dim} [1-5] (other cancels): "
+        _safe_addstr(stdscr, max_y - 1, 0, " " * (max_x - 1))
+        _safe_addstr(stdscr, max_y - 1, 0, prompt, curses.A_REVERSE)
+        stdscr.refresh()
+        key = stdscr.getch()
+        ch = chr(key) if 0 <= key < 256 else ""
+        if ch not in "12345":
+            return None
+        scores[dim] = int(ch)
+    return scores
+
+
+def _prompt_themes(stdscr) -> list[str]:
+    """Multi-select themes by toggling s/c/h/v/d; Enter to finish."""
+    selected: list[str] = []
+    while True:
+        max_y, max_x = stdscr.getmaxyx()
+        legend = "  ".join(f"[{k}]{v}" for k, v in _THEME_KEYS.items())
+        prompt = f"Themes {selected}: {legend}  Enter=done"
+        _safe_addstr(stdscr, max_y - 1, 0, " " * (max_x - 1))
+        _safe_addstr(stdscr, max_y - 1, 0, prompt, curses.A_REVERSE)
+        stdscr.refresh()
+        key = stdscr.getch()
+        if key in (curses.KEY_ENTER, ord("\n"), ord("\r")):
+            return selected
+        ch = chr(key).lower() if 0 <= key < 256 else ""
+        if ch in _THEME_KEYS:
+            theme = _THEME_KEYS[ch]
+            if theme in selected:
+                selected.remove(theme)
+            else:
+                selected.append(theme)
+
+
+# ---------------------------------------------------------------------------
+# Detail view — Phase A (curate) then Phase B (label) for one newsletter
+# ---------------------------------------------------------------------------
+
+def _newsletter_detail(stdscr, newsletters, index, all_newsletters, path, *, extract_fn=None):
+    """Curate + label one newsletter. Returns "back" or "quit"."""
+    newsletter = newsletters[index]
+    total = len(newsletters)
+    scroll_y = 0
+    snapshot = None  # one snapshot per newsletter for undo
+
+    def save():
+        _auto_save(all_newsletters, path, stdscr)
+
+    while True:
+        lines = _newsletter_lines(newsletter, index, total)
+        max_y, max_x = stdscr.getmaxyx()
+        content_rows = max(1, max_y - 2)
+        stdscr.clear()
+        for row_i in range(content_rows):
+            li = scroll_y + row_i
+            if li >= len(lines):
+                break
+            _safe_addstr(stdscr, row_i, 0, lines[li])
+        help_text = (
+            "[Space]seed [a]dd [e]dit [x]split [m]erge [d]el [c]onfirm "
+            "[l]abel [u]nexclude/exclude [n]notes [z]undo Esc:Back q:Quit"
+        )
+        _safe_addstr(stdscr, max_y - 2, 0, help_text, curses.A_DIM)
+        max_scroll = max(0, len(lines) - content_rows)
+        stdscr.refresh()
+
+        key = stdscr.getch()
+
+        if key == curses.KEY_UP and scroll_y > 0:
+            scroll_y -= 1
+        elif key == curses.KEY_DOWN and scroll_y < max_scroll:
+            scroll_y += 1
+        elif key == curses.KEY_NPAGE:
+            scroll_y = min(max_scroll, scroll_y + content_rows)
+        elif key == curses.KEY_PPAGE:
+            scroll_y = max(0, scroll_y - content_rows)
+
+        elif key == ord(" "):  # seed via extractor
+            if extract_fn is not None:
+                snapshot = capture_snapshot(newsletter)
+                try:
+                    seed_from_extractor(newsletter, extract_fn)
+                    save()
+                except Exception as exc:
+                    _safe_addstr(stdscr, max_y - 1, 0, f"Seed failed: {exc}", curses.A_REVERSE)
+                    stdscr.refresh()
+                    stdscr.getch()
+
+        elif key == ord("a"):  # add story
+            snapshot = capture_snapshot(newsletter)
+            title = _prompt_line(stdscr, "New title:")
+            text = _prompt_line(stdscr, "New text:")
+            if title and text:
+                add_story(newsletter, title, text)
+                save()
+
+        elif key == ord("e"):  # edit story
+            snapshot = capture_snapshot(newsletter)
+            si = _prompt_index(stdscr, newsletter)
+            if si is not None:
+                title = _prompt_line(stdscr, "Title (blank=keep):")
+                text = _prompt_line(stdscr, "Text (blank=keep):")
+                edit_story(
+                    newsletter, si,
+                    title=title or None,
+                    text=text or None,
+                )
+                save()
+
+        elif key == ord("x"):  # split
+            snapshot = capture_snapshot(newsletter)
+            si = _prompt_index(stdscr, newsletter)
+            if si is not None:
+                marker = _prompt_line(stdscr, "Split at text:")
+                if marker:
+                    split_story(newsletter, si, marker)
+                    save()
+
+        elif key == ord("m"):  # merge with successor
+            snapshot = capture_snapshot(newsletter)
+            si = _prompt_index(stdscr, newsletter)
+            if si is not None:
+                merge_stories(newsletter, si)
+                save()
+
+        elif key == ord("d"):  # delete
+            snapshot = capture_snapshot(newsletter)
+            si = _prompt_index(stdscr, newsletter)
+            if si is not None:
+                delete_story(newsletter, si)
+                save()
+
+        elif key == ord("c"):  # confirm story list (Phase A done)
+            snapshot = capture_snapshot(newsletter)
+            confirm_story_list(newsletter)
+            save()
+
+        elif key == ord("l"):  # label a story (Phase B)
+            si = _prompt_index(stdscr, newsletter)
+            if si is not None:
+                snapshot = capture_snapshot(newsletter)
+                scores = _prompt_scores(stdscr)
+                if scores is not None:
+                    themes = _prompt_themes(stdscr)
+                    assign_scores_and_themes(newsletter.stories[si], scores, themes)
+                    save()
+
+        elif key == ord("u"):  # toggle exclude on a story
+            si = _prompt_index(stdscr, newsletter)
+            if si is not None:
+                snapshot = capture_snapshot(newsletter)
+                story = newsletter.stories[si]
+                story.excluded = not story.excluded
+                save()
+
+        elif key == ord("n"):  # newsletter notes
+            snapshot = capture_snapshot(newsletter)
+            newsletter.notes = _prompt_line(stdscr, "Notes:")
+            save()
+
+        elif key == ord("z"):  # undo one snapshot
+            if snapshot is not None:
+                restore_snapshot(newsletter, snapshot)
+                snapshot = None
+                save()
+
+        elif key == 27:  # Esc
+            return "back"
+        elif key == ord("q"):
+            return "quit"
+
+
+def _prompt_index(stdscr, newsletter) -> int | None:
+    """Prompt for a story index; return it or None if out of range/blank."""
+    raw = _prompt_line(stdscr, "Story #:")
+    if not raw.isdigit():
+        return None
+    si = int(raw)
+    if 0 <= si < len(newsletter.stories):
+        return si
+    return None
+
+
+def _auto_save(all_newsletters, path, stdscr) -> None:
+    try:
+        save_golden_set(all_newsletters, path)
+    except Exception as exc:
+        max_y, _ = stdscr.getmaxyx()
+        _safe_addstr(stdscr, max_y - 1, 0, f"Save failed: {exc}", curses.A_REVERSE)
+        stdscr.refresh()
+        stdscr.getch()
+
+
+# ---------------------------------------------------------------------------
+# List view + loop
+# ---------------------------------------------------------------------------
+
+def _list_view(stdscr, newsletters, all_newsletters, path, *, extract_fn=None):
+    cursor = 0
+    scroll_offset = 0
+    while True:
+        max_y, max_x = stdscr.getmaxyx()
+        page_size = max(1, max_y - 3)
+        stdscr.clear()
+        _safe_addstr(stdscr, 0, 0, f"Newsletter Label — {len(newsletters)} newsletters",
+                     curses.A_BOLD)
+        _safe_addstr(stdscr, 1, 0, f"{'R':<2}  {'Stories':<8}  Subject", curses.A_UNDERLINE)
+        for vi in range(page_size):
+            ti = scroll_offset + vi
+            if ti >= len(newsletters):
+                break
+            n = newsletters[ti]
+            r = "Y" if n.reviewed else " "
+            row = f"{r:<2}  {len(n.stories):<8}  {n.subject}"
+            attr = curses.A_REVERSE if ti == cursor else curses.A_NORMAL
+            _safe_addstr(stdscr, 2 + vi, 0, row, attr)
+        _safe_addstr(stdscr, max_y - 1, 0,
+                     "↑/↓:Nav  Enter:Open  q:Quit", curses.A_DIM)
+        stdscr.refresh()
+
+        key = stdscr.getch()
+        if key == curses.KEY_UP and cursor > 0:
+            cursor -= 1
+            if cursor < scroll_offset:
+                scroll_offset = cursor
+        elif key == curses.KEY_DOWN and cursor < len(newsletters) - 1:
+            cursor += 1
+            if cursor >= scroll_offset + page_size:
+                scroll_offset = cursor - page_size + 1
+        elif key in (curses.KEY_ENTER, ord("\n"), ord("\r")):
+            result = _newsletter_detail(
+                stdscr, newsletters, cursor, all_newsletters, path, extract_fn=extract_fn
+            )
+            if result == "quit":
+                return
+        elif key == ord("q"):
+            return
+
+
+def _curses_main(stdscr, newsletters, all_newsletters, path, extract_fn):
+    curses.curs_set(0)
+    stdscr.keypad(True)
+    _list_view(stdscr, newsletters, all_newsletters, path, extract_fn=extract_fn)
+
+
+def label_loop(newsletters, all_newsletters, path, *, extract_fn=None):
+    """Launch the curses labeling TUI. Saving is atomic + auto on each edit."""
+    if not newsletters:
+        print("No newsletters to label.")
+        return
+    curses.wrapper(_curses_main, newsletters, all_newsletters, path, extract_fn)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def cli():
+    parser = argparse.ArgumentParser(description="Label newsletter golden set (curate + score)")
+    parser.add_argument(
+        "--golden-set", default="evals/newsletter_golden_set.jsonl",
+        help="Path to newsletter golden set JSONL",
+    )
+    parser.add_argument("--edit", action="store_true",
+                        help="Edit mode: no LLM seeding (curate/label existing stories)")
+    parser.add_argument("--unreviewed-only", action="store_true",
+                        help="Queue only unreviewed newsletters")
+    parser.add_argument("--config", help="Path to config.toml (default: ./config.toml)")
+    args = parser.parse_args()
+
+    path = Path(args.golden_set)
+    if not path.exists():
+        print(f"Golden set not found: {path}", file=sys.stderr)
+        print("Run 'python -m evals.newsletter_harvest' first to create it.", file=sys.stderr)
+        sys.exit(1)
+
+    all_newsletters = load_golden_set(path)
+    if not all_newsletters:
+        print("Golden set is empty.", file=sys.stderr)
+        sys.exit(1)
+
+    newsletters = select_label_newsletters(all_newsletters, unreviewed_only=args.unreviewed_only)
+    if not newsletters:
+        print("No newsletters match the filters.", file=sys.stderr)
+        sys.exit(0)
+
+    # Build the Phase-A seed extractor unless --edit (edit mode never hits an LLM).
+    extract_fn = None
+    if not args.edit:
+        from evals.newsletter_harvest import load_eval_config
+
+        extract_fn = build_extractor(load_eval_config(args.config))
+
+    label_loop(newsletters, all_newsletters, path, extract_fn=extract_fn)
+
+    # The TUI auto-saves on each edit; save once more so a monkeypatched loop
+    # (and any final in-memory state) is persisted. Saving all_newsletters keeps
+    # excluded/filtered-out newsletters and their order untouched.
+    save_golden_set(all_newsletters, path)
+
+    reviewed_count = sum(1 for n in newsletters if n.reviewed)
+    print(f"\nSaved. {reviewed_count}/{len(newsletters)} newsletters reviewed.")
+
+
+if __name__ == "__main__":
+    cli()

--- a/evals/newsletter_report.py
+++ b/evals/newsletter_report.py
@@ -111,11 +111,13 @@ def compute_all_metrics(
 ) -> dict:
     """Bundle every metric section for a single run."""
     return {
+        "story_count": len(story_results),
         "tier": compute_tier_metrics(story_results),
         "dimension_mae": compute_dimension_mae(story_results),
         "dimension_exact": compute_dimension_exact_match(story_results),
         "dimension_within1": compute_dimension_within1(story_results),
         "themes": compute_multilabel_metrics(story_results, THEMES),
+        "theme_anomalies": theme_parse_anomalies(story_results),
         "extraction": compute_extraction_metrics(
             extraction_results or [], threshold=match_threshold
         ),
@@ -129,8 +131,11 @@ def compute_extraction_metrics(
     """Extraction metrics aggregated over newsletters.
 
     Per newsletter: precision = matched/predicted, recall = matched/golden via
-    greedy one-to-one match_stories. Aggregate as micro (pooled counts) and macro
-    (mean of per-newsletter precision/recall).
+    greedy one-to-one match_stories. A newsletter with 0 predicted and 0 golden
+    stories is a correct abstention (precision = recall = 1.0). Aggregate as micro
+    (pooled counts) and macro (mean of per-newsletter precision/recall). All
+    aggregates are None when there are no scored newsletters, so empty sections
+    render as N/A rather than a fake 0.0%.
     """
     total_matched = total_pred = total_gold = 0
     per_nl_precision: list[float] = []
@@ -146,8 +151,10 @@ def compute_extraction_metrics(
         total_matched += matched
         total_pred += n_pred
         total_gold += n_gold
-        p = matched / n_pred if n_pred > 0 else 0.0
-        rec = matched / n_gold if n_gold > 0 else 0.0
+        # 0/0 = correct abstention, not a zero: the model was right to predict
+        # nothing for a story-less newsletter.
+        p = matched / n_pred if n_pred > 0 else (1.0 if n_gold == 0 else 0.0)
+        rec = matched / n_gold if n_gold > 0 else (1.0 if n_pred == 0 else 0.0)
         per_nl_precision.append(p)
         per_nl_recall.append(rec)
         per_newsletter.append({
@@ -159,13 +166,25 @@ def compute_extraction_metrics(
             "recall": rec,
         })
 
-    micro_p = total_matched / total_pred if total_pred > 0 else 0.0
-    micro_r = total_matched / total_gold if total_gold > 0 else 0.0
+    if not per_newsletter:
+        return {
+            "micro_precision": None,
+            "micro_recall": None,
+            "micro_f1": None,
+            "macro_precision": None,
+            "macro_recall": None,
+            "macro_f1": None,
+            "count": 0,
+            "per_newsletter": [],
+        }
+
+    micro_p = total_matched / total_pred if total_pred > 0 else 1.0
+    micro_r = total_matched / total_gold if total_gold > 0 else 1.0
     micro_f1 = (
         2 * micro_p * micro_r / (micro_p + micro_r) if (micro_p + micro_r) > 0 else 0.0
     )
-    macro_p = sum(per_nl_precision) / len(per_nl_precision) if per_nl_precision else 0.0
-    macro_r = sum(per_nl_recall) / len(per_nl_recall) if per_nl_recall else 0.0
+    macro_p = sum(per_nl_precision) / len(per_nl_precision)
+    macro_r = sum(per_nl_recall) / len(per_nl_recall)
     macro_f1 = (
         2 * macro_p * macro_r / (macro_p + macro_r) if (macro_p + macro_r) > 0 else 0.0
     )
@@ -182,6 +201,19 @@ def compute_extraction_metrics(
     }
 
 
+def _theme_scored(r: StoryPrediction) -> bool:
+    """Whether a row's own theme call succeeded (independent of quality parsing).
+
+    A row participates in theme metrics iff it has no error and the theme
+    response exists (themes_raw recorded, or — for legacy rows without
+    themes_raw — a non-empty parsed prediction). A quality-parse failure must
+    NOT drop a story whose themes parsed fine.
+    """
+    if r.error is not None:
+        return False
+    return r.themes_raw is not None or bool(r.predicted_themes)
+
+
 def compute_multilabel_metrics(
     results: list[StoryPrediction],
     themes: list[str],
@@ -189,11 +221,26 @@ def compute_multilabel_metrics(
     """Multi-label theme metrics.
 
     Each theme is an independent binary label (present/absent) derived from the
-    expected_themes vs predicted_themes sets. Parse-failure rows (predicted_scores
-    is None) are excluded. Returns per-theme P/R/F1, micro-F1, macro-F1, and
-    exact-set-match (fraction where set(expected) == set(predicted)).
+    expected_themes vs predicted_themes sets. Rows whose own theme call failed
+    (see _theme_scored) are excluded; a quality-parse failure alone is not.
+    Returns per-theme P/R/F1, micro-F1, macro-F1, and exact-set-match (fraction
+    where set(expected) == set(predicted)). Aggregates are None when no rows
+    were scored, so empty sections render as N/A rather than a fake 0.0%.
     """
-    scored = [r for r in results if r.predicted_scores is not None]
+    scored = [r for r in results if _theme_scored(r)]
+
+    if not scored:
+        return {
+            "per_theme": {
+                t: {"precision": None, "recall": None, "f1": None} for t in themes
+            },
+            "micro_precision": None,
+            "micro_recall": None,
+            "micro_f1": None,
+            "macro_f1": None,
+            "exact_set_match": None,
+            "count": 0,
+        }
 
     per_theme: dict[str, dict[str, float]] = {}
     total_tp = total_fp = total_fn = 0
@@ -239,14 +286,34 @@ def compute_multilabel_metrics(
     }
 
 
+def _quality_attempted(r: StoryPrediction) -> bool:
+    """Whether the quality call ran (or failed) for this row.
+
+    A --mode themes run never fires the quality call: error=None AND
+    scores_raw=None AND predicted_scores=None means "never attempted", which
+    must be skipped — not counted as a parse failure. scores_raw captured (or
+    an error, or parsed scores) means quality was genuinely attempted.
+    """
+    return (
+        r.error is not None
+        or r.scores_raw is not None
+        or r.predicted_scores is not None
+    )
+
+
 def compute_tier_metrics(results: list[StoryPrediction]) -> dict:
     """Tier metrics over the 4 tier classes.
 
-    Rows whose predicted_scores is None are parse failures: counted as errors
-    and excluded from the confusion matrix / accuracy.
+    Rows where quality was attempted but predicted_scores is None are parse/
+    network failures: counted as errors and excluded from the confusion matrix
+    / accuracy. Their story_ids are returned under "error_stories" so failures
+    are identifiable in the report. Rows where quality was never attempted
+    (e.g. a --mode themes run: error=None, scores_raw=None) are skipped
+    entirely — neither scored nor errors.
     """
-    errors = [r for r in results if r.predicted_scores is None]
-    valid = [r for r in results if r.predicted_scores is not None]
+    attempted = [r for r in results if _quality_attempted(r)]
+    errors = [r for r in attempted if r.predicted_scores is None]
+    valid = [r for r in attempted if r.predicted_scores is not None]
 
     matrix = compute_confusion_matrix(valid, "expected_tier", "predicted_tier", TIERS)
     prf = compute_precision_recall_f1(matrix, TIERS)
@@ -261,28 +328,36 @@ def compute_tier_metrics(results: list[StoryPrediction]) -> dict:
         "per_class": prf,
         "count": len(scored),
         "errors": len(errors),
+        "error_stories": [r.story_id for r in errors],
     }
 
 
 def _normalize(story: dict) -> str:
-    """Lowercase, whitespace-collapse the story's title-or-text for matching."""
-    raw = story.get("title") or story.get("text") or ""
+    """Lowercase, whitespace-collapse the story's text-or-title for matching.
+
+    Text is the ground truth curated in the labeling TUI; titles are model-
+    invented wording. Matching must be on the extracted spans (text), falling
+    back to title only when a story has no text.
+    """
+    raw = story.get("text") or story.get("title") or ""
     return re.sub(r"\s+", " ", raw).strip().lower()
 
 
-def match_stories(
+def match_stories_detailed(
     predicted: list[dict],
     golden: list[dict],
     threshold: float = 0.6,
-) -> tuple[int, int, int]:
-    """Greedy one-to-one match of predicted stories to golden stories.
+) -> dict:
+    """Greedy one-to-one matching with full pair/unmatched detail.
 
     Uses difflib.SequenceMatcher ratio on normalized (lowercased,
-    whitespace-collapsed) title-or-text. Highest-ratio candidate pairs are
+    whitespace-collapsed) text-or-title. Highest-ratio candidate pairs are
     assigned first; each predicted and each golden story matches at most once.
 
     Returns:
-        (matched, n_predicted, n_golden)
+        {"matched": [{"pred_index", "gold_index", "ratio"}, ...],
+         "unmatched_predicted": [pred indices],
+         "unmatched_golden": [gold indices]}
     """
     pred_norm = [_normalize(p) for p in predicted]
     gold_norm = [_normalize(g) for g in golden]
@@ -299,15 +374,75 @@ def match_stories(
 
     used_pred: set[int] = set()
     used_gold: set[int] = set()
-    matched = 0
-    for _ratio, pi, gi in pairs:
+    matched: list[dict] = []
+    for ratio, pi, gi in pairs:
         if pi in used_pred or gi in used_gold:
             continue
         used_pred.add(pi)
         used_gold.add(gi)
-        matched += 1
+        matched.append({"pred_index": pi, "gold_index": gi, "ratio": ratio})
 
-    return matched, len(predicted), len(golden)
+    return {
+        "matched": matched,
+        "unmatched_predicted": [i for i in range(len(predicted)) if i not in used_pred],
+        "unmatched_golden": [i for i in range(len(golden)) if i not in used_gold],
+    }
+
+
+def match_stories(
+    predicted: list[dict],
+    golden: list[dict],
+    threshold: float = 0.6,
+) -> tuple[int, int, int]:
+    """Greedy one-to-one match count (see match_stories_detailed).
+
+    Returns:
+        (matched, n_predicted, n_golden)
+    """
+    detail = match_stories_detailed(predicted, golden, threshold=threshold)
+    return len(detail["matched"]), len(predicted), len(golden)
+
+
+def theme_parse_anomalies(results: list[StoryPrediction]) -> list[dict]:
+    """Detect theme responses that parse_themes silently normalized.
+
+    Two kinds, mirroring newsletter.parse_themes (one uppercase token per line,
+    unrecognized lines dropped, NONE -> []):
+
+    - "empty_parse": themes_raw is non-empty and not NONE, yet nothing parsed —
+      the model's output was unusable prose, not a genuine NONE.
+    - "invalid_tokens": some lines were not valid theme names and were silently
+      dropped (e.g. FELLOWSHIP) even though other lines parsed.
+
+    Rows without themes_raw (legacy files, error rows) are skipped.
+    """
+    valid_upper = {t.upper() for t in THEMES}
+    anomalies: list[dict] = []
+    for r in results:
+        if r.error is not None or r.themes_raw is None:
+            continue
+        raw = r.themes_raw.strip()
+        if not raw or raw.upper() == "NONE":
+            continue
+        invalid = [
+            line.strip() for line in raw.splitlines()
+            if line.strip() and line.strip().upper() not in valid_upper
+        ]
+        if not r.predicted_themes:
+            anomalies.append({
+                "story_id": r.story_id,
+                "kind": "empty_parse",
+                "invalid_tokens": invalid,
+                "themes_raw": r.themes_raw,
+            })
+        elif invalid:
+            anomalies.append({
+                "story_id": r.story_id,
+                "kind": "invalid_tokens",
+                "invalid_tokens": invalid,
+                "themes_raw": r.themes_raw,
+            })
+    return anomalies
 
 
 # --- Loading ---
@@ -340,6 +475,29 @@ def load_results(
     return meta, story_preds, extraction_preds
 
 
+def load_story_titles(golden_set_path: str) -> dict[str, str]:
+    """Best-effort story_id -> title map from the run's golden set file.
+
+    Results rows carry only story_ids; titles live in the golden set. Any
+    failure (moved/deleted file, malformed line) degrades to {} so verbose
+    output falls back to bare story_ids.
+    """
+    titles: dict[str, str] = {}
+    try:
+        with open(golden_set_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                d = json.loads(line)
+                for s in d.get("stories", []):
+                    if s.get("story_id") and s.get("title"):
+                        titles[s["story_id"]] = s["title"]
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return titles
+
+
 # --- Formatters ---
 
 def _format_dim_table(
@@ -347,7 +505,7 @@ def _format_dim_table(
     exact: dict[str, float | None],
     within1: dict[str, float | None],
 ) -> str:
-    widths = [max(len(d) for d in DIMENSIONS), 10, 12, 12]
+    widths = [max(len("Dimension"), *(len(d) for d in DIMENSIONS)), 10, 12, 12]
     lines = []
     lines.append("  " + format_table_row(["Dimension", "MAE", "Exact", "Within-1"], widths))
     lines.append("  " + "-" * sum(w + 2 for w in widths))
@@ -375,14 +533,26 @@ def _format_theme_table(themes: dict) -> str:
     return "\n".join(lines)
 
 
+def _plural(n: int, word: str) -> str:
+    if n == 1:
+        return f"1 {word}"
+    plural = word[:-1] + "ies" if word.endswith("y") else word + "s"
+    return f"{n} {plural}"
+
+
 def print_report(
     meta: NewsletterRunMeta,
     metrics: dict,
     verbose: bool = False,
     story_results: list[StoryPrediction] | None = None,
     extraction_results: list[ExtractionPrediction] | None = None,
+    match_threshold: float = 0.6,
 ) -> None:
-    """Print a formatted single-run report to stdout."""
+    """Print a formatted single-run report to stdout.
+
+    match_threshold must be the same threshold the metrics were computed with,
+    so verbose extraction diffs agree with the headline numbers.
+    """
     print(f"\n{'=' * 60}")
     print(f"Newsletter Evaluation Report: {meta.run_id[:8]}")
     print(f"{'=' * 60}")
@@ -395,35 +565,51 @@ def print_report(
         print(f"  Tag:          {meta.tag}")
     if meta.seeded_from:
         print(f"  Seeded from:  {meta.seeded_from}")
+    print(f"  Golden set:   {meta.golden_set_path}")
     print(f"  Newsletters:  {meta.golden_set_count}")
     print(f"  Stories:      {meta.story_count}")
+
+    # Sections with zero underlying predictions are omitted (mirroring the tier
+    # section) instead of rendering as a fake 0.0%.
+    has_story_rows = bool(metrics.get("story_count", len(story_results or [])))
 
     tier = metrics["tier"]
     if tier["count"] or tier["errors"]:
         print("\n--- Tier Classification (4-class) ---")
         print(f"  Accuracy: {format_pct(tier['accuracy'])} "
-              f"({tier['count']} stories, {tier['errors']} errors)")
+              f"({_plural(tier['count'], 'story')}, {_plural(tier['errors'], 'error')})")
+        if tier["error_stories"]:
+            print(f"  Failed stories (quality parse/network): "
+                  f"{', '.join(tier['error_stories'])}")
         print("\n  Confusion matrix:")
         print(format_confusion_matrix(tier["confusion_matrix"], TIERS))
         print("\n  Per-class metrics:")
         print(format_per_class_table(tier["per_class"], TIERS))
 
-    print("\n--- Quality Dimensions ---")
-    print(_format_dim_table(
-        metrics["dimension_mae"], metrics["dimension_exact"], metrics["dimension_within1"]
-    ))
+    if has_story_rows:
+        print("\n--- Quality Dimensions ---")
+        print(_format_dim_table(
+            metrics["dimension_mae"], metrics["dimension_exact"],
+            metrics["dimension_within1"],
+        ))
 
-    themes = metrics["themes"]
-    print("\n--- Themes (multi-label) ---")
-    print(f"  Micro-F1: {format_pct(themes['micro_f1'])}   "
-          f"Macro-F1: {format_pct(themes['macro_f1'])}   "
-          f"Exact-set match: {format_pct(themes['exact_set_match'])}")
-    print()
-    print(_format_theme_table(themes))
+        themes = metrics["themes"]
+        print("\n--- Themes (multi-label) ---")
+        print(f"  Micro-F1: {format_pct(themes['micro_f1'])}   "
+              f"Macro-F1: {format_pct(themes['macro_f1'])}   "
+              f"Exact-set match: {format_pct(themes['exact_set_match'])}")
+        anomalies = metrics.get("theme_anomalies", [])
+        if anomalies:
+            print(f"  Parse anomalies: {_plural(len(anomalies), 'story')} "
+                  f"(invalid/unparseable theme output; --verbose shows raw)")
+        print()
+        print(_format_theme_table(themes))
 
     extraction = metrics["extraction"]
     if extraction["count"]:
         print("\n--- Extraction ---")
+        print(f"  ({_plural(extraction['count'], 'newsletter')}, "
+              f"match threshold {match_threshold})")
         print(f"  Micro:  P={format_pct(extraction['micro_precision'])} "
               f"R={format_pct(extraction['micro_recall'])} "
               f"F1={format_pct(extraction['micro_f1'])}")
@@ -432,42 +618,116 @@ def print_report(
               f"F1={format_pct(extraction['macro_f1'])}")
 
     if verbose:
-        _print_verbose_single(story_results or [], extraction_results or [])
+        _print_verbose_single(
+            story_results or [],
+            extraction_results or [],
+            match_threshold=match_threshold,
+            titles=load_story_titles(meta.golden_set_path),
+            anomalies=metrics.get("theme_anomalies", []),
+        )
 
     print()
+
+
+def _story_label(story: dict) -> str:
+    """Human-readable story identifier: the title, else a text excerpt."""
+    title = (story.get("title") or "").strip()
+    if title:
+        return title
+    text = re.sub(r"\s+", " ", story.get("text") or "").strip()
+    return text[:57] + "..." if len(text) > 60 else text
 
 
 def _print_verbose_single(
     story_results: list[StoryPrediction],
     extraction_results: list[ExtractionPrediction],
+    match_threshold: float = 0.6,
+    titles: dict[str, str] | None = None,
+    anomalies: list[dict] | None = None,
 ) -> None:
+    titles = titles or {}
+
+    def label(story_id: str) -> str:
+        title = titles.get(story_id)
+        return f"{story_id} ({title})" if title else story_id
+
     print("\n--- Story Disagreements ---")
-    disagreements = [
-        r for r in story_results
-        if r.predicted_scores is not None
-        and (r.expected_tier != r.predicted_tier
-             or set(r.expected_themes or []) != set(r.predicted_themes or []))
-    ]
+    # A row is compared field-by-field on whatever DID parse: tiers only when
+    # quality parsed, themes only when the theme call succeeded — so a quality
+    # parse failure can't hide a theme disagreement.
+    disagreements = []
+    for r in story_results:
+        if r.error is not None:
+            continue
+        tier_diff = r.predicted_scores is not None and r.expected_tier != r.predicted_tier
+        theme_diff = _theme_scored(r) and (
+            set(r.expected_themes or []) != set(r.predicted_themes or [])
+        )
+        if tier_diff or theme_diff:
+            disagreements.append((r, tier_diff, theme_diff))
     if not disagreements:
         print("  None!")
-    for r in disagreements:
-        parts = [f"  {r.story_id}:"]
-        if r.expected_tier != r.predicted_tier:
+    for r, tier_diff, theme_diff in disagreements:
+        parts = [f"  {label(r.story_id)}:"]
+        if tier_diff:
             parts.append(f"tier={r.expected_tier}->{r.predicted_tier}")
-        exp_th = set(r.expected_themes or [])
-        pred_th = set(r.predicted_themes or [])
-        if exp_th != pred_th:
-            parts.append(f"themes={sorted(exp_th)}->{sorted(pred_th)}")
+        if theme_diff:
+            parts.append(f"themes={sorted(set(r.expected_themes or []))}"
+                         f"->{sorted(set(r.predicted_themes or []))}")
         print(" ".join(parts))
 
+    # "Never attempted" rows (e.g. --mode themes: no error, no scores_raw) are
+    # not failures — only attempted-but-unparsed or errored rows are listed.
+    failures = [
+        r for r in story_results
+        if _quality_attempted(r) and r.predicted_scores is None
+    ]
+    if failures:
+        print("\n--- Parse/Network Failures ---")
+        for r in failures:
+            print(f"  {label(r.story_id)}:")
+            if r.error is not None:
+                print(f"    error: {r.error}")
+            elif r.scores_raw is not None:
+                raw = "\n".join(f"    | {ln}" for ln in r.scores_raw.splitlines())
+                print("    quality response failed to parse; raw:")
+                print(raw)
+            else:
+                print("    quality response missing (no raw captured)")
+
+    if anomalies:
+        print("\n--- Theme Parse Anomalies ---")
+        for a in anomalies:
+            what = ("unparseable output (parsed to [])" if a["kind"] == "empty_parse"
+                    else f"invalid tokens dropped: {', '.join(a['invalid_tokens'])}")
+            print(f"  {label(a['story_id'])}: {what}")
+            raw = "\n".join(f"    | {ln}" for ln in a["themes_raw"].splitlines())
+            print(raw)
+
     if extraction_results:
-        print("\n--- Extraction Diffs (per newsletter) ---")
+        print(f"\n--- Extraction Diffs (per newsletter, threshold {match_threshold}) ---")
         for r in extraction_results:
             if r.error is not None:
                 print(f"  {r.thread_id}: ERROR {r.error}")
                 continue
-            matched, n_pred, n_gold = match_stories(r.predicted_stories, r.golden_stories)
-            print(f"  {r.thread_id}: matched={matched} predicted={n_pred} golden={n_gold}")
+            detail = match_stories_detailed(
+                r.predicted_stories, r.golden_stories, threshold=match_threshold
+            )
+            matched = detail["matched"]
+            n_pred, n_gold = len(r.predicted_stories), len(r.golden_stories)
+            print(f"  {r.thread_id}: matched={len(matched)} "
+                  f"predicted={n_pred} golden={n_gold}")
+            if len(matched) == n_pred == n_gold:
+                continue  # perfect match: counts line is enough
+            for pair in matched:
+                p = r.predicted_stories[pair["pred_index"]]
+                g = r.golden_stories[pair["gold_index"]]
+                print(f"    matched ({pair['ratio']:.2f}): "
+                      f"'{_story_label(p)}' ~ '{_story_label(g)}'")
+            for i in detail["unmatched_predicted"]:
+                print(f"    unmatched predicted: '{_story_label(r.predicted_stories[i])}'")
+            for i in detail["unmatched_golden"]:
+                print(f"    unmatched golden:    '{_story_label(r.golden_stories[i])}'")
 
 
 def print_comparison(
@@ -477,14 +737,21 @@ def print_comparison(
     story1: list[StoryPrediction] | None = None,
     story2: list[StoryPrediction] | None = None,
 ) -> None:
-    """Print a side-by-side comparison of two newsletter runs."""
+    """Print a side-by-side comparison of two newsletter runs.
+
+    Sections where a run has zero scored items render as N/A (not 0.0%), so a
+    mode-mismatched comparison can't fake a -100% regression.
+    """
     print(f"\n{'=' * 60}")
     print("Newsletter Comparison Report")
     print(f"{'=' * 60}")
-    print(f"  Run A: {meta1.run_id[:8]}  prompt_hash={meta1.prompt_hash or 'n/a'}  "
-          f"tag={meta1.tag or '-'}")
-    print(f"  Run B: {meta2.run_id[:8]}  prompt_hash={meta2.prompt_hash or 'n/a'}  "
-          f"tag={meta2.tag or '-'}")
+    print(f"  Run A: {meta1.run_id[:8]}  mode={meta1.mode}  "
+          f"prompt_hash={meta1.prompt_hash or 'n/a'}  tag={meta1.tag or '-'}")
+    print(f"  Run B: {meta2.run_id[:8]}  mode={meta2.mode}  "
+          f"prompt_hash={meta2.prompt_hash or 'n/a'}  tag={meta2.tag or '-'}")
+    if meta1.mode != meta2.mode:
+        print(f"\n  WARNING: run modes differ ({meta1.mode} vs {meta2.mode}); "
+              "sections absent from one run show N/A and deltas are not comparable.")
 
     widths = [22, 12, 12, 16]
 
@@ -498,12 +765,14 @@ def print_comparison(
             [label, format_pct(a), format_pct(b), format_metric_delta(a, b)], widths
         ))
 
-    # Tier
+    # Tier — per-class F1 is only meaningful when the run scored tier rows.
     ta, tb = metrics1["tier"], metrics2["tier"]
     header("Tier")
     pct_row("Accuracy", ta["accuracy"], tb["accuracy"])
     for cls in TIERS:
-        pct_row(f"  {cls} F1", ta["per_class"][cls]["f1"], tb["per_class"][cls]["f1"])
+        a_f1 = ta["per_class"][cls]["f1"] if ta["count"] else None
+        b_f1 = tb["per_class"][cls]["f1"] if tb["count"] else None
+        pct_row(f"  {cls} F1", a_f1, b_f1)
 
     # Dimensions (MAE, lower is better)
     header("Dimension MAE (lower=better)")
@@ -571,50 +840,117 @@ def report_as_json(meta: NewsletterRunMeta, metrics: dict) -> None:
     print(json.dumps({"meta": meta.to_dict(), "metrics": metrics}, indent=2))
 
 
-def print_trend(results_dir: Path, match_threshold: float = 0.6) -> None:
-    """Print a trend table across all result files in a directory."""
+def comparison_as_json(
+    meta1: NewsletterRunMeta, metrics1: dict,
+    meta2: NewsletterRunMeta, metrics2: dict,
+) -> None:
+    print(json.dumps({
+        "run_a": {"meta": meta1.to_dict(), "metrics": metrics1},
+        "run_b": {"meta": meta2.to_dict(), "metrics": metrics2},
+    }, indent=2))
+
+
+def build_trend_rows(
+    results_dir: Path, match_threshold: float = 0.6,
+) -> tuple[list[dict], list[str]]:
+    """Summary row per results file, sorted chronologically by run timestamp.
+
+    Returns (rows, errors): unreadable files land in errors as one-line
+    strings instead of aborting the whole trend.
+    """
     files = sorted(results_dir.glob("*.jsonl"))
     files = [f for f in files if not f.name.endswith(".cot.jsonl")]
-    if not files:
-        print(f"No result files found in {results_dir}", file=sys.stderr)
-        return
 
-    print(f"\n{'=' * 60}")
-    print(f"Newsletter Trend Report ({len(files)} runs)")
-    print(f"{'=' * 60}")
-
-    widths = [10, 10, 12, 10, 10, 12, 10]
-    print("  " + format_table_row(
-        ["Run ID", "Mode", "Tag", "TierAcc", "ThemeF1", "MAE(simple)", "ExtractF1"],
-        widths,
-    ))
-    print("  " + "-" * sum(w + 2 for w in widths))
-
+    rows: list[dict] = []
+    errors: list[str] = []
     for f in files:
         try:
             meta, story_preds, extraction_preds = load_results(f)
             metrics = compute_all_metrics(story_preds, extraction_preds, match_threshold)
-            mae_simple = metrics["dimension_mae"].get("simple")
-            mae_s = "N/A" if mae_simple is None else f"{mae_simple:.2f}"
-            print("  " + format_table_row([
-                meta.run_id[:8],
-                meta.mode,
-                meta.tag or meta.prompt_hash[:10],
-                format_pct(metrics["tier"]["accuracy"]),
-                format_pct(metrics["themes"]["micro_f1"]),
-                mae_s,
-                format_pct(metrics["extraction"]["micro_f1"]),
-            ], widths))
+            rows.append({
+                "file": f.name,
+                "run_id": meta.run_id,
+                "timestamp": meta.timestamp,
+                "mode": meta.mode,
+                "tag": meta.tag,
+                "prompt_hash": meta.prompt_hash,
+                "tier_accuracy": metrics["tier"]["accuracy"],
+                "theme_micro_f1": metrics["themes"]["micro_f1"],
+                "mae_simple": metrics["dimension_mae"].get("simple"),
+                "extraction_micro_f1": metrics["extraction"]["micro_f1"],
+            })
         except Exception as exc:
-            print(f"  Error reading {f.name}: {exc}", file=sys.stderr)
+            errors.append(f"Error reading {f.name}: {exc}")
+
+    rows.sort(key=lambda r: r["timestamp"])
+    return rows, errors
+
+
+def print_trend(results_dir: Path, match_threshold: float = 0.6) -> None:
+    """Print a trend table across all result files in a directory."""
+    rows, errors = build_trend_rows(results_dir, match_threshold)
+    for err in errors:
+        print(f"  {err}", file=sys.stderr)
+    if not rows:
+        print(f"No result files found in {results_dir}", file=sys.stderr)
+        return
+
+    print(f"\n{'=' * 60}")
+    print(f"Newsletter Trend Report ({len(rows)} runs)")
+    print(f"{'=' * 60}")
+
+    widths = [10, 16, 10, 12, 10, 10, 10, 12, 10]
+    print("  " + format_table_row(
+        ["Run ID", "Timestamp", "Mode", "Tag", "Prompt", "TierAcc", "ThemeF1",
+         "MAE(simple)", "ExtractF1"],
+        widths,
+    ))
+    print("  " + "-" * sum(w + 2 for w in widths))
+
+    for r in rows:
+        mae_simple = r["mae_simple"]
+        mae_s = "N/A" if mae_simple is None else f"{mae_simple:.2f}"
+        print("  " + format_table_row([
+            r["run_id"][:8],
+            r["timestamp"][:16],
+            r["mode"],
+            r["tag"] or "-",
+            r["prompt_hash"][:8],
+            format_pct(r["tier_accuracy"]),
+            format_pct(r["theme_micro_f1"]),
+            mae_s,
+            format_pct(r["extraction_micro_f1"]),
+        ], widths))
 
     print()
+
+
+def _load_results_or_exit(
+    path_str: str,
+) -> tuple[NewsletterRunMeta, list[StoryPrediction], list[ExtractionPrediction]]:
+    """load_results with a friendly one-line error + exit 1 instead of a traceback."""
+    path = Path(path_str)
+    try:
+        return load_results(path)
+    except FileNotFoundError:
+        print(f"Error: results file not found: {path}", file=sys.stderr)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"Error: could not read results file {path}: {exc}", file=sys.stderr)
+        if path.name.endswith(".cot.jsonl"):
+            print(
+                f"Hint: {path.name} looks like a chain-of-thought sidecar — "
+                f"pass the main results file ({path.name[:-len('.cot.jsonl')]}.jsonl).",
+                file=sys.stderr,
+            )
+    sys.exit(1)
 
 
 def cli():
     parser = argparse.ArgumentParser(description="Generate newsletter evaluation reports")
     parser.add_argument("--results", help="Path to results JSONL file")
-    parser.add_argument("--compare", nargs=2, metavar="PATH", help="Compare two result files")
+    parser.add_argument("--compare", nargs="+", metavar="PATH",
+                        help="Compare two result files (.cot.jsonl sidecars matched "
+                             "by a glob are ignored)")
     parser.add_argument("--results-dir", help="Directory of results for trend view")
     parser.add_argument("--verbose", action="store_true",
                         help="Show per-story flips and per-newsletter extraction diffs")
@@ -628,23 +964,53 @@ def cli():
         parser.error("Provide --results, --compare, or --results-dir")
 
     if args.results:
-        meta, story_preds, extraction_preds = load_results(Path(args.results))
+        meta, story_preds, extraction_preds = _load_results_or_exit(args.results)
         metrics = compute_all_metrics(story_preds, extraction_preds, args.match_threshold)
         if args.format == "json":
             report_as_json(meta, metrics)
         else:
             print_report(meta, metrics, verbose=args.verbose,
-                         story_results=story_preds, extraction_results=extraction_preds)
+                         story_results=story_preds, extraction_results=extraction_preds,
+                         match_threshold=args.match_threshold)
 
     elif args.compare:
-        meta1, s1, e1 = load_results(Path(args.compare[0]))
-        meta2, s2, e2 = load_results(Path(args.compare[1]))
+        # A glob like *baseline*.jsonl also matches the run's .cot.jsonl
+        # sidecar; drop sidecars so the documented glob workflow works.
+        sidecars = [p for p in args.compare if p.endswith(".cot.jsonl")]
+        compare_paths = [p for p in args.compare if not p.endswith(".cot.jsonl")]
+        if sidecars:
+            print(
+                "Note: ignoring chain-of-thought sidecar file(s): "
+                + ", ".join(sidecars),
+                file=sys.stderr,
+            )
+        if len(compare_paths) != 2:
+            parser.error(
+                f"--compare needs exactly two results files, got "
+                f"{len(compare_paths)} after ignoring .cot.jsonl sidecars: "
+                f"{', '.join(compare_paths) or '(none)'}"
+            )
+        meta1, s1, e1 = _load_results_or_exit(compare_paths[0])
+        meta2, s2, e2 = _load_results_or_exit(compare_paths[1])
         m1 = compute_all_metrics(s1, e1, args.match_threshold)
         m2 = compute_all_metrics(s2, e2, args.match_threshold)
-        print_comparison(meta1, m1, meta2, m2, verbose=args.verbose, story1=s1, story2=s2)
+        if args.format == "json":
+            comparison_as_json(meta1, m1, meta2, m2)
+        else:
+            print_comparison(meta1, m1, meta2, m2, verbose=args.verbose,
+                             story1=s1, story2=s2)
 
     elif args.results_dir:
-        print_trend(Path(args.results_dir), args.match_threshold)
+        if args.verbose:
+            print("Note: --verbose has no effect with --results-dir (trend view).",
+                  file=sys.stderr)
+        if args.format == "json":
+            rows, errors = build_trend_rows(Path(args.results_dir), args.match_threshold)
+            for err in errors:
+                print(f"  {err}", file=sys.stderr)
+            print(json.dumps(rows, indent=2))
+        else:
+            print_trend(Path(args.results_dir), args.match_threshold)
 
 
 if __name__ == "__main__":

--- a/evals/newsletter_report.py
+++ b/evals/newsletter_report.py
@@ -1,0 +1,651 @@
+"""Compute and display metrics from newsletter evaluation results.
+
+Usage:
+    python -m evals.newsletter_report --results evals/newsletter_results/run.jsonl
+    python -m evals.newsletter_report --compare run1.jsonl run2.jsonl
+    python -m evals.newsletter_report --results-dir evals/newsletter_results/
+    python -m evals.newsletter_report --results run.jsonl --verbose
+    python -m evals.newsletter_report --results run.jsonl --format json
+"""
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from pathlib import Path
+
+from evals.newsletter_schemas import (
+    ExtractionPrediction,
+    NewsletterRunMeta,
+    StoryPrediction,
+)
+from evals.report import (
+    compute_confusion_matrix,
+    compute_precision_recall_f1,
+    format_confusion_matrix,
+    format_pct,
+    format_per_class_table,
+    format_table_row,
+)
+
+TIERS = ["excellent", "good", "fair", "poor"]
+DIMENSIONS = ["simple", "concrete", "personal", "dynamic"]
+THEMES = ["scripture", "christlikeness", "church", "vocation_family", "disciple_making"]
+
+
+def _dimension_pairs(results: list[StoryPrediction], dim: str) -> list[tuple[int, int]]:
+    """(expected, predicted) pairs for a dimension over stories where both are present."""
+    pairs: list[tuple[int, int]] = []
+    for r in results:
+        if r.expected_scores is None or r.predicted_scores is None:
+            continue
+        if dim not in r.expected_scores or dim not in r.predicted_scores:
+            continue
+        pairs.append((r.expected_scores[dim], r.predicted_scores[dim]))
+    return pairs
+
+
+def compute_dimension_mae(results: list[StoryPrediction]) -> dict[str, float]:
+    """Mean absolute error per dimension over stories with both scores present."""
+    out: dict[str, float] = {}
+    for dim in DIMENSIONS:
+        pairs = _dimension_pairs(results, dim)
+        if pairs:
+            out[dim] = sum(abs(e - p) for e, p in pairs) / len(pairs)
+        else:
+            out[dim] = None
+    return out
+
+
+def compute_dimension_exact_match(results: list[StoryPrediction]) -> dict[str, float]:
+    """Fraction of exact-match predictions per dimension."""
+    out: dict[str, float] = {}
+    for dim in DIMENSIONS:
+        pairs = _dimension_pairs(results, dim)
+        if pairs:
+            out[dim] = sum(1 for e, p in pairs if e == p) / len(pairs)
+        else:
+            out[dim] = None
+    return out
+
+
+def compute_dimension_within1(results: list[StoryPrediction]) -> dict[str, float]:
+    """Fraction of predictions within 1 point of expected per dimension."""
+    out: dict[str, float] = {}
+    for dim in DIMENSIONS:
+        pairs = _dimension_pairs(results, dim)
+        if pairs:
+            out[dim] = sum(1 for e, p in pairs if abs(e - p) <= 1) / len(pairs)
+        else:
+            out[dim] = None
+    return out
+
+
+def format_metric_delta(a: float | None, b: float | None) -> str:
+    """Delta for a higher-is-better metric (accuracy, F1), formatted as a percent."""
+    if a is None or b is None:
+        return "N/A"
+    d = b - a
+    sign = "+" if d >= 0 else ""
+    return f"{sign}{d:.1%}"
+
+
+def format_mae_delta(a: float | None, b: float | None) -> str:
+    """Delta for MAE (lower-is-better).
+
+    Reports the raw signed change (b - a) and flags a decrease as an improvement.
+    """
+    if a is None or b is None:
+        return "N/A"
+    d = b - a
+    sign = "+" if d >= 0 else ""
+    label = " (improved)" if d < 0 else (" (worse)" if d > 0 else "")
+    return f"{sign}{d:.2f}{label}"
+
+
+def compute_all_metrics(
+    story_results: list[StoryPrediction],
+    extraction_results: list[ExtractionPrediction] | None = None,
+    match_threshold: float = 0.6,
+) -> dict:
+    """Bundle every metric section for a single run."""
+    return {
+        "tier": compute_tier_metrics(story_results),
+        "dimension_mae": compute_dimension_mae(story_results),
+        "dimension_exact": compute_dimension_exact_match(story_results),
+        "dimension_within1": compute_dimension_within1(story_results),
+        "themes": compute_multilabel_metrics(story_results, THEMES),
+        "extraction": compute_extraction_metrics(
+            extraction_results or [], threshold=match_threshold
+        ),
+    }
+
+
+def compute_extraction_metrics(
+    results: list[ExtractionPrediction],
+    threshold: float = 0.6,
+) -> dict:
+    """Extraction metrics aggregated over newsletters.
+
+    Per newsletter: precision = matched/predicted, recall = matched/golden via
+    greedy one-to-one match_stories. Aggregate as micro (pooled counts) and macro
+    (mean of per-newsletter precision/recall).
+    """
+    total_matched = total_pred = total_gold = 0
+    per_nl_precision: list[float] = []
+    per_nl_recall: list[float] = []
+    per_newsletter: list[dict] = []
+
+    for r in results:
+        if r.error is not None:
+            continue
+        matched, n_pred, n_gold = match_stories(
+            r.predicted_stories, r.golden_stories, threshold=threshold
+        )
+        total_matched += matched
+        total_pred += n_pred
+        total_gold += n_gold
+        p = matched / n_pred if n_pred > 0 else 0.0
+        rec = matched / n_gold if n_gold > 0 else 0.0
+        per_nl_precision.append(p)
+        per_nl_recall.append(rec)
+        per_newsletter.append({
+            "thread_id": r.thread_id,
+            "matched": matched,
+            "predicted": n_pred,
+            "golden": n_gold,
+            "precision": p,
+            "recall": rec,
+        })
+
+    micro_p = total_matched / total_pred if total_pred > 0 else 0.0
+    micro_r = total_matched / total_gold if total_gold > 0 else 0.0
+    micro_f1 = (
+        2 * micro_p * micro_r / (micro_p + micro_r) if (micro_p + micro_r) > 0 else 0.0
+    )
+    macro_p = sum(per_nl_precision) / len(per_nl_precision) if per_nl_precision else 0.0
+    macro_r = sum(per_nl_recall) / len(per_nl_recall) if per_nl_recall else 0.0
+    macro_f1 = (
+        2 * macro_p * macro_r / (macro_p + macro_r) if (macro_p + macro_r) > 0 else 0.0
+    )
+
+    return {
+        "micro_precision": micro_p,
+        "micro_recall": micro_r,
+        "micro_f1": micro_f1,
+        "macro_precision": macro_p,
+        "macro_recall": macro_r,
+        "macro_f1": macro_f1,
+        "count": len(per_newsletter),
+        "per_newsletter": per_newsletter,
+    }
+
+
+def compute_multilabel_metrics(
+    results: list[StoryPrediction],
+    themes: list[str],
+) -> dict:
+    """Multi-label theme metrics.
+
+    Each theme is an independent binary label (present/absent) derived from the
+    expected_themes vs predicted_themes sets. Parse-failure rows (predicted_scores
+    is None) are excluded. Returns per-theme P/R/F1, micro-F1, macro-F1, and
+    exact-set-match (fraction where set(expected) == set(predicted)).
+    """
+    scored = [r for r in results if r.predicted_scores is not None]
+
+    per_theme: dict[str, dict[str, float]] = {}
+    total_tp = total_fp = total_fn = 0
+    for theme in themes:
+        tp = fp = fn = 0
+        for r in scored:
+            exp = theme in set(r.expected_themes or [])
+            pred = theme in set(r.predicted_themes or [])
+            if exp and pred:
+                tp += 1
+            elif pred and not exp:
+                fp += 1
+            elif exp and not pred:
+                fn += 1
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+        per_theme[theme] = {"precision": precision, "recall": recall, "f1": f1}
+        total_tp += tp
+        total_fp += fp
+        total_fn += fn
+
+    micro_p = total_tp / (total_tp + total_fp) if (total_tp + total_fp) > 0 else 0.0
+    micro_r = total_tp / (total_tp + total_fn) if (total_tp + total_fn) > 0 else 0.0
+    micro_f1 = (
+        2 * micro_p * micro_r / (micro_p + micro_r) if (micro_p + micro_r) > 0 else 0.0
+    )
+    macro_f1 = sum(per_theme[t]["f1"] for t in themes) / len(themes) if themes else 0.0
+
+    exact = sum(
+        1 for r in scored if set(r.expected_themes or []) == set(r.predicted_themes or [])
+    )
+    exact_set_match = exact / len(scored) if scored else None
+
+    return {
+        "per_theme": per_theme,
+        "micro_precision": micro_p,
+        "micro_recall": micro_r,
+        "micro_f1": micro_f1,
+        "macro_f1": macro_f1,
+        "exact_set_match": exact_set_match,
+        "count": len(scored),
+    }
+
+
+def compute_tier_metrics(results: list[StoryPrediction]) -> dict:
+    """Tier metrics over the 4 tier classes.
+
+    Rows whose predicted_scores is None are parse failures: counted as errors
+    and excluded from the confusion matrix / accuracy.
+    """
+    errors = [r for r in results if r.predicted_scores is None]
+    valid = [r for r in results if r.predicted_scores is not None]
+
+    matrix = compute_confusion_matrix(valid, "expected_tier", "predicted_tier", TIERS)
+    prf = compute_precision_recall_f1(matrix, TIERS)
+
+    scored = [r for r in valid if r.expected_tier in TIERS and r.predicted_tier in TIERS]
+    correct = sum(1 for r in scored if r.expected_tier == r.predicted_tier)
+    accuracy = correct / len(scored) if scored else None
+
+    return {
+        "accuracy": accuracy,
+        "confusion_matrix": matrix,
+        "per_class": prf,
+        "count": len(scored),
+        "errors": len(errors),
+    }
+
+
+def _normalize(story: dict) -> str:
+    """Lowercase, whitespace-collapse the story's title-or-text for matching."""
+    raw = story.get("title") or story.get("text") or ""
+    return re.sub(r"\s+", " ", raw).strip().lower()
+
+
+def match_stories(
+    predicted: list[dict],
+    golden: list[dict],
+    threshold: float = 0.6,
+) -> tuple[int, int, int]:
+    """Greedy one-to-one match of predicted stories to golden stories.
+
+    Uses difflib.SequenceMatcher ratio on normalized (lowercased,
+    whitespace-collapsed) title-or-text. Highest-ratio candidate pairs are
+    assigned first; each predicted and each golden story matches at most once.
+
+    Returns:
+        (matched, n_predicted, n_golden)
+    """
+    pred_norm = [_normalize(p) for p in predicted]
+    gold_norm = [_normalize(g) for g in golden]
+
+    # Score every predicted/golden pair, then assign greedily by descending ratio.
+    pairs: list[tuple[float, int, int]] = []
+    for pi, pn in enumerate(pred_norm):
+        for gi, gn in enumerate(gold_norm):
+            ratio = difflib.SequenceMatcher(None, pn, gn).ratio()
+            if ratio >= threshold:
+                pairs.append((ratio, pi, gi))
+
+    pairs.sort(key=lambda x: x[0], reverse=True)
+
+    used_pred: set[int] = set()
+    used_gold: set[int] = set()
+    matched = 0
+    for _ratio, pi, gi in pairs:
+        if pi in used_pred or gi in used_gold:
+            continue
+        used_pred.add(pi)
+        used_gold.add(gi)
+        matched += 1
+
+    return matched, len(predicted), len(golden)
+
+
+# --- Loading ---
+
+def load_results(
+    path: Path,
+) -> tuple[NewsletterRunMeta, list[StoryPrediction], list[ExtractionPrediction]]:
+    """Load run metadata and predictions from a newsletter results JSONL.
+
+    Dispatches rows on the "type" discriminator.
+    """
+    meta = None
+    story_preds: list[StoryPrediction] = []
+    extraction_preds: list[ExtractionPrediction] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            t = d.get("type")
+            if t == "run_meta":
+                meta = NewsletterRunMeta.from_dict(d)
+            elif t == "story_prediction":
+                story_preds.append(StoryPrediction.from_dict(d))
+            elif t == "extraction_prediction":
+                extraction_preds.append(ExtractionPrediction.from_dict(d))
+    if meta is None:
+        raise ValueError(f"No run_meta found in {path}")
+    return meta, story_preds, extraction_preds
+
+
+# --- Formatters ---
+
+def _format_dim_table(
+    mae: dict[str, float | None],
+    exact: dict[str, float | None],
+    within1: dict[str, float | None],
+) -> str:
+    widths = [max(len(d) for d in DIMENSIONS), 10, 12, 12]
+    lines = []
+    lines.append("  " + format_table_row(["Dimension", "MAE", "Exact", "Within-1"], widths))
+    lines.append("  " + "-" * sum(w + 2 for w in widths))
+    for dim in DIMENSIONS:
+        m = mae.get(dim)
+        mae_s = "N/A" if m is None else f"{m:.2f}"
+        lines.append("  " + format_table_row(
+            [dim, mae_s, format_pct(exact.get(dim)), format_pct(within1.get(dim))],
+            widths,
+        ))
+    return "\n".join(lines)
+
+
+def _format_theme_table(themes: dict) -> str:
+    widths = [max(len(t) for t in THEMES), 10, 10, 10]
+    lines = []
+    lines.append("  " + format_table_row(["Theme", "Precision", "Recall", "F1"], widths))
+    lines.append("  " + "-" * sum(w + 2 for w in widths))
+    for t in THEMES:
+        m = themes["per_theme"][t]
+        lines.append("  " + format_table_row(
+            [t, format_pct(m["precision"]), format_pct(m["recall"]), format_pct(m["f1"])],
+            widths,
+        ))
+    return "\n".join(lines)
+
+
+def print_report(
+    meta: NewsletterRunMeta,
+    metrics: dict,
+    verbose: bool = False,
+    story_results: list[StoryPrediction] | None = None,
+    extraction_results: list[ExtractionPrediction] | None = None,
+) -> None:
+    """Print a formatted single-run report to stdout."""
+    print(f"\n{'=' * 60}")
+    print(f"Newsletter Evaluation Report: {meta.run_id[:8]}")
+    print(f"{'=' * 60}")
+    print(f"  Timestamp:    {meta.timestamp}")
+    print(f"  Config:       {meta.config_path} ({meta.config_hash})")
+    print(f"  Model:        {meta.newsletter_model}")
+    print(f"  Mode:         {meta.mode}")
+    print(f"  Prompt hash:  {meta.prompt_hash}")
+    if meta.tag:
+        print(f"  Tag:          {meta.tag}")
+    if meta.seeded_from:
+        print(f"  Seeded from:  {meta.seeded_from}")
+    print(f"  Newsletters:  {meta.golden_set_count}")
+    print(f"  Stories:      {meta.story_count}")
+
+    tier = metrics["tier"]
+    if tier["count"] or tier["errors"]:
+        print("\n--- Tier Classification (4-class) ---")
+        print(f"  Accuracy: {format_pct(tier['accuracy'])} "
+              f"({tier['count']} stories, {tier['errors']} errors)")
+        print("\n  Confusion matrix:")
+        print(format_confusion_matrix(tier["confusion_matrix"], TIERS))
+        print("\n  Per-class metrics:")
+        print(format_per_class_table(tier["per_class"], TIERS))
+
+    print("\n--- Quality Dimensions ---")
+    print(_format_dim_table(
+        metrics["dimension_mae"], metrics["dimension_exact"], metrics["dimension_within1"]
+    ))
+
+    themes = metrics["themes"]
+    print("\n--- Themes (multi-label) ---")
+    print(f"  Micro-F1: {format_pct(themes['micro_f1'])}   "
+          f"Macro-F1: {format_pct(themes['macro_f1'])}   "
+          f"Exact-set match: {format_pct(themes['exact_set_match'])}")
+    print()
+    print(_format_theme_table(themes))
+
+    extraction = metrics["extraction"]
+    if extraction["count"]:
+        print("\n--- Extraction ---")
+        print(f"  Micro:  P={format_pct(extraction['micro_precision'])} "
+              f"R={format_pct(extraction['micro_recall'])} "
+              f"F1={format_pct(extraction['micro_f1'])}")
+        print(f"  Macro:  P={format_pct(extraction['macro_precision'])} "
+              f"R={format_pct(extraction['macro_recall'])} "
+              f"F1={format_pct(extraction['macro_f1'])}")
+
+    if verbose:
+        _print_verbose_single(story_results or [], extraction_results or [])
+
+    print()
+
+
+def _print_verbose_single(
+    story_results: list[StoryPrediction],
+    extraction_results: list[ExtractionPrediction],
+) -> None:
+    print("\n--- Story Disagreements ---")
+    disagreements = [
+        r for r in story_results
+        if r.predicted_scores is not None
+        and (r.expected_tier != r.predicted_tier
+             or set(r.expected_themes or []) != set(r.predicted_themes or []))
+    ]
+    if not disagreements:
+        print("  None!")
+    for r in disagreements:
+        parts = [f"  {r.story_id}:"]
+        if r.expected_tier != r.predicted_tier:
+            parts.append(f"tier={r.expected_tier}->{r.predicted_tier}")
+        exp_th = set(r.expected_themes or [])
+        pred_th = set(r.predicted_themes or [])
+        if exp_th != pred_th:
+            parts.append(f"themes={sorted(exp_th)}->{sorted(pred_th)}")
+        print(" ".join(parts))
+
+    if extraction_results:
+        print("\n--- Extraction Diffs (per newsletter) ---")
+        for r in extraction_results:
+            if r.error is not None:
+                print(f"  {r.thread_id}: ERROR {r.error}")
+                continue
+            matched, n_pred, n_gold = match_stories(r.predicted_stories, r.golden_stories)
+            print(f"  {r.thread_id}: matched={matched} predicted={n_pred} golden={n_gold}")
+
+
+def print_comparison(
+    meta1: NewsletterRunMeta, metrics1: dict,
+    meta2: NewsletterRunMeta, metrics2: dict,
+    verbose: bool = False,
+    story1: list[StoryPrediction] | None = None,
+    story2: list[StoryPrediction] | None = None,
+) -> None:
+    """Print a side-by-side comparison of two newsletter runs."""
+    print(f"\n{'=' * 60}")
+    print("Newsletter Comparison Report")
+    print(f"{'=' * 60}")
+    print(f"  Run A: {meta1.run_id[:8]}  prompt_hash={meta1.prompt_hash or 'n/a'}  "
+          f"tag={meta1.tag or '-'}")
+    print(f"  Run B: {meta2.run_id[:8]}  prompt_hash={meta2.prompt_hash or 'n/a'}  "
+          f"tag={meta2.tag or '-'}")
+
+    widths = [22, 12, 12, 16]
+
+    def header(title: str) -> None:
+        print(f"\n--- {title} ---")
+        print("  " + format_table_row(["Metric", "Run A", "Run B", "Delta"], widths))
+        print("  " + "-" * sum(w + 2 for w in widths))
+
+    def pct_row(label: str, a: float | None, b: float | None) -> None:
+        print("  " + format_table_row(
+            [label, format_pct(a), format_pct(b), format_metric_delta(a, b)], widths
+        ))
+
+    # Tier
+    ta, tb = metrics1["tier"], metrics2["tier"]
+    header("Tier")
+    pct_row("Accuracy", ta["accuracy"], tb["accuracy"])
+    for cls in TIERS:
+        pct_row(f"  {cls} F1", ta["per_class"][cls]["f1"], tb["per_class"][cls]["f1"])
+
+    # Dimensions (MAE, lower is better)
+    header("Dimension MAE (lower=better)")
+    for dim in DIMENSIONS:
+        a = metrics1["dimension_mae"].get(dim)
+        b = metrics2["dimension_mae"].get(dim)
+        a_s = "N/A" if a is None else f"{a:.2f}"
+        b_s = "N/A" if b is None else f"{b:.2f}"
+        print("  " + format_table_row([dim, a_s, b_s, format_mae_delta(a, b)], widths))
+
+    # Themes
+    tha, thb = metrics1["themes"], metrics2["themes"]
+    header("Themes")
+    pct_row("Micro-F1", tha["micro_f1"], thb["micro_f1"])
+    pct_row("Macro-F1", tha["macro_f1"], thb["macro_f1"])
+
+    # Extraction
+    ea, eb = metrics1["extraction"], metrics2["extraction"]
+    header("Extraction")
+    pct_row("Micro-F1", ea["micro_f1"], eb["micro_f1"])
+    pct_row("Macro-F1", ea["macro_f1"], eb["macro_f1"])
+
+    if verbose and story1 is not None and story2 is not None:
+        _print_verbose_compare(story1, story2)
+
+    print()
+
+
+def _print_verbose_compare(
+    story1: list[StoryPrediction],
+    story2: list[StoryPrediction],
+) -> None:
+    print("\n--- Per-story Flips (A -> B) ---")
+    r2_by_id = {r.story_id: r for r in story2}
+    flips = []
+    for r1 in story1:
+        r2 = r2_by_id.get(r1.story_id)
+        if r2 is None:
+            continue
+        if r1.predicted_scores is None or r2.predicted_scores is None:
+            continue
+        parts = []
+        if r1.predicted_tier != r2.predicted_tier:
+            a_right = r1.predicted_tier == r1.expected_tier
+            b_right = r2.predicted_tier == r2.expected_tier
+            flag = ""
+            if a_right and not b_right:
+                flag = " [regression]"
+            elif b_right and not a_right:
+                flag = " [improvement]"
+            parts.append(f"tier: {r1.predicted_tier}->{r2.predicted_tier} "
+                         f"(expected {r1.expected_tier}){flag}")
+        s1, s2 = set(r1.predicted_themes or []), set(r2.predicted_themes or [])
+        if s1 != s2:
+            parts.append(f"themes: {sorted(s1)}->{sorted(s2)}")
+        if parts:
+            flips.append((r1.story_id, parts))
+    if not flips:
+        print("  None!")
+    for sid, parts in flips:
+        print(f"  {sid}: {', '.join(parts)}")
+
+
+def report_as_json(meta: NewsletterRunMeta, metrics: dict) -> None:
+    print(json.dumps({"meta": meta.to_dict(), "metrics": metrics}, indent=2))
+
+
+def print_trend(results_dir: Path, match_threshold: float = 0.6) -> None:
+    """Print a trend table across all result files in a directory."""
+    files = sorted(results_dir.glob("*.jsonl"))
+    files = [f for f in files if not f.name.endswith(".cot.jsonl")]
+    if not files:
+        print(f"No result files found in {results_dir}", file=sys.stderr)
+        return
+
+    print(f"\n{'=' * 60}")
+    print(f"Newsletter Trend Report ({len(files)} runs)")
+    print(f"{'=' * 60}")
+
+    widths = [10, 10, 12, 10, 10, 12, 10]
+    print("  " + format_table_row(
+        ["Run ID", "Mode", "Tag", "TierAcc", "ThemeF1", "MAE(simple)", "ExtractF1"],
+        widths,
+    ))
+    print("  " + "-" * sum(w + 2 for w in widths))
+
+    for f in files:
+        try:
+            meta, story_preds, extraction_preds = load_results(f)
+            metrics = compute_all_metrics(story_preds, extraction_preds, match_threshold)
+            mae_simple = metrics["dimension_mae"].get("simple")
+            mae_s = "N/A" if mae_simple is None else f"{mae_simple:.2f}"
+            print("  " + format_table_row([
+                meta.run_id[:8],
+                meta.mode,
+                meta.tag or meta.prompt_hash[:10],
+                format_pct(metrics["tier"]["accuracy"]),
+                format_pct(metrics["themes"]["micro_f1"]),
+                mae_s,
+                format_pct(metrics["extraction"]["micro_f1"]),
+            ], widths))
+        except Exception as exc:
+            print(f"  Error reading {f.name}: {exc}", file=sys.stderr)
+
+    print()
+
+
+def cli():
+    parser = argparse.ArgumentParser(description="Generate newsletter evaluation reports")
+    parser.add_argument("--results", help="Path to results JSONL file")
+    parser.add_argument("--compare", nargs=2, metavar="PATH", help="Compare two result files")
+    parser.add_argument("--results-dir", help="Directory of results for trend view")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Show per-story flips and per-newsletter extraction diffs")
+    parser.add_argument("--format", choices=["table", "json"], default="table",
+                        help="Output format")
+    parser.add_argument("--match-threshold", type=float, default=0.6,
+                        help="SequenceMatcher ratio threshold for extraction matching (default 0.6)")
+    args = parser.parse_args()
+
+    if not any([args.results, args.compare, args.results_dir]):
+        parser.error("Provide --results, --compare, or --results-dir")
+
+    if args.results:
+        meta, story_preds, extraction_preds = load_results(Path(args.results))
+        metrics = compute_all_metrics(story_preds, extraction_preds, args.match_threshold)
+        if args.format == "json":
+            report_as_json(meta, metrics)
+        else:
+            print_report(meta, metrics, verbose=args.verbose,
+                         story_results=story_preds, extraction_results=extraction_preds)
+
+    elif args.compare:
+        meta1, s1, e1 = load_results(Path(args.compare[0]))
+        meta2, s2, e2 = load_results(Path(args.compare[1]))
+        m1 = compute_all_metrics(s1, e1, args.match_threshold)
+        m2 = compute_all_metrics(s2, e2, args.match_threshold)
+        print_comparison(meta1, m1, meta2, m2, verbose=args.verbose, story1=s1, story2=s2)
+
+    elif args.results_dir:
+        print_trend(Path(args.results_dir), args.match_threshold)
+
+
+if __name__ == "__main__":
+    cli()

--- a/evals/newsletter_report.py
+++ b/evals/newsletter_report.py
@@ -15,6 +15,7 @@ import re
 import sys
 from pathlib import Path
 
+from evals import plural
 from evals.newsletter_schemas import (
     ExtractionPrediction,
     NewsletterRunMeta,
@@ -28,10 +29,20 @@ from evals.report import (
     format_per_class_table,
     format_table_row,
 )
+from newsletter import _VALID_THEMES
 
 TIERS = ["excellent", "good", "fair", "poor"]
 DIMENSIONS = ["simple", "concrete", "personal", "dynamic"]
-THEMES = ["scripture", "christlikeness", "church", "vocation_family", "disciple_making"]
+
+# Display order for theme tables; the theme SET is single-sourced from
+# newsletter._VALID_THEMES — a theme dropped there disappears here, and any
+# theme added there is appended (sorted) even before this ordering is updated.
+_THEME_DISPLAY_ORDER = [
+    "scripture", "christlikeness", "church", "vocation_family", "disciple_making",
+]
+THEMES = [t for t in _THEME_DISPLAY_ORDER if t.upper() in _VALID_THEMES] + sorted(
+    t.lower() for t in _VALID_THEMES if t.lower() not in _THEME_DISPLAY_ORDER
+)
 
 
 def _dimension_pairs(results: list[StoryPrediction], dim: str) -> list[tuple[int, int]]:
@@ -46,40 +57,31 @@ def _dimension_pairs(results: list[StoryPrediction], dim: str) -> list[tuple[int
     return pairs
 
 
-def compute_dimension_mae(results: list[StoryPrediction]) -> dict[str, float]:
-    """Mean absolute error per dimension over stories with both scores present."""
-    out: dict[str, float] = {}
+def _dimension_mean(
+    results: list[StoryPrediction],
+    per_pair,
+) -> dict[str, float | None]:
+    """Mean of per_pair(expected, predicted) per dimension; None with no pairs."""
+    out: dict[str, float | None] = {}
     for dim in DIMENSIONS:
         pairs = _dimension_pairs(results, dim)
-        if pairs:
-            out[dim] = sum(abs(e - p) for e, p in pairs) / len(pairs)
-        else:
-            out[dim] = None
+        out[dim] = sum(per_pair(e, p) for e, p in pairs) / len(pairs) if pairs else None
     return out
+
+
+def compute_dimension_mae(results: list[StoryPrediction]) -> dict[str, float]:
+    """Mean absolute error per dimension over stories with both scores present."""
+    return _dimension_mean(results, lambda e, p: abs(e - p))
 
 
 def compute_dimension_exact_match(results: list[StoryPrediction]) -> dict[str, float]:
     """Fraction of exact-match predictions per dimension."""
-    out: dict[str, float] = {}
-    for dim in DIMENSIONS:
-        pairs = _dimension_pairs(results, dim)
-        if pairs:
-            out[dim] = sum(1 for e, p in pairs if e == p) / len(pairs)
-        else:
-            out[dim] = None
-    return out
+    return _dimension_mean(results, lambda e, p: e == p)
 
 
 def compute_dimension_within1(results: list[StoryPrediction]) -> dict[str, float]:
     """Fraction of predictions within 1 point of expected per dimension."""
-    out: dict[str, float] = {}
-    for dim in DIMENSIONS:
-        pairs = _dimension_pairs(results, dim)
-        if pairs:
-            out[dim] = sum(1 for e, p in pairs if abs(e - p) <= 1) / len(pairs)
-        else:
-            out[dim] = None
-    return out
+    return _dimension_mean(results, lambda e, p: abs(e - p) <= 1)
 
 
 def format_metric_delta(a: float | None, b: float | None) -> str:
@@ -108,11 +110,16 @@ def compute_all_metrics(
     story_results: list[StoryPrediction],
     extraction_results: list[ExtractionPrediction] | None = None,
     match_threshold: float = 0.6,
+    mode: str = "all",
 ) -> dict:
-    """Bundle every metric section for a single run."""
+    """Bundle every metric section for a single run.
+
+    mode is the run's RunMeta.mode; it tells tier metrics whether errored rows
+    count as quality failures (they don't in a themes-only run).
+    """
     return {
         "story_count": len(story_results),
-        "tier": compute_tier_metrics(story_results),
+        "tier": compute_tier_metrics(story_results, mode),
         "dimension_mae": compute_dimension_mae(story_results),
         "dimension_exact": compute_dimension_exact_match(story_results),
         "dimension_within1": compute_dimension_within1(story_results),
@@ -135,15 +142,19 @@ def compute_extraction_metrics(
     stories is a correct abstention (precision = recall = 1.0). Aggregate as micro
     (pooled counts) and macro (mean of per-newsletter precision/recall). All
     aggregates are None when there are no scored newsletters, so empty sections
-    render as N/A rather than a fake 0.0%.
+    render as N/A rather than a fake 0.0%. Rows with error set are excluded
+    from scoring but counted under "errors"/"error_threads" so a failed run is
+    visible in the report (mirroring the tier section).
     """
     total_matched = total_pred = total_gold = 0
     per_nl_precision: list[float] = []
     per_nl_recall: list[float] = []
     per_newsletter: list[dict] = []
+    error_threads: list[str] = []
 
     for r in results:
         if r.error is not None:
+            error_threads.append(r.thread_id)
             continue
         matched, n_pred, n_gold = match_stories(
             r.predicted_stories, r.golden_stories, threshold=threshold
@@ -175,6 +186,8 @@ def compute_extraction_metrics(
             "macro_recall": None,
             "macro_f1": None,
             "count": 0,
+            "errors": len(error_threads),
+            "error_threads": error_threads,
             "per_newsletter": [],
         }
 
@@ -197,6 +210,8 @@ def compute_extraction_metrics(
         "macro_recall": macro_r,
         "macro_f1": macro_f1,
         "count": len(per_newsletter),
+        "errors": len(error_threads),
+        "error_threads": error_threads,
         "per_newsletter": per_newsletter,
     }
 
@@ -286,14 +301,20 @@ def compute_multilabel_metrics(
     }
 
 
-def _quality_attempted(r: StoryPrediction) -> bool:
+def _quality_attempted(r: StoryPrediction, mode: str = "all") -> bool:
     """Whether the quality call ran (or failed) for this row.
 
     A --mode themes run never fires the quality call: error=None AND
     scores_raw=None AND predicted_scores=None means "never attempted", which
     must be skipped — not counted as a parse failure. scores_raw captured (or
     an error, or parsed scores) means quality was genuinely attempted.
+
+    In a themes-only run (mode="themes", from the run's RunMeta) an error is a
+    *theme* call failure, so it does not count as a quality attempt either —
+    only actual quality evidence (scores_raw / predicted_scores) does.
     """
+    if mode == "themes":
+        return r.scores_raw is not None or r.predicted_scores is not None
     return (
         r.error is not None
         or r.scores_raw is not None
@@ -301,17 +322,18 @@ def _quality_attempted(r: StoryPrediction) -> bool:
     )
 
 
-def compute_tier_metrics(results: list[StoryPrediction]) -> dict:
+def compute_tier_metrics(results: list[StoryPrediction], mode: str = "all") -> dict:
     """Tier metrics over the 4 tier classes.
 
     Rows where quality was attempted but predicted_scores is None are parse/
     network failures: counted as errors and excluded from the confusion matrix
     / accuracy. Their story_ids are returned under "error_stories" so failures
     are identifiable in the report. Rows where quality was never attempted
-    (e.g. a --mode themes run: error=None, scores_raw=None) are skipped
-    entirely — neither scored nor errors.
+    (e.g. a --mode themes run: error=None, scores_raw=None — or, given
+    mode="themes", any errored row) are skipped entirely — neither scored nor
+    errors.
     """
-    attempted = [r for r in results if _quality_attempted(r)]
+    attempted = [r for r in results if _quality_attempted(r, mode)]
     errors = [r for r in attempted if r.predicted_scores is None]
     valid = [r for r in attempted if r.predicted_scores is not None]
 
@@ -416,7 +438,7 @@ def theme_parse_anomalies(results: list[StoryPrediction]) -> list[dict]:
 
     Rows without themes_raw (legacy files, error rows) are skipped.
     """
-    valid_upper = {t.upper() for t in THEMES}
+    valid_upper = _VALID_THEMES
     anomalies: list[dict] = []
     for r in results:
         if r.error is not None or r.themes_raw is None:
@@ -533,13 +555,6 @@ def _format_theme_table(themes: dict) -> str:
     return "\n".join(lines)
 
 
-def _plural(n: int, word: str) -> str:
-    if n == 1:
-        return f"1 {word}"
-    plural = word[:-1] + "ies" if word.endswith("y") else word + "s"
-    return f"{n} {plural}"
-
-
 def print_report(
     meta: NewsletterRunMeta,
     metrics: dict,
@@ -577,7 +592,8 @@ def print_report(
     if tier["count"] or tier["errors"]:
         print("\n--- Tier Classification (4-class) ---")
         print(f"  Accuracy: {format_pct(tier['accuracy'])} "
-              f"({_plural(tier['count'], 'story')}, {_plural(tier['errors'], 'error')})")
+              f"({plural(tier['count'], 'story', 'stories')}, "
+              f"{plural(tier['errors'], 'error')})")
         if tier["error_stories"]:
             print(f"  Failed stories (quality parse/network): "
                   f"{', '.join(tier['error_stories'])}")
@@ -600,16 +616,20 @@ def print_report(
               f"Exact-set match: {format_pct(themes['exact_set_match'])}")
         anomalies = metrics.get("theme_anomalies", [])
         if anomalies:
-            print(f"  Parse anomalies: {_plural(len(anomalies), 'story')} "
+            print(f"  Parse anomalies: {plural(len(anomalies), 'story', 'stories')} "
                   f"(invalid/unparseable theme output; --verbose shows raw)")
         print()
         print(_format_theme_table(themes))
 
     extraction = metrics["extraction"]
-    if extraction["count"]:
+    if extraction["count"] or extraction.get("errors"):
         print("\n--- Extraction ---")
-        print(f"  ({_plural(extraction['count'], 'newsletter')}, "
+        print(f"  ({plural(extraction['count'], 'newsletter')}, "
+              f"{plural(extraction.get('errors', 0), 'error')}, "
               f"match threshold {match_threshold})")
+        if extraction.get("error_threads"):
+            print(f"  Failed newsletters (extraction call): "
+                  f"{', '.join(extraction['error_threads'])}")
         print(f"  Micro:  P={format_pct(extraction['micro_precision'])} "
               f"R={format_pct(extraction['micro_recall'])} "
               f"F1={format_pct(extraction['micro_f1'])}")
@@ -812,22 +832,25 @@ def _print_verbose_compare(
         r2 = r2_by_id.get(r1.story_id)
         if r2 is None:
             continue
-        if r1.predicted_scores is None or r2.predicted_scores is None:
-            continue
         parts = []
-        if r1.predicted_tier != r2.predicted_tier:
-            a_right = r1.predicted_tier == r1.expected_tier
-            b_right = r2.predicted_tier == r2.expected_tier
-            flag = ""
-            if a_right and not b_right:
-                flag = " [regression]"
-            elif b_right and not a_right:
-                flag = " [improvement]"
-            parts.append(f"tier: {r1.predicted_tier}->{r2.predicted_tier} "
-                         f"(expected {r1.expected_tier}){flag}")
-        s1, s2 = set(r1.predicted_themes or []), set(r2.predicted_themes or [])
-        if s1 != s2:
-            parts.append(f"themes: {sorted(s1)}->{sorted(s2)}")
+        # Tier flips are only meaningful when both runs' quality calls parsed;
+        # theme flips only need both rows' theme side attempted (a --mode
+        # themes run never has predicted_scores but can still flip themes).
+        if r1.predicted_scores is not None and r2.predicted_scores is not None:
+            if r1.predicted_tier != r2.predicted_tier:
+                a_right = r1.predicted_tier == r1.expected_tier
+                b_right = r2.predicted_tier == r2.expected_tier
+                flag = ""
+                if a_right and not b_right:
+                    flag = " [regression]"
+                elif b_right and not a_right:
+                    flag = " [improvement]"
+                parts.append(f"tier: {r1.predicted_tier}->{r2.predicted_tier} "
+                             f"(expected {r1.expected_tier}){flag}")
+        if _theme_scored(r1) and _theme_scored(r2):
+            s1, s2 = set(r1.predicted_themes or []), set(r2.predicted_themes or [])
+            if s1 != s2:
+                parts.append(f"themes: {sorted(s1)}->{sorted(s2)}")
         if parts:
             flips.append((r1.story_id, parts))
     if not flips:
@@ -866,7 +889,8 @@ def build_trend_rows(
     for f in files:
         try:
             meta, story_preds, extraction_preds = load_results(f)
-            metrics = compute_all_metrics(story_preds, extraction_preds, match_threshold)
+            metrics = compute_all_metrics(story_preds, extraction_preds,
+                                          match_threshold, mode=meta.mode)
             rows.append({
                 "file": f.name,
                 "run_id": meta.run_id,
@@ -934,7 +958,9 @@ def _load_results_or_exit(
         return load_results(path)
     except FileNotFoundError:
         print(f"Error: results file not found: {path}", file=sys.stderr)
-    except (ValueError, json.JSONDecodeError) as exc:
+    # OSError covers IsADirectoryError, PermissionError, etc.; JSONDecodeError
+    # is a ValueError subclass but is listed for clarity.
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"Error: could not read results file {path}: {exc}", file=sys.stderr)
         if path.name.endswith(".cot.jsonl"):
             print(
@@ -965,7 +991,8 @@ def cli():
 
     if args.results:
         meta, story_preds, extraction_preds = _load_results_or_exit(args.results)
-        metrics = compute_all_metrics(story_preds, extraction_preds, args.match_threshold)
+        metrics = compute_all_metrics(story_preds, extraction_preds,
+                                      args.match_threshold, mode=meta.mode)
         if args.format == "json":
             report_as_json(meta, metrics)
         else:
@@ -992,8 +1019,8 @@ def cli():
             )
         meta1, s1, e1 = _load_results_or_exit(compare_paths[0])
         meta2, s2, e2 = _load_results_or_exit(compare_paths[1])
-        m1 = compute_all_metrics(s1, e1, args.match_threshold)
-        m2 = compute_all_metrics(s2, e2, args.match_threshold)
+        m1 = compute_all_metrics(s1, e1, args.match_threshold, mode=meta1.mode)
+        m2 = compute_all_metrics(s2, e2, args.match_threshold, mode=meta2.mode)
         if args.format == "json":
             comparison_as_json(meta1, m1, meta2, m2)
         else:

--- a/evals/newsletter_run.py
+++ b/evals/newsletter_run.py
@@ -1,0 +1,536 @@
+"""Replay the newsletter golden set through the real NewsletterClassifier.
+
+Usage:
+    python -m evals.newsletter_run
+    python -m evals.newsletter_run --golden-set evals/newsletter_golden_set.jsonl --mode all
+    python -m evals.newsletter_run --prompts alt.toml --tag variant
+    python -m evals.newsletter_run --mode quality --no-cache
+
+Mirrors evals/run_eval.py: load config (tomllib + env substitution), resolve the
+newsletter endpoint, build one LLMClient from [newsletter.llm], wrap in the disk
+LLM cache unless --no-cache, preflight the endpoint, then replay the golden set.
+"""
+
+import argparse
+import asyncio
+import copy
+import hashlib
+import json
+import sys
+import time
+import tomllib
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+from config_utils import substitute_env_vars
+from daemon import resolve_newsletter_llm_endpoint
+from evals import format_network_error
+from evals.llm_cache import CachedLLMClient
+from evals.newsletter_schemas import (
+    ExtractionPrediction,
+    GoldenNewsletter,
+    GoldenStory,
+    NewsletterRunMeta,
+    NewsletterThinkingEntry,
+    StoryPrediction,
+)
+from llm_client import LLMClient
+from newsletter import NewsletterClassifier, compute_tier
+
+
+def load_golden_set(path: Path, reviewed_only: bool = True) -> list[GoldenNewsletter]:
+    """Load newsletters from the golden set JSONL.
+
+    Drops ``excluded`` newsletters unconditionally; drops unreviewed ones unless
+    ``reviewed_only`` is False. Blank lines are skipped.
+    """
+    newsletters = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            gn = GoldenNewsletter.from_dict(json.loads(line))
+            if gn.excluded:
+                continue
+            if reviewed_only and not gn.reviewed:
+                continue
+            newsletters.append(gn)
+    return newsletters
+
+
+def compute_prompt_hash(config: dict) -> str:
+    """Content-hash the newsletter prompt block so prompt A/Bs are self-identifying.
+
+    Hashes config["newsletter"]["prompts"] deterministically (sorted keys) — any
+    change to a prompt string (system or user_template) changes the hash, and an
+    identical prompt block always hashes the same.
+    """
+    prompts = config["newsletter"]["prompts"]
+    raw = json.dumps(prompts, sort_keys=True)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+class _RawCapture:
+    """Wraps an LLM client to record the raw (non-thinking) response of each call.
+
+    The NewsletterClassifier parses scores/themes internally and only returns the
+    parsed result + chain-of-thought, discarding the raw model text. To store the
+    raw text in a StoryPrediction (for debugging a parse failure) without a second
+    LLM call, temporarily route the classifier's client through this recorder — it
+    delegates every call to the inner client and keeps the last response.
+    """
+
+    def __init__(self, inner):
+        self.inner = inner
+        self.last_raw = None
+
+    def __getattr__(self, name):
+        return getattr(self.inner, name)
+
+    async def complete(self, system_prompt, user_content, include_thinking=False):
+        result = await self.inner.complete(system_prompt, user_content, include_thinking=True)
+        response, thinking = result
+        self.last_raw = response
+        if include_thinking:
+            return response, thinking
+        return response
+
+
+def _elapsed(llm, start: float) -> float:
+    """Actual LLM call time when caching (0 for pure cache hits), else wall time.
+
+    Mirrors run_eval: a CachedLLMClient exposes take_llm_seconds() (miss-only
+    time); an un-cached raw client falls back to wall-clock.
+    """
+    if hasattr(llm, "take_llm_seconds"):
+        return round(llm.take_llm_seconds(), 3)
+    return round(time.monotonic() - start, 3)
+
+
+async def evaluate_extraction(
+    newsletter: GoldenNewsletter, classifier: NewsletterClassifier,
+) -> ExtractionPrediction:
+    """Run extract_stories on the raw body; compare predicted vs golden story list.
+
+    Extraction is scored at the newsletter-body level: the raw body goes in, and
+    the predicted [{title,text}] list is matched (in the report) against the
+    newsletter's confirmed golden stories.
+    """
+    pred = ExtractionPrediction(
+        thread_id=newsletter.thread_id,
+        golden_stories=[
+            {"story_id": s.story_id, "title": s.title, "text": s.text}
+            for s in newsletter.stories
+        ],
+    )
+    start = time.monotonic()
+    try:
+        stories = await classifier.extract_stories(newsletter.body)
+        pred.predicted_stories = [{"title": t, "text": x} for t, x in stories]
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        pred.error = format_network_error(exc, "newsletter LLM")
+    except Exception as exc:
+        pred.error = str(exc)
+    pred.duration_seconds = _elapsed(classifier.cloud_llm, start)
+    return pred
+
+
+async def evaluate_story(
+    story: GoldenStory, thread_id: str, classifier: NewsletterClassifier,
+) -> tuple[StoryPrediction, NewsletterThinkingEntry]:
+    """Score one fixed golden story on quality + themes; derive tier from scores.
+
+    Quality and themes are evaluated on the fixed golden (title, text), decoupled
+    from extraction variability. predicted_tier is derived via compute_tier only
+    when the scores parsed; a parse failure leaves scores/tier None (an error in
+    the report, not a mis-tier).
+    """
+    pred = StoryPrediction(
+        story_id=story.story_id,
+        thread_id=thread_id,
+        expected_scores=story.expected_scores,
+        expected_tier=story.expected_tier,
+        expected_themes=list(story.expected_themes),
+    )
+    thinking = NewsletterThinkingEntry(story_id=story.story_id)
+
+    real_client = classifier.cloud_llm
+    capture = _RawCapture(real_client)
+    # Shallow-copy the classifier so swapping the client is concurrency-safe: under
+    # parallelism>1, mutating the shared classifier's cloud_llm would race between
+    # tasks. The copy shares the (immutable) config dicts but owns its client ref.
+    local_classifier = copy.copy(classifier)
+    local_classifier.cloud_llm = capture
+    start = time.monotonic()
+    try:
+        capture.last_raw = None
+        scores, quality_cot = await local_classifier.assess_quality(story.title, story.text)
+        pred.scores_raw = capture.last_raw
+        pred.predicted_scores = scores
+        thinking.quality_cot = quality_cot
+        if scores:
+            pred.predicted_tier = compute_tier(scores).value
+
+        capture.last_raw = None
+        themes, theme_cot = await local_classifier.classify_themes(story.title, story.text)
+        pred.themes_raw = capture.last_raw
+        pred.predicted_themes = themes
+        thinking.theme_cot = theme_cot
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        pred.error = format_network_error(exc, "newsletter LLM")
+    except Exception as exc:
+        pred.error = str(exc)
+    pred.duration_seconds = _elapsed(real_client, start)
+    return pred, thinking
+
+
+VALID_MODES = ("extraction", "quality", "themes", "all")
+
+
+async def run_evaluation(
+    golden_set: list[GoldenNewsletter],
+    classifier: NewsletterClassifier,
+    mode: str,
+    parallelism: int = 1,
+) -> tuple[list, list[NewsletterThinkingEntry]]:
+    """Replay the golden set through the classifier under *mode*.
+
+    Returns (rows, thinking_entries). ``rows`` mixes ExtractionPrediction (one per
+    reviewed newsletter, extraction/all modes) and StoryPrediction (one per
+    reviewed, non-excluded golden story, quality/themes/all modes). Concurrency is
+    bounded by an asyncio.Semaphore(parallelism); the shared classifier's client is
+    never mutated (evaluate_story shallow-copies it), so tasks don't race.
+    """
+    semaphore = asyncio.Semaphore(parallelism)
+    do_extraction = mode in ("extraction", "all")
+    do_stories = mode in ("quality", "themes", "all")
+
+    async def run_extraction(nl: GoldenNewsletter):
+        async with semaphore:
+            return await evaluate_extraction(nl, classifier)
+
+    async def run_story(story: GoldenStory, thread_id: str):
+        async with semaphore:
+            return await evaluate_story(story, thread_id, classifier)
+
+    extraction_tasks = []
+    if do_extraction:
+        extraction_tasks = [run_extraction(nl) for nl in golden_set]
+
+    story_tasks = []
+    if do_stories:
+        for nl in golden_set:
+            for story in nl.stories:
+                if story.excluded:
+                    continue
+                story_tasks.append(run_story(story, nl.thread_id))
+
+    extraction_rows = await asyncio.gather(*extraction_tasks)
+    story_pairs = await asyncio.gather(*story_tasks)
+
+    rows = list(extraction_rows)
+    thinking = []
+    for pred, entry in story_pairs:
+        rows.append(pred)
+        thinking.append(entry)
+    return rows, thinking
+
+
+def _deep_merge(base: dict, override: dict) -> None:
+    """Recursively merge *override* into *base* in place (override wins on leaves)."""
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+
+
+def build_meta(
+    config: dict,
+    config_path: str,
+    golden_path: str,
+    golden_set: list[GoldenNewsletter],
+    mode: str,
+    tag: str,
+    parallelism: int,
+) -> "NewsletterRunMeta":
+    """Assemble the NewsletterRunMeta first-line record for a results file.
+
+    Records prompt_hash (content-hash of the merged prompt block) + the three
+    system prompts verbatim + model/temperature/max_tokens/extra_body/counts/tag/
+    mode so prompt A/Bs are self-identifying and comparable. seeded_from is pulled
+    from the golden set (first newsletter that carries it) so the report can flag
+    extraction-recall bias from Phase-A seeding.
+    """
+    llm_cfg = config["newsletter"]["llm"]
+    prompts = config["newsletter"]["prompts"]
+    config_bytes = json.dumps(config, sort_keys=True).encode()
+    story_count = sum(
+        1 for nl in golden_set for s in nl.stories if not s.excluded
+    )
+    seeded_from = next((nl.seeded_from for nl in golden_set if nl.seeded_from), "")
+    return NewsletterRunMeta(
+        run_id=uuid.uuid4().hex,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        config_hash=hashlib.sha256(config_bytes).hexdigest()[:16],
+        config_path=config_path,
+        newsletter_model=llm_cfg["model"],
+        golden_set_path=golden_path,
+        golden_set_count=len(golden_set),
+        story_count=story_count,
+        mode=mode,
+        prompt_hash=compute_prompt_hash(config),
+        temperature=llm_cfg.get("temperature", 0.0),
+        max_tokens=llm_cfg.get("max_tokens", 0),
+        extra_body=llm_cfg.get("extra_body"),
+        parallelism=parallelism,
+        tag=tag,
+        seeded_from=seeded_from,
+        extraction_system_prompt=prompts["story_extraction"]["system"],
+        quality_system_prompt=prompts["quality_assessment"]["system"],
+        theme_system_prompt=prompts["theme_classification"]["system"],
+    )
+
+
+def build_output_path(output_dir: Path, mode: str, tag: str, run_id: str) -> Path:
+    """Build the timestamped results file path: <ts>_<mode>_<tag>_<runid8>.jsonl."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    parts = [timestamp, mode]
+    if tag:
+        parts.append(tag)
+    parts.append(run_id[:8])
+    return output_dir / ("_".join(parts) + ".jsonl")
+
+
+def write_results(path: Path, meta: "NewsletterRunMeta", rows: list) -> None:
+    """Write the run meta (first line) then each prediction row to JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write(json.dumps(meta.to_dict()) + "\n")
+        for row in rows:
+            f.write(json.dumps(row.to_dict()) + "\n")
+
+
+def write_thinking_sidecar(
+    results_path: Path, thinking_entries: list[NewsletterThinkingEntry],
+) -> None:
+    """Write non-empty chain-of-thought entries to the .cot.jsonl sidecar.
+
+    Only entries with at least one non-empty cot field are written; if none
+    qualify, no sidecar file is created.
+    """
+    entries = [t for t in thinking_entries if t.quality_cot or t.theme_cot]
+    if not entries:
+        return
+    sidecar_path = results_path.with_suffix(".cot.jsonl")
+    with open(sidecar_path, "w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry.to_dict()) + "\n")
+
+
+def merge_prompts_override(config: dict, override: dict) -> None:
+    """Deep-merge only [newsletter.prompts.*] from *override* onto *config*, in place.
+
+    A --prompts alt.toml may declare other sections, but only its newsletter prompt
+    blocks are applied (everything else — model, recipient — is ignored) so a prompt
+    variant file can't silently change the model or other run parameters. Must run
+    BEFORE compute_prompt_hash so the recorded hash reflects the merged prompts.
+    """
+    prompts_override = override.get("newsletter", {}).get("prompts")
+    if not prompts_override:
+        return
+    base_prompts = config.setdefault("newsletter", {}).setdefault("prompts", {})
+    _deep_merge(base_prompts, prompts_override)
+
+
+def build_classifier(config: dict, no_cache: bool) -> tuple[NewsletterClassifier, object]:
+    """Build the LLM client (cached unless *no_cache*) and the classifier.
+
+    Resolves the newsletter endpoint via daemon.resolve_newsletter_llm_endpoint()
+    (falls back to the cloud endpoint) and builds one LLMClient from
+    [newsletter.llm], mirroring daemon.run_daemon(). Returns (classifier, llm) so
+    the caller can flush()/report cache stats on the wrapping client.
+    """
+    llm_cfg = config["newsletter"]["llm"]
+    base_url, api_key = resolve_newsletter_llm_endpoint()
+    inner = LLMClient(
+        base_url=base_url,
+        api_key=api_key,
+        model=llm_cfg["model"],
+        max_tokens=llm_cfg.get("max_tokens", 1024),
+        temperature=llm_cfg.get("temperature", 0),
+        timeout=llm_cfg.get("timeout", 60),
+        extra_body=llm_cfg.get("extra_body"),
+    )
+    if no_cache:
+        llm = inner
+    else:
+        cache_path = Path(__file__).parent / "cache" / "llm_cache.jsonl"
+        llm = CachedLLMClient(inner, cache_path)
+    classifier = NewsletterClassifier(cloud_llm=llm, config=config)
+    return classifier, llm
+
+
+def _split_rows(rows: list) -> tuple[list[StoryPrediction], list[ExtractionPrediction]]:
+    """Split a mixed prediction row list into (story_preds, extraction_preds)."""
+    story = [r for r in rows if isinstance(r, StoryPrediction)]
+    extraction = [r for r in rows if isinstance(r, ExtractionPrediction)]
+    return story, extraction
+
+
+def maybe_report(meta, rows, report_enabled: bool, compare_to: str | None) -> None:
+    """Print a metrics report (and optional comparison) for a just-finished run.
+
+    A no-op unless --report or --compare-to was passed. Defers to
+    evals.newsletter_report; prints a hint if it isn't importable so a missing
+    report module never crashes a completed run.
+    """
+    if not report_enabled and not compare_to:
+        return
+    try:
+        from evals import newsletter_report
+    except ImportError:
+        print("Note: evals.newsletter_report is not available; skipping --report.",
+              file=sys.stderr)
+        return
+
+    story_preds, extraction_preds = _split_rows(rows)
+    metrics = newsletter_report.compute_all_metrics(story_preds, extraction_preds)
+    if report_enabled:
+        newsletter_report.print_report(
+            meta, metrics,
+            story_results=story_preds, extraction_results=extraction_preds,
+        )
+    if compare_to:
+        compare_path = Path(compare_to)
+        if not compare_path.exists():
+            print(f"Error: --compare-to file not found: {compare_path}", file=sys.stderr)
+            return
+        meta_b, story_b, extraction_b = newsletter_report.load_results(compare_path)
+        metrics_b = newsletter_report.compute_all_metrics(story_b, extraction_b)
+        # Prior run is Run A, the just-finished run is Run B (chronological order).
+        newsletter_report.print_comparison(
+            meta_b, metrics_b, meta, metrics,
+            verbose=True, story1=story_b, story2=story_preds,
+        )
+
+
+async def main(args: argparse.Namespace) -> None:
+    # Load config (tomllib + env substitution), mirroring run_eval.
+    config_path = (
+        Path(args.config) if args.config
+        else Path(__file__).parent.parent / "config.toml"
+    )
+    with open(config_path, "rb") as f:
+        config = tomllib.load(f)
+    config = substitute_env_vars(config)
+
+    # --prompts deep-merges alternate [newsletter.prompts.*] BEFORE prompt_hash and
+    # classifier are computed, so the run measures (and records the hash of) the
+    # merged prompts. --model overrides the newsletter model.
+    if args.prompts:
+        with open(args.prompts, "rb") as f:
+            override = tomllib.load(f)
+        override = substitute_env_vars(override)
+        merge_prompts_override(config, override)
+    if args.model:
+        config["newsletter"]["llm"]["model"] = args.model
+
+    parallelism = args.parallelism if args.parallelism is not None else 1
+
+    # Load golden set
+    golden_path = Path(args.golden_set)
+    golden_set = load_golden_set(golden_path, reviewed_only=not args.include_unreviewed)
+    if not golden_set:
+        print("No newsletters to evaluate.", file=sys.stderr)
+        sys.exit(1)
+    print(f"Loaded {len(golden_set)} newsletters from {golden_path}", file=sys.stderr)
+
+    classifier, llm = build_classifier(config, args.no_cache)
+
+    # Preflight: probe the newsletter endpoint once and fail fast on an
+    # unreachable / name-mismatched one (skippable via --skip-preflight).
+    if not args.skip_preflight:
+        if not await llm.is_available():
+            base = config["newsletter"]["llm"]
+            print(
+                f"Error: newsletter LLM '{base['model']}' not reachable "
+                "(a model-name mismatch with the served model returns 404)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    try:
+        print(f"Running newsletter evaluation (mode={args.mode}, "
+              f"parallelism={parallelism})...", file=sys.stderr)
+        rows, thinking_entries = await run_evaluation(
+            golden_set=golden_set,
+            classifier=classifier,
+            mode=args.mode,
+            parallelism=parallelism,
+        )
+
+        meta = build_meta(
+            config=config,
+            config_path=str(config_path),
+            golden_path=str(golden_path),
+            golden_set=golden_set,
+            mode=args.mode,
+            tag=args.tag or "",
+            parallelism=parallelism,
+        )
+
+        output_dir = Path(args.output_dir)
+        output_path = build_output_path(output_dir, args.mode, args.tag or "", meta.run_id)
+        write_results(output_path, meta, rows)
+        write_thinking_sidecar(output_path, thinking_entries)
+
+        maybe_report(meta, rows, args.report, args.compare_to)
+
+        errors = sum(1 for r in rows if getattr(r, "error", None))
+        print(f"\nResults written to {output_path}", file=sys.stderr)
+        print(f"  Rows: {len(rows)} ({errors} errors)", file=sys.stderr)
+        if not args.no_cache and hasattr(llm, "hits"):
+            total = llm.hits + llm.misses
+            if total:
+                print(f"  Cache: {llm.hits}/{total} hits ({llm.hits / total:.1%})",
+                      file=sys.stderr)
+    finally:
+        if not args.no_cache and hasattr(llm, "flush"):
+            llm.flush()
+
+
+def cli():
+    parser = argparse.ArgumentParser(description="Run newsletter classification evaluation")
+    parser.add_argument("--golden-set", default="evals/newsletter_golden_set.jsonl",
+                        help="Path to newsletter golden set JSONL")
+    parser.add_argument("--config", help="Path to config.toml (default: ./config.toml)")
+    parser.add_argument("--output-dir", default="evals/newsletter_results/",
+                        help="Output directory for results")
+    parser.add_argument("--mode", choices=VALID_MODES, default="all",
+                        help="Which outputs to evaluate")
+    parser.add_argument("--tag", help="Tag for the results file name")
+    parser.add_argument("--no-cache", action="store_true", help="Disable LLM response cache")
+    parser.add_argument("--parallelism", type=int, default=None,
+                        help="Concurrent evaluations (default: 1)")
+    parser.add_argument("--include-unreviewed", action="store_true",
+                        help="Also evaluate newsletters not yet reviewed (default: reviewed only)")
+    parser.add_argument("--prompts", metavar="TOML",
+                        help="Deep-merge [newsletter.prompts.*] from this TOML over the base config")
+    parser.add_argument("--model", help="Override the newsletter LLM model name")
+    parser.add_argument("--report", action="store_true",
+                        help="Print a metrics report for this run after it completes")
+    parser.add_argument("--compare-to", metavar="PATH",
+                        help="After the run, print a comparison against this prior results file")
+    parser.add_argument("--skip-preflight", action="store_true",
+                        help="Skip the endpoint reachability check before evaluating")
+    args = parser.parse_args()
+    asyncio.run(main(args))
+
+
+if __name__ == "__main__":
+    cli()

--- a/evals/newsletter_run.py
+++ b/evals/newsletter_run.py
@@ -16,6 +16,9 @@ import asyncio
 import copy
 import hashlib
 import json
+import logging
+import os
+import re
 import sys
 import time
 import tomllib
@@ -38,28 +41,69 @@ from evals.newsletter_schemas import (
     StoryPrediction,
 )
 from llm_client import LLMClient
-from newsletter import NewsletterClassifier, compute_tier
+from newsletter import _VALID_THEMES, NewsletterClassifier, compute_tier
 
 
-def load_golden_set(path: Path, reviewed_only: bool = True) -> list[GoldenNewsletter]:
+def load_golden_set(
+    path: Path, reviewed_only: bool = True,
+) -> tuple[list[GoldenNewsletter], dict]:
     """Load newsletters from the golden set JSONL.
 
     Drops ``excluded`` newsletters unconditionally; drops unreviewed ones unless
     ``reviewed_only`` is False. Blank lines are skipped.
+
+    Returns (kept newsletters, stats) where stats counts what the file held and
+    what filtering dropped: {"total", "excluded", "unreviewed"} — so the CLI can
+    explain an empty result instead of dead-ending.
     """
     newsletters = []
+    stats = {"total": 0, "excluded": 0, "unreviewed": 0}
     with open(path) as f:
         for line in f:
             line = line.strip()
             if not line:
                 continue
             gn = GoldenNewsletter.from_dict(json.loads(line))
+            stats["total"] += 1
             if gn.excluded:
+                stats["excluded"] += 1
                 continue
-            if reviewed_only and not gn.reviewed:
-                continue
+            if not gn.reviewed:
+                stats["unreviewed"] += 1
+                if reviewed_only:
+                    continue
             newsletters.append(gn)
-    return newsletters
+    return newsletters, stats
+
+
+def format_load_summary(kept: int, stats: dict, path) -> str:
+    """Human-readable summary of what the golden-set load kept vs dropped.
+
+    Covers the three UX dead-ends: an empty file (points at harvest), an
+    all-filtered file (points at the labeling TUI and --include-unreviewed),
+    and a partial load (reports the unreviewed/excluded breakdown).
+    """
+    total = stats["total"]
+    if kept == 0:
+        if total == 0:
+            return (
+                f"No newsletters to evaluate: golden set {path} is empty.\n"
+                "Harvest newsletters first with: python -m evals.newsletter_harvest"
+            )
+        return (
+            f"No newsletters to evaluate: {total} loaded from {path}, "
+            f"but {stats['unreviewed']} unreviewed and {stats['excluded']} excluded.\n"
+            "Label them with: python -m evals.newsletter_label\n"
+            "(or pass --include-unreviewed to run extraction on uncurated newsletters)"
+        )
+    dropped = []
+    if total - stats["excluded"] - kept > 0:
+        dropped.append(f"{stats['unreviewed']} unreviewed skipped")
+    if stats["excluded"]:
+        dropped.append(f"{stats['excluded']} excluded")
+    if dropped:
+        return f"Loaded {kept} of {total} newsletters from {path} ({', '.join(dropped)})"
+    return f"Loaded {kept} newsletters from {path}"
 
 
 def compute_prompt_hash(config: dict) -> str:
@@ -72,6 +116,28 @@ def compute_prompt_hash(config: dict) -> str:
     prompts = config["newsletter"]["prompts"]
     raw = json.dumps(prompts, sort_keys=True)
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def describe_endpoint() -> str:
+    """The resolved newsletter LLM URL + which env var supplied it.
+
+    Mirrors daemon.resolve_newsletter_llm_endpoint()'s precedence so error
+    messages can say WHICH endpoint was probed — the NEWSLETTER_LLM_URL vs
+    CLOUD_LLM_URL fallback is a documented source of confusion.
+    """
+    url = os.environ.get("NEWSLETTER_LLM_URL")
+    if url:
+        return f"{url} (from NEWSLETTER_LLM_URL)"
+    return f"{os.environ.get('CLOUD_LLM_URL') or '(unset)'} (from CLOUD_LLM_URL)"
+
+
+def _endpoint_url(llm) -> str | None:
+    """Best-effort base_url of a (possibly cache-wrapped) LLM client."""
+    url = getattr(llm, "base_url", None)
+    if url:
+        return url
+    inner = getattr(llm, "inner", None)
+    return getattr(inner, "base_url", None) if inner is not None else None
 
 
 class _RawCapture:
@@ -87,6 +153,7 @@ class _RawCapture:
     def __init__(self, inner):
         self.inner = inner
         self.last_raw = None
+        self.last_thinking = None
 
     def __getattr__(self, name):
         return getattr(self.inner, name)
@@ -95,6 +162,7 @@ class _RawCapture:
         result = await self.inner.complete(system_prompt, user_content, include_thinking=True)
         response, thinking = result
         self.last_raw = response
+        self.last_thinking = thinking
         if include_thinking:
             return response, thinking
         return response
@@ -113,12 +181,15 @@ def _elapsed(llm, start: float) -> float:
 
 async def evaluate_extraction(
     newsletter: GoldenNewsletter, classifier: NewsletterClassifier,
-) -> ExtractionPrediction:
+) -> tuple[ExtractionPrediction, NewsletterThinkingEntry]:
     """Run extract_stories on the raw body; compare predicted vs golden story list.
 
     Extraction is scored at the newsletter-body level: the raw body goes in, and
     the predicted [{title,text}] list is matched (in the report) against the
-    newsletter's confirmed golden stories.
+    newsletter's confirmed golden stories. The extraction chain-of-thought is
+    captured into a newsletter-level ``NewsletterThinkingEntry`` (thread_id +
+    extraction_cot) so segmentation mangles can be prompt-debugged from the
+    ``.cot.jsonl`` sidecar, just like quality/theme scoring.
     """
     pred = ExtractionPrediction(
         thread_id=newsletter.thread_id,
@@ -127,27 +198,43 @@ async def evaluate_extraction(
             for s in newsletter.stories
         ],
     )
+    thinking = NewsletterThinkingEntry(thread_id=newsletter.thread_id)
+
+    real_client = classifier.cloud_llm
+    capture = _RawCapture(real_client)
+    # Shallow-copy for the same concurrency reason as evaluate_story: swapping
+    # the shared classifier's client would race under parallelism > 1.
+    local_classifier = copy.copy(classifier)
+    local_classifier.cloud_llm = capture
     start = time.monotonic()
     try:
-        stories = await classifier.extract_stories(newsletter.body)
+        stories = await local_classifier.extract_stories(newsletter.body)
         pred.predicted_stories = [{"title": t, "text": x} for t, x in stories]
+        thinking.extraction_cot = capture.last_thinking or ""
     except (httpx.ConnectError, httpx.TimeoutException) as exc:
         pred.error = format_network_error(exc, "newsletter LLM")
     except Exception as exc:
         pred.error = str(exc)
-    pred.duration_seconds = _elapsed(classifier.cloud_llm, start)
-    return pred
+    if pred.error:
+        url = _endpoint_url(real_client)
+        if url:
+            pred.error += f" (endpoint: {url})"
+    pred.duration_seconds = _elapsed(real_client, start)
+    return pred, thinking
 
 
 async def evaluate_story(
     story: GoldenStory, thread_id: str, classifier: NewsletterClassifier,
+    do_quality: bool = True, do_themes: bool = True,
 ) -> tuple[StoryPrediction, NewsletterThinkingEntry]:
-    """Score one fixed golden story on quality + themes; derive tier from scores.
+    """Score one fixed golden story on quality and/or themes; derive tier from scores.
 
     Quality and themes are evaluated on the fixed golden (title, text), decoupled
     from extraction variability. predicted_tier is derived via compute_tier only
     when the scores parsed; a parse failure leaves scores/tier None (an error in
-    the report, not a mis-tier).
+    the report, not a mis-tier). *do_quality*/*do_themes* let quality/themes modes
+    skip the other LLM call entirely (skipped fields stay None/[], with raw=None
+    marking "never attempted" as distinct from a parse failure).
     """
     pred = StoryPrediction(
         story_id=story.story_id,
@@ -167,23 +254,29 @@ async def evaluate_story(
     local_classifier.cloud_llm = capture
     start = time.monotonic()
     try:
-        capture.last_raw = None
-        scores, quality_cot = await local_classifier.assess_quality(story.title, story.text)
-        pred.scores_raw = capture.last_raw
-        pred.predicted_scores = scores
-        thinking.quality_cot = quality_cot
-        if scores:
-            pred.predicted_tier = compute_tier(scores).value
+        if do_quality:
+            capture.last_raw = None
+            scores, quality_cot = await local_classifier.assess_quality(story.title, story.text)
+            pred.scores_raw = capture.last_raw
+            pred.predicted_scores = scores
+            thinking.quality_cot = quality_cot
+            if scores:
+                pred.predicted_tier = compute_tier(scores).value
 
-        capture.last_raw = None
-        themes, theme_cot = await local_classifier.classify_themes(story.title, story.text)
-        pred.themes_raw = capture.last_raw
-        pred.predicted_themes = themes
-        thinking.theme_cot = theme_cot
+        if do_themes:
+            capture.last_raw = None
+            themes, theme_cot = await local_classifier.classify_themes(story.title, story.text)
+            pred.themes_raw = capture.last_raw
+            pred.predicted_themes = themes
+            thinking.theme_cot = theme_cot
     except (httpx.ConnectError, httpx.TimeoutException) as exc:
         pred.error = format_network_error(exc, "newsletter LLM")
     except Exception as exc:
         pred.error = str(exc)
+    if pred.error:
+        url = _endpoint_url(real_client)
+        if url:
+            pred.error += f" (endpoint: {url})"
     pred.duration_seconds = _elapsed(real_client, start)
     return pred, thinking
 
@@ -191,11 +284,36 @@ async def evaluate_story(
 VALID_MODES = ("extraction", "quality", "themes", "all")
 
 
+def select_stories(
+    golden_set: list[GoldenNewsletter],
+) -> tuple[list[tuple[GoldenStory, str]], int, int]:
+    """Pick the (story, thread_id) pairs story modes evaluate + skip counts.
+
+    A story is evaluated only when it is Phase-B labeled (``story.reviewed``)
+    and not ``excluded`` — an unlabeled story has no ground truth, so scoring
+    it would burn LLM calls and pollute metrics with expected=None/[] rows.
+
+    Returns (pairs, n_excluded, n_unlabeled).
+    """
+    pairs: list[tuple[GoldenStory, str]] = []
+    n_excluded = n_unlabeled = 0
+    for nl in golden_set:
+        for story in nl.stories:
+            if story.excluded:
+                n_excluded += 1
+            elif not story.reviewed:
+                n_unlabeled += 1
+            else:
+                pairs.append((story, nl.thread_id))
+    return pairs, n_excluded, n_unlabeled
+
+
 async def run_evaluation(
     golden_set: list[GoldenNewsletter],
     classifier: NewsletterClassifier,
     mode: str,
     parallelism: int = 1,
+    progress: bool = False,
 ) -> tuple[list, list[NewsletterThinkingEntry]]:
     """Replay the golden set through the classifier under *mode*.
 
@@ -204,36 +322,54 @@ async def run_evaluation(
     reviewed, non-excluded golden story, quality/themes/all modes). Concurrency is
     bounded by an asyncio.Semaphore(parallelism); the shared classifier's client is
     never mutated (evaluate_story shallow-copies it), so tasks don't race.
+    With *progress*, a "[k/N] <what>" line is printed to stderr as each task
+    finishes, so long runs show signs of life.
     """
     semaphore = asyncio.Semaphore(parallelism)
     do_extraction = mode in ("extraction", "all")
-    do_stories = mode in ("quality", "themes", "all")
+    do_quality = mode in ("quality", "all")
+    do_themes = mode in ("themes", "all")
+    ticker = {"done": 0, "total": 0}
+
+    def _tick(label: str) -> None:
+        ticker["done"] += 1
+        if progress:
+            print(f"  [{ticker['done']}/{ticker['total']}] {label}", file=sys.stderr)
 
     async def run_extraction(nl: GoldenNewsletter):
         async with semaphore:
-            return await evaluate_extraction(nl, classifier)
+            result = await evaluate_extraction(nl, classifier)
+        _tick(f"extraction {nl.thread_id}")
+        return result  # (ExtractionPrediction, NewsletterThinkingEntry)
 
     async def run_story(story: GoldenStory, thread_id: str):
         async with semaphore:
-            return await evaluate_story(story, thread_id, classifier)
+            result = await evaluate_story(
+                story, thread_id, classifier,
+                do_quality=do_quality, do_themes=do_themes,
+            )
+        _tick(f"story {story.story_id}")
+        return result
 
     extraction_tasks = []
     if do_extraction:
         extraction_tasks = [run_extraction(nl) for nl in golden_set]
 
     story_tasks = []
-    if do_stories:
-        for nl in golden_set:
-            for story in nl.stories:
-                if story.excluded:
-                    continue
-                story_tasks.append(run_story(story, nl.thread_id))
+    if do_quality or do_themes:
+        story_pairs_in, _n_excluded, _n_unlabeled = select_stories(golden_set)
+        story_tasks = [run_story(story, tid) for story, tid in story_pairs_in]
 
-    extraction_rows = await asyncio.gather(*extraction_tasks)
+    ticker["total"] = len(extraction_tasks) + len(story_tasks)
+
+    extraction_pairs = await asyncio.gather(*extraction_tasks)
     story_pairs = await asyncio.gather(*story_tasks)
 
-    rows = list(extraction_rows)
+    rows = []
     thinking = []
+    for pred, entry in extraction_pairs:
+        rows.append(pred)
+        thinking.append(entry)
     for pred, entry in story_pairs:
         rows.append(pred)
         thinking.append(entry)
@@ -269,8 +405,10 @@ def build_meta(
     llm_cfg = config["newsletter"]["llm"]
     prompts = config["newsletter"]["prompts"]
     config_bytes = json.dumps(config, sort_keys=True).encode()
+    # Count only stories a story-mode run would actually evaluate (Phase-B
+    # labeled, non-excluded) so the report header matches metric denominators.
     story_count = sum(
-        1 for nl in golden_set for s in nl.stories if not s.excluded
+        1 for nl in golden_set for s in nl.stories if not s.excluded and s.reviewed
     )
     seeded_from = next((nl.seeded_from for nl in golden_set if nl.seeded_from), "")
     return NewsletterRunMeta(
@@ -317,19 +455,148 @@ def write_results(path: Path, meta: "NewsletterRunMeta", rows: list) -> None:
 
 def write_thinking_sidecar(
     results_path: Path, thinking_entries: list[NewsletterThinkingEntry],
-) -> None:
+) -> Path | None:
     """Write non-empty chain-of-thought entries to the .cot.jsonl sidecar.
 
     Only entries with at least one non-empty cot field are written; if none
-    qualify, no sidecar file is created.
+    qualify, no sidecar file is created. Returns the sidecar path when one was
+    written (so the run summary can mention it), else None.
     """
-    entries = [t for t in thinking_entries if t.quality_cot or t.theme_cot]
+    entries = [
+        t for t in thinking_entries
+        if t.quality_cot or t.theme_cot or t.extraction_cot
+    ]
     if not entries:
-        return
+        return None
     sidecar_path = results_path.with_suffix(".cot.jsonl")
     with open(sidecar_path, "w") as f:
         for entry in entries:
             f.write(json.dumps(entry.to_dict()) + "\n")
+    return sidecar_path
+
+
+def _plural(n: int, word: str) -> str:
+    if n == 1:
+        return f"1 {word}"
+    plural = word[:-1] + "ies" if word.endswith("y") else word + "s"
+    return f"{n} {plural}"
+
+
+def clamped_dimensions(scores_raw: str) -> list[str]:
+    """Dimensions whose raw model score was outside 1-5 (silently clamped).
+
+    Re-reads the raw quality response with parse_quality_scores' own pattern:
+    an out-of-range score is strong evidence the model misread the rubric, so
+    the run summary must surface it rather than leave it buried in scores_raw.
+    """
+    clamped = []
+    for dim in ("simple", "concrete", "personal", "dynamic"):
+        match = re.search(rf"{dim.upper()}\s*:\s*(\d+)", scores_raw, flags=re.IGNORECASE)
+        if match and not 1 <= int(match.group(1)) <= 5:
+            clamped.append(dim.upper())
+    return clamped
+
+
+def summarize_rows(rows: list) -> dict:
+    """Count the silent-failure modes in a run's prediction rows.
+
+    - errors: rows with .error set (network/exception failures)
+    - quality_parse_failures: quality was attempted (scores_raw captured) but
+      parse_quality_scores returned None
+    - theme_parse_failures: theme response was neither NONE nor parseable —
+      garbage output masquerading as a confident "no themes"
+    - clamped: {story_id: [DIMS]} where raw scores were out of 1-5
+    - dropped_theme_tokens: {token: count} of off-taxonomy labels parse_themes
+      silently dropped from otherwise-parsed responses
+    """
+    counts = {
+        "rows": len(rows),
+        "errors": 0,
+        "quality_parse_failures": 0,
+        "theme_parse_failures": 0,
+        "clamped": {},
+        "dropped_theme_tokens": {},
+    }
+    for r in rows:
+        if getattr(r, "error", None):
+            counts["errors"] += 1
+            continue
+        scores_raw = getattr(r, "scores_raw", None)
+        if scores_raw is not None:
+            if getattr(r, "predicted_scores", None) is None:
+                counts["quality_parse_failures"] += 1
+            else:
+                dims = clamped_dimensions(scores_raw)
+                if dims:
+                    counts["clamped"][r.story_id] = dims
+        themes_raw = getattr(r, "themes_raw", None)
+        if themes_raw is not None:
+            stripped = themes_raw.strip()
+            if stripped and stripped.upper() != "NONE":
+                invalid = [
+                    line.strip() for line in stripped.splitlines()
+                    if line.strip() and line.strip().upper() not in _VALID_THEMES
+                ]
+                if not r.predicted_themes:
+                    counts["theme_parse_failures"] += 1
+                elif invalid:
+                    for token in invalid:
+                        counts["dropped_theme_tokens"][token] = (
+                            counts["dropped_theme_tokens"].get(token, 0) + 1
+                        )
+    return counts
+
+
+def format_unreviewed_note(golden_set: list[GoldenNewsletter], mode: str) -> str | None:
+    """Warn when extraction metrics will score unreviewed newsletters.
+
+    An unreviewed (harvested-but-uncurated) newsletter has an empty golden
+    story list, so every correct prediction on it counts as a false positive.
+    Returns None outside extraction modes or when everything is reviewed.
+    """
+    if mode not in ("extraction", "all"):
+        return None
+    n_unreviewed = sum(1 for nl in golden_set if not nl.reviewed)
+    if not n_unreviewed:
+        return None
+    return (
+        f"Note: {n_unreviewed} of {len(golden_set)} evaluated newsletters are "
+        "unreviewed (no curated story list) — extraction metrics count every "
+        "predicted story on them as a false positive; treat precision as "
+        "smoke-test only."
+    )
+
+
+def format_run_summary(rows: list) -> str:
+    """Multi-line run summary: row count plus every silent-failure signal.
+
+    A catastrophic parse failure (e.g. a --prompts variant that broke the
+    response format for every story) must be visible here, not just via
+    --report or grepping the results JSONL.
+    """
+    counts = summarize_rows(rows)
+    problems = []
+    if counts["errors"]:
+        problems.append(_plural(counts["errors"], "error"))
+    if counts["quality_parse_failures"]:
+        problems.append(_plural(counts["quality_parse_failures"], "quality parse failure"))
+    if counts["theme_parse_failures"]:
+        problems.append(_plural(counts["theme_parse_failures"], "theme parse failure"))
+    lines = [f"  Rows: {counts['rows']} ({', '.join(problems) if problems else 'no errors'})"]
+    if counts["clamped"]:
+        detail = "; ".join(
+            f"{sid}: {', '.join(dims)}" for sid, dims in counts["clamped"].items()
+        )
+        lines.append(
+            f"  Out-of-range scores clamped to 1-5 in "
+            f"{_plural(len(counts['clamped']), 'story')} ({detail})"
+        )
+    if counts["dropped_theme_tokens"]:
+        detail = ", ".join(
+            f"{tok} x{n}" for tok, n in sorted(counts["dropped_theme_tokens"].items())
+        )
+        lines.append(f"  Unrecognized theme labels dropped by the parser: {detail}")
+    return "\n".join(lines)
 
 
 def merge_prompts_override(config: dict, override: dict) -> None:
@@ -382,12 +649,17 @@ def _split_rows(rows: list) -> tuple[list[StoryPrediction], list[ExtractionPredi
     return story, extraction
 
 
-def maybe_report(meta, rows, report_enabled: bool, compare_to: str | None) -> None:
+def maybe_report(
+    meta, rows, report_enabled: bool, compare_to: str | None,
+    verbose: bool = False, match_threshold: float = 0.6,
+) -> None:
     """Print a metrics report (and optional comparison) for a just-finished run.
 
     A no-op unless --report or --compare-to was passed. Defers to
     evals.newsletter_report; prints a hint if it isn't importable so a missing
-    report module never crashes a completed run.
+    report module never crashes a completed run. *verbose* and *match_threshold*
+    forward the standalone report's knobs so run --report doesn't require a
+    second newsletter_report invocation.
     """
     if not report_enabled and not compare_to:
         return
@@ -399,24 +671,48 @@ def maybe_report(meta, rows, report_enabled: bool, compare_to: str | None) -> No
         return
 
     story_preds, extraction_preds = _split_rows(rows)
-    metrics = newsletter_report.compute_all_metrics(story_preds, extraction_preds)
+    metrics = newsletter_report.compute_all_metrics(
+        story_preds, extraction_preds, match_threshold=match_threshold
+    )
     if report_enabled:
         newsletter_report.print_report(
-            meta, metrics,
+            meta, metrics, verbose=verbose,
             story_results=story_preds, extraction_results=extraction_preds,
+            match_threshold=match_threshold,
         )
     if compare_to:
         compare_path = Path(compare_to)
         if not compare_path.exists():
             print(f"Error: --compare-to file not found: {compare_path}", file=sys.stderr)
             return
-        meta_b, story_b, extraction_b = newsletter_report.load_results(compare_path)
-        metrics_b = newsletter_report.compute_all_metrics(story_b, extraction_b)
+        try:
+            meta_b, story_b, extraction_b = newsletter_report.load_results(compare_path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            # Never crash a completed (paid) run over a bad comparison file —
+            # e.g. --compare-to pointed at a .cot.jsonl sidecar by mistake.
+            print(f"Error: could not read --compare-to file {compare_path}: {exc}",
+                  file=sys.stderr)
+            return
+        metrics_b = newsletter_report.compute_all_metrics(
+            story_b, extraction_b, match_threshold=match_threshold
+        )
         # Prior run is Run A, the just-finished run is Run B (chronological order).
         newsletter_report.print_comparison(
             meta_b, metrics_b, meta, metrics,
-            verbose=True, story1=story_b, story2=story_preds,
+            verbose=verbose, story1=story_b, story2=story_preds,
         )
+
+
+def _load_toml_or_exit(path: Path, description: str) -> dict:
+    """tomllib.load with a one-line error + exit 1 instead of a traceback."""
+    try:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except FileNotFoundError:
+        print(f"Error: {description} not found: {path}", file=sys.stderr)
+    except tomllib.TOMLDecodeError as exc:
+        print(f"Error: could not parse {description} {path}: {exc}", file=sys.stderr)
+    sys.exit(1)
 
 
 async def main(args: argparse.Namespace) -> None:
@@ -425,17 +721,15 @@ async def main(args: argparse.Namespace) -> None:
         Path(args.config) if args.config
         else Path(__file__).parent.parent / "config.toml"
     )
-    with open(config_path, "rb") as f:
-        config = tomllib.load(f)
-    config = substitute_env_vars(config)
+    config = substitute_env_vars(_load_toml_or_exit(config_path, "config file"))
 
     # --prompts deep-merges alternate [newsletter.prompts.*] BEFORE prompt_hash and
     # classifier are computed, so the run measures (and records the hash of) the
     # merged prompts. --model overrides the newsletter model.
     if args.prompts:
-        with open(args.prompts, "rb") as f:
-            override = tomllib.load(f)
-        override = substitute_env_vars(override)
+        override = substitute_env_vars(
+            _load_toml_or_exit(Path(args.prompts), "--prompts file")
+        )
         merge_prompts_override(config, override)
     if args.model:
         config["newsletter"]["llm"]["model"] = args.model
@@ -444,11 +738,19 @@ async def main(args: argparse.Namespace) -> None:
 
     # Load golden set
     golden_path = Path(args.golden_set)
-    golden_set = load_golden_set(golden_path, reviewed_only=not args.include_unreviewed)
-    if not golden_set:
-        print("No newsletters to evaluate.", file=sys.stderr)
+    try:
+        golden_set, load_stats = load_golden_set(
+            golden_path, reviewed_only=not args.include_unreviewed
+        )
+    except FileNotFoundError:
+        print(f"Error: golden set file not found: {golden_path}", file=sys.stderr)
         sys.exit(1)
-    print(f"Loaded {len(golden_set)} newsletters from {golden_path}", file=sys.stderr)
+    print(format_load_summary(len(golden_set), load_stats, golden_path), file=sys.stderr)
+    if not golden_set:
+        sys.exit(1)
+    unreviewed_note = format_unreviewed_note(golden_set, args.mode)
+    if unreviewed_note:
+        print(unreviewed_note, file=sys.stderr)
 
     classifier, llm = build_classifier(config, args.no_cache)
 
@@ -458,13 +760,24 @@ async def main(args: argparse.Namespace) -> None:
         if not await llm.is_available():
             base = config["newsletter"]["llm"]
             print(
-                f"Error: newsletter LLM '{base['model']}' not reachable "
-                "(a model-name mismatch with the served model returns 404)",
+                f"Error: newsletter LLM '{base['model']}' not reachable at "
+                f"{describe_endpoint()}.\n"
+                "Check that the endpoint is up; a 404 can also mean the model "
+                "name does not match the served model.",
                 file=sys.stderr,
             )
             sys.exit(1)
 
     try:
+        if args.mode != "extraction":
+            _pairs, _n_excluded, n_unlabeled = select_stories(golden_set)
+            if n_unlabeled:
+                print(
+                    f"Skipping {_plural(n_unlabeled, 'story')} never labeled in the "
+                    "TUI (no expected scores/themes — label with "
+                    "python -m evals.newsletter_label)",
+                    file=sys.stderr,
+                )
         print(f"Running newsletter evaluation (mode={args.mode}, "
               f"parallelism={parallelism})...", file=sys.stderr)
         rows, thinking_entries = await run_evaluation(
@@ -472,6 +785,7 @@ async def main(args: argparse.Namespace) -> None:
             classifier=classifier,
             mode=args.mode,
             parallelism=parallelism,
+            progress=True,
         )
 
         meta = build_meta(
@@ -487,13 +801,18 @@ async def main(args: argparse.Namespace) -> None:
         output_dir = Path(args.output_dir)
         output_path = build_output_path(output_dir, args.mode, args.tag or "", meta.run_id)
         write_results(output_path, meta, rows)
-        write_thinking_sidecar(output_path, thinking_entries)
+        sidecar_path = write_thinking_sidecar(output_path, thinking_entries)
 
-        maybe_report(meta, rows, args.report, args.compare_to)
+        maybe_report(
+            meta, rows, args.report, args.compare_to,
+            verbose=getattr(args, "verbose", False),
+            match_threshold=getattr(args, "match_threshold", 0.6),
+        )
 
-        errors = sum(1 for r in rows if getattr(r, "error", None))
         print(f"\nResults written to {output_path}", file=sys.stderr)
-        print(f"  Rows: {len(rows)} ({errors} errors)", file=sys.stderr)
+        if sidecar_path:
+            print(f"Chain-of-thought written to {sidecar_path}", file=sys.stderr)
+        print(format_run_summary(rows), file=sys.stderr)
         if not args.no_cache and hasattr(llm, "hits"):
             total = llm.hits + llm.misses
             if total:
@@ -508,7 +827,9 @@ def cli():
     parser = argparse.ArgumentParser(description="Run newsletter classification evaluation")
     parser.add_argument("--golden-set", default="evals/newsletter_golden_set.jsonl",
                         help="Path to newsletter golden set JSONL")
-    parser.add_argument("--config", help="Path to config.toml (default: ./config.toml)")
+    parser.add_argument("--config",
+                        help="Path to config.toml (default: the repo-root config.toml, "
+                             "regardless of CWD)")
     parser.add_argument("--output-dir", default="evals/newsletter_results/",
                         help="Output directory for results")
     parser.add_argument("--mode", choices=VALID_MODES, default="all",
@@ -526,9 +847,17 @@ def cli():
                         help="Print a metrics report for this run after it completes")
     parser.add_argument("--compare-to", metavar="PATH",
                         help="After the run, print a comparison against this prior results file")
+    parser.add_argument("--verbose", action="store_true",
+                        help="With --report/--compare-to: per-story diffs and extraction detail")
+    parser.add_argument("--match-threshold", type=float, default=0.6,
+                        help="With --report/--compare-to: SequenceMatcher ratio threshold "
+                             "for extraction matching (default 0.6)")
     parser.add_argument("--skip-preflight", action="store_true",
                         help="Skip the endpoint reachability check before evaluating")
     args = parser.parse_args()
+    # httpx logs one INFO line per request; at eval volume that drowns the
+    # run's own progress output.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     asyncio.run(main(args))
 
 

--- a/evals/newsletter_run.py
+++ b/evals/newsletter_run.py
@@ -30,7 +30,7 @@ import httpx
 
 from config_utils import substitute_env_vars
 from daemon import resolve_newsletter_llm_endpoint
-from evals import format_network_error
+from evals import format_network_error, plural
 from evals.llm_cache import CachedLLMClient
 from evals.newsletter_schemas import (
     ExtractionPrediction,
@@ -401,15 +401,20 @@ def build_meta(
     mode so prompt A/Bs are self-identifying and comparable. seeded_from is pulled
     from the golden set (first newsletter that carries it) so the report can flag
     extraction-recall bias from Phase-A seeding.
+
+    story_count reflects what the run actually evaluated: story modes count only
+    Phase-B-labeled, non-excluded stories (the metric denominators), while an
+    extraction-only run counts every golden story — evaluate_extraction matches
+    predictions against the full story list, so an --include-unreviewed
+    extraction run must not record 0.
     """
     llm_cfg = config["newsletter"]["llm"]
     prompts = config["newsletter"]["prompts"]
     config_bytes = json.dumps(config, sort_keys=True).encode()
-    # Count only stories a story-mode run would actually evaluate (Phase-B
-    # labeled, non-excluded) so the report header matches metric denominators.
-    story_count = sum(
-        1 for nl in golden_set for s in nl.stories if not s.excluded and s.reviewed
-    )
+    if mode == "extraction":
+        story_count = sum(len(nl.stories) for nl in golden_set)
+    else:
+        story_count = len(select_stories(golden_set)[0])
     seeded_from = next((nl.seeded_from for nl in golden_set if nl.seeded_from), "")
     return NewsletterRunMeta(
         run_id=uuid.uuid4().hex,
@@ -473,13 +478,6 @@ def write_thinking_sidecar(
         for entry in entries:
             f.write(json.dumps(entry.to_dict()) + "\n")
     return sidecar_path
-
-
-def _plural(n: int, word: str) -> str:
-    if n == 1:
-        return f"1 {word}"
-    plural = word[:-1] + "ies" if word.endswith("y") else word + "s"
-    return f"{n} {plural}"
 
 
 def clamped_dimensions(scores_raw: str) -> list[str]:
@@ -577,11 +575,11 @@ def format_run_summary(rows: list) -> str:
     counts = summarize_rows(rows)
     problems = []
     if counts["errors"]:
-        problems.append(_plural(counts["errors"], "error"))
+        problems.append(plural(counts["errors"], "error"))
     if counts["quality_parse_failures"]:
-        problems.append(_plural(counts["quality_parse_failures"], "quality parse failure"))
+        problems.append(plural(counts["quality_parse_failures"], "quality parse failure"))
     if counts["theme_parse_failures"]:
-        problems.append(_plural(counts["theme_parse_failures"], "theme parse failure"))
+        problems.append(plural(counts["theme_parse_failures"], "theme parse failure"))
     lines = [f"  Rows: {counts['rows']} ({', '.join(problems) if problems else 'no errors'})"]
     if counts["clamped"]:
         detail = "; ".join(
@@ -589,7 +587,7 @@ def format_run_summary(rows: list) -> str:
         )
         lines.append(
             f"  Out-of-range scores clamped to 1-5 in "
-            f"{_plural(len(counts['clamped']), 'story')} ({detail})"
+            f"{plural(len(counts['clamped']), 'story', 'stories')} ({detail})"
         )
     if counts["dropped_theme_tokens"]:
         detail = ", ".join(
@@ -773,7 +771,7 @@ async def main(args: argparse.Namespace) -> None:
             _pairs, _n_excluded, n_unlabeled = select_stories(golden_set)
             if n_unlabeled:
                 print(
-                    f"Skipping {_plural(n_unlabeled, 'story')} never labeled in the "
+                    f"Skipping {plural(n_unlabeled, 'story', 'stories')} never labeled in the "
                     "TUI (no expected scores/themes — label with "
                     "python -m evals.newsletter_label)",
                     file=sys.stderr,
@@ -855,6 +853,10 @@ def cli():
     parser.add_argument("--skip-preflight", action="store_true",
                         help="Skip the endpoint reachability check before evaluating")
     args = parser.parse_args()
+    if args.parallelism is not None and args.parallelism < 1:
+        # Semaphore(0) would make every task block forever: the run hangs
+        # silently after preflight. Reject up front.
+        parser.error(f"--parallelism must be >= 1 (got {args.parallelism})")
     # httpx logs one INFO line per request; at eval volume that drowns the
     # run's own progress output.
     logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/evals/newsletter_schemas.py
+++ b/evals/newsletter_schemas.py
@@ -187,14 +187,18 @@ class ExtractionPrediction:
 
 @dataclass
 class NewsletterThinkingEntry:
-    """Chain-of-thought content for one story in an eval run.
+    """Chain-of-thought content for one eval-run unit of work.
 
+    Story-level entries (quality/theme scoring) set story_id; newsletter-level
+    entries (extraction segmentation) set thread_id + extraction_cot instead.
     Stored in sidecar .cot.jsonl files alongside main results.
     """
 
-    story_id: str
+    story_id: str = ""
     quality_cot: str = ""
     theme_cot: str = ""
+    thread_id: str = ""
+    extraction_cot: str = ""
 
     def to_dict(self) -> dict:
         return {
@@ -202,14 +206,18 @@ class NewsletterThinkingEntry:
             "story_id": self.story_id,
             "quality_cot": self.quality_cot,
             "theme_cot": self.theme_cot,
+            "thread_id": self.thread_id,
+            "extraction_cot": self.extraction_cot,
         }
 
     @classmethod
     def from_dict(cls, d: dict) -> "NewsletterThinkingEntry":
         return cls(
-            story_id=d["story_id"],
+            story_id=d.get("story_id", ""),
             quality_cot=d.get("quality_cot", ""),
             theme_cot=d.get("theme_cot", ""),
+            thread_id=d.get("thread_id", ""),
+            extraction_cot=d.get("extraction_cot", ""),
         )
 
 

--- a/evals/newsletter_schemas.py
+++ b/evals/newsletter_schemas.py
@@ -1,0 +1,287 @@
+"""Dataclasses for the newsletter golden set and evaluation results.
+
+All types support JSONL serialization via to_dict() / from_dict().
+from_dict is tolerant of missing optional keys (via d.get(...) defaults) so
+older golden sets and result files keep loading as the schema grows.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class GoldenStory:
+    """One story within a golden newsletter (ground truth)."""
+
+    story_id: str  # stable, f"{thread_id}:{index}"
+    title: str
+    text: str
+    expected_scores: dict[str, int] | None = None  # simple/concrete/personal/dynamic, 1-5
+    expected_tier: str | None = None  # "excellent" / "good" / "fair" / "poor"
+    expected_themes: list[str] = field(default_factory=list)  # lowercase theme names
+    reviewed: bool = False
+    notes: str = ""
+    excluded: bool = False  # drop from quality/theme scoring, keep as extraction truth
+
+    def to_dict(self) -> dict:
+        return {
+            "story_id": self.story_id,
+            "title": self.title,
+            "text": self.text,
+            "expected_scores": self.expected_scores,
+            "expected_tier": self.expected_tier,
+            "expected_themes": self.expected_themes,
+            "reviewed": self.reviewed,
+            "notes": self.notes,
+            "excluded": self.excluded,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "GoldenStory":
+        return cls(
+            story_id=d["story_id"],
+            title=d["title"],
+            text=d["text"],
+            expected_scores=d.get("expected_scores"),
+            expected_tier=d.get("expected_tier"),
+            expected_themes=d.get("expected_themes", []),
+            reviewed=d.get("reviewed", False),
+            notes=d.get("notes", ""),
+            excluded=d.get("excluded", False),
+        )
+
+
+@dataclass
+class GoldenNewsletter:
+    """One newsletter in the golden set; owns its list of GoldenStory."""
+
+    thread_id: str
+    message_id: str
+    sender: str
+    subject: str
+    body: str  # raw body fed verbatim to extract_stories
+    stories: list[GoldenStory] = field(default_factory=list)
+    source: str = "harvested"
+    harvested_at: str = ""  # ISO 8601
+    seeded_from: str = ""  # provenance of Phase-A story seeding, e.g. "parse_stories"
+    reviewed: bool = False  # story list confirmed = authoritative extraction truth
+    notes: str = ""
+    excluded: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "type": "golden_newsletter",
+            "thread_id": self.thread_id,
+            "message_id": self.message_id,
+            "sender": self.sender,
+            "subject": self.subject,
+            "body": self.body,
+            "stories": [s.to_dict() for s in self.stories],
+            "source": self.source,
+            "harvested_at": self.harvested_at,
+            "seeded_from": self.seeded_from,
+            "reviewed": self.reviewed,
+            "notes": self.notes,
+            "excluded": self.excluded,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "GoldenNewsletter":
+        return cls(
+            thread_id=d["thread_id"],
+            message_id=d["message_id"],
+            sender=d["sender"],
+            subject=d["subject"],
+            body=d["body"],
+            stories=[GoldenStory.from_dict(s) for s in d.get("stories", [])],
+            source=d.get("source", "harvested"),
+            harvested_at=d.get("harvested_at", ""),
+            seeded_from=d.get("seeded_from", ""),
+            reviewed=d.get("reviewed", False),
+            notes=d.get("notes", ""),
+            excluded=d.get("excluded", False),
+        )
+
+
+@dataclass
+class StoryPrediction:
+    """One prediction per golden story in quality/theme mode."""
+
+    story_id: str
+    thread_id: str
+    expected_scores: dict[str, int] | None = None
+    expected_tier: str | None = None
+    expected_themes: list[str] = field(default_factory=list)
+    predicted_scores: dict[str, int] | None = None
+    predicted_tier: str | None = None
+    predicted_themes: list[str] = field(default_factory=list)
+    scores_raw: str | None = None
+    themes_raw: str | None = None
+    duration_seconds: float = 0.0
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "type": "story_prediction",
+            "story_id": self.story_id,
+            "thread_id": self.thread_id,
+            "expected_scores": self.expected_scores,
+            "expected_tier": self.expected_tier,
+            "expected_themes": self.expected_themes,
+            "predicted_scores": self.predicted_scores,
+            "predicted_tier": self.predicted_tier,
+            "predicted_themes": self.predicted_themes,
+            "scores_raw": self.scores_raw,
+            "themes_raw": self.themes_raw,
+            "duration_seconds": self.duration_seconds,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "StoryPrediction":
+        return cls(
+            story_id=d["story_id"],
+            thread_id=d["thread_id"],
+            expected_scores=d.get("expected_scores"),
+            expected_tier=d.get("expected_tier"),
+            expected_themes=d.get("expected_themes", []),
+            predicted_scores=d.get("predicted_scores"),
+            predicted_tier=d.get("predicted_tier"),
+            predicted_themes=d.get("predicted_themes", []),
+            scores_raw=d.get("scores_raw"),
+            themes_raw=d.get("themes_raw"),
+            duration_seconds=d.get("duration_seconds", 0.0),
+            error=d.get("error"),
+        )
+
+
+@dataclass
+class ExtractionPrediction:
+    """One prediction per newsletter in extraction mode."""
+
+    thread_id: str
+    golden_stories: list[dict] = field(default_factory=list)  # [{"story_id","title","text"}]
+    predicted_stories: list[dict] = field(default_factory=list)  # [{"title","text"}]
+    duration_seconds: float = 0.0
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "type": "extraction_prediction",
+            "thread_id": self.thread_id,
+            "golden_stories": self.golden_stories,
+            "predicted_stories": self.predicted_stories,
+            "duration_seconds": self.duration_seconds,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ExtractionPrediction":
+        return cls(
+            thread_id=d["thread_id"],
+            golden_stories=d.get("golden_stories", []),
+            predicted_stories=d.get("predicted_stories", []),
+            duration_seconds=d.get("duration_seconds", 0.0),
+            error=d.get("error"),
+        )
+
+
+@dataclass
+class NewsletterThinkingEntry:
+    """Chain-of-thought content for one story in an eval run.
+
+    Stored in sidecar .cot.jsonl files alongside main results.
+    """
+
+    story_id: str
+    quality_cot: str = ""
+    theme_cot: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "type": "thinking",
+            "story_id": self.story_id,
+            "quality_cot": self.quality_cot,
+            "theme_cot": self.theme_cot,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NewsletterThinkingEntry":
+        return cls(
+            story_id=d["story_id"],
+            quality_cot=d.get("quality_cot", ""),
+            theme_cot=d.get("theme_cot", ""),
+        )
+
+
+@dataclass
+class NewsletterRunMeta:
+    """Metadata for a newsletter evaluation run (first line of results JSONL)."""
+
+    run_id: str
+    timestamp: str  # ISO 8601
+    config_hash: str
+    config_path: str
+    newsletter_model: str
+    golden_set_path: str
+    golden_set_count: int  # number of newsletters evaluated
+    story_count: int  # number of golden stories evaluated
+    mode: str = "all"  # "extraction" / "quality" / "themes" / "all"
+    prompt_hash: str = ""
+    temperature: float = 0.0
+    max_tokens: int = 0
+    extra_body: dict | None = None
+    parallelism: int = 1
+    tag: str = ""
+    seeded_from: str = ""
+    # System prompts (constant across a run, deterministic from config)
+    extraction_system_prompt: str = ""
+    quality_system_prompt: str = ""
+    theme_system_prompt: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "type": "run_meta",
+            "run_id": self.run_id,
+            "timestamp": self.timestamp,
+            "config_hash": self.config_hash,
+            "config_path": self.config_path,
+            "newsletter_model": self.newsletter_model,
+            "golden_set_path": self.golden_set_path,
+            "golden_set_count": self.golden_set_count,
+            "story_count": self.story_count,
+            "mode": self.mode,
+            "prompt_hash": self.prompt_hash,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+            "extra_body": self.extra_body,
+            "parallelism": self.parallelism,
+            "tag": self.tag,
+            "seeded_from": self.seeded_from,
+            "extraction_system_prompt": self.extraction_system_prompt,
+            "quality_system_prompt": self.quality_system_prompt,
+            "theme_system_prompt": self.theme_system_prompt,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NewsletterRunMeta":
+        return cls(
+            run_id=d["run_id"],
+            timestamp=d["timestamp"],
+            config_hash=d["config_hash"],
+            config_path=d["config_path"],
+            newsletter_model=d["newsletter_model"],
+            golden_set_path=d["golden_set_path"],
+            golden_set_count=d["golden_set_count"],
+            story_count=d["story_count"],
+            mode=d.get("mode", "all"),
+            prompt_hash=d.get("prompt_hash", ""),
+            temperature=d.get("temperature", 0.0),
+            max_tokens=d.get("max_tokens", 0),
+            extra_body=d.get("extra_body"),
+            parallelism=d.get("parallelism", 1),
+            tag=d.get("tag", ""),
+            seeded_from=d.get("seeded_from", ""),
+            extraction_system_prompt=d.get("extraction_system_prompt", ""),
+            quality_system_prompt=d.get("quality_system_prompt", ""),
+            theme_system_prompt=d.get("theme_system_prompt", ""),
+        )

--- a/evals/newsletter_schemas.py
+++ b/evals/newsletter_schemas.py
@@ -232,7 +232,10 @@ class NewsletterRunMeta:
     newsletter_model: str
     golden_set_path: str
     golden_set_count: int  # number of newsletters evaluated
-    story_count: int  # number of golden stories evaluated
+    # Stories the run evaluated: Phase-B-labeled, non-excluded stories for story
+    # modes (quality/themes/all); ALL golden stories for extraction-only runs,
+    # since extraction matches against the full confirmed story list.
+    story_count: int
     mode: str = "all"  # "extraction" / "quality" / "themes" / "all"
     prompt_hash: str = ""
     temperature: float = 0.0

--- a/tests/test_eval_newsletter_cli_docs.py
+++ b/tests/test_eval_newsletter_cli_docs.py
@@ -1,0 +1,89 @@
+"""Verify that all newsletter eval CLI options are documented in the README.
+
+Mirrors tests/test_eval_cli_docs.py for the newsletter_* eval modules. Uses
+pytest-subtests so each flag is reported individually on failure.
+"""
+
+import argparse
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+# Flags that argparse adds automatically and don't need README docs
+_ARGPARSE_BUILTINS = {"-h", "--help"}
+
+README_PATH = Path(__file__).parent.parent / "evals" / "README-technical.md"
+
+# Map: module import path -> section heading text in README-technical.md
+_CLI_MODULES = {
+    "evals.newsletter_harvest": "### newsletter_harvest",
+    "evals.newsletter_label": "### newsletter_label",
+    "evals.newsletter_run": "### newsletter_run",
+    "evals.newsletter_report": "### newsletter_report",
+}
+
+
+def _capture_parser(module_name: str) -> argparse.ArgumentParser:
+    """Import an eval module and capture its ArgumentParser before parse_args runs."""
+    captured = {}
+
+    original_parse_args = argparse.ArgumentParser.parse_args
+
+    def intercept(self, args=None, namespace=None):
+        captured["parser"] = self
+        raise SystemExit(0)  # Stop cli() from proceeding
+
+    with patch.object(argparse.ArgumentParser, "parse_args", intercept):
+        import importlib
+        mod = importlib.import_module(module_name)
+        try:
+            mod.cli()
+        except SystemExit:
+            pass
+
+    argparse.ArgumentParser.parse_args = original_parse_args
+    return captured["parser"]
+
+
+def _get_parser_flags(parser: argparse.ArgumentParser) -> set[str]:
+    """Extract all --flag names from a parser.
+
+    Excludes -h/--help and hidden flags (help=argparse.SUPPRESS).
+    """
+    flags = set()
+    for action in parser._actions:
+        if action.help == argparse.SUPPRESS:
+            continue
+        for opt in action.option_strings:
+            if opt.startswith("--") and opt not in _ARGPARSE_BUILTINS:
+                flags.add(opt)
+    return flags
+
+
+def _get_readme_section(full_text: str, heading: str) -> str:
+    """Extract the README section starting at heading, ending at the next ### or ##."""
+    pattern = re.escape(heading) + r".*?(?=\n###?\s|\Z)"
+    match = re.search(pattern, full_text, re.DOTALL)
+    return match.group(0) if match else ""
+
+
+def _get_documented_flags(section_text: str) -> set[str]:
+    """Extract all `--flag` patterns from backtick-quoted text in a README section."""
+    return set(re.findall(r"`(--[\w-]+)`", section_text))
+
+
+def test_all_newsletter_eval_cli_options_documented(subtests):
+    readme_text = README_PATH.read_text()
+
+    for module_name, heading in _CLI_MODULES.items():
+        parser = _capture_parser(module_name)
+        parser_flags = _get_parser_flags(parser)
+        section = _get_readme_section(readme_text, heading)
+        documented_flags = _get_documented_flags(section)
+
+        for flag in sorted(parser_flags):
+            with subtests.test(module=module_name, flag=flag):
+                assert flag in documented_flags, (
+                    f"{flag} from {module_name} is not documented in README "
+                    f"under '{heading}'"
+                )

--- a/tests/test_eval_newsletter_cli_docs.py
+++ b/tests/test_eval_newsletter_cli_docs.py
@@ -72,6 +72,23 @@ def _get_documented_flags(section_text: str) -> set[str]:
     return set(re.findall(r"`(--[\w-]+)`", section_text))
 
 
+def test_config_flag_help_states_repo_root_default(subtests):
+    """The --config default is resolved against the repo root
+    (Path(__file__).parent.parent / "config.toml"), not the CWD — the help
+    text must not claim './config.toml'."""
+    for module_name in ("evals.newsletter_harvest", "evals.newsletter_label",
+                        "evals.newsletter_run"):
+        parser = _capture_parser(module_name)
+        config_actions = [
+            a for a in parser._actions if "--config" in a.option_strings
+        ]
+        assert config_actions, f"{module_name} has no --config flag"
+        with subtests.test(module=module_name):
+            help_text = config_actions[0].help or ""
+            assert "./config.toml" not in help_text
+            assert "repo-root" in help_text
+
+
 def test_all_newsletter_eval_cli_options_documented(subtests):
     readme_text = README_PATH.read_text()
 

--- a/tests/test_eval_newsletter_harvest.py
+++ b/tests/test_eval_newsletter_harvest.py
@@ -1,0 +1,193 @@
+"""Tests for evals.newsletter_harvest — newsletter filtering and deduplication."""
+
+import argparse
+import json
+
+import evals.newsletter_harvest as harvest_mod
+from daemon import format_thread_transcript
+from evals.newsletter_harvest import deduplicate, harvest_newsletters, write_golden_set
+from evals.newsletter_schemas import GoldenNewsletter
+from newsletter import is_newsletter
+
+RECIPIENT = "newsletters@dm.org"
+
+CONFIG = {
+    "newsletter": {"recipient": RECIPIENT},
+    "daemon": {"max_thread_chars": 16000},
+}
+
+
+def _msg(msg_id, internal_date, to_value, from_value="ministry@example.com",
+         subject="Update", body_text="Story body"):
+    return {
+        "id": msg_id,
+        "internalDate": internal_date,
+        "snippet": "snip",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": from_value},
+                {"name": "To", "value": to_value},
+                {"name": "Subject", "value": subject},
+                {"name": "Date", "value": "Mon, 1 Jul 2026 10:00:00 +0000"},
+            ],
+            "body": {"data": ""},
+        },
+    }
+
+
+class TestIsNewsletterGuard:
+    """The harvest guard accepts a To/Cc-matching thread and rejects others."""
+
+    def test_accepts_matching_recipient(self):
+        messages = [_msg("m1", "1000", to_value=RECIPIENT)]
+        assert is_newsletter(messages, RECIPIENT) is True
+
+    def test_rejects_non_matching_recipient(self):
+        messages = [_msg("m1", "1000", to_value="someone-else@dm.org")]
+        assert is_newsletter(messages, RECIPIENT) is False
+
+
+class TestDeduplicate:
+    def _make_golden(self, thread_id: str) -> GoldenNewsletter:
+        return GoldenNewsletter(
+            thread_id=thread_id,
+            message_id="m1",
+            sender="ministry@example.com",
+            subject="Update",
+            body="body",
+        )
+
+    def test_no_existing_file(self, tmp_path):
+        goldens = [self._make_golden("t1"), self._make_golden("t2")]
+        result = deduplicate(goldens, tmp_path / "nonexistent.jsonl")
+        assert len(result) == 2
+
+    def test_dedup_removes_existing(self, tmp_path):
+        existing_file = tmp_path / "golden.jsonl"
+        existing_file.write_text(
+            json.dumps({"thread_id": "t1"}) + "\n"
+        )
+        goldens = [self._make_golden("t1"), self._make_golden("t2")]
+        result = deduplicate(goldens, existing_file)
+        assert {g.thread_id for g in result} == {"t2"}
+
+    def test_skips_malformed_line(self, tmp_path):
+        """A corrupt/partial line must not crash dedup."""
+        existing_file = tmp_path / "golden.jsonl"
+        existing_file.write_text(
+            json.dumps({"thread_id": "t1"}) + "\n"
+            + '{"thread_id": "t2", "body":\n'  # truncated, invalid JSON
+        )
+        goldens = [self._make_golden("t1"), self._make_golden("t2"), self._make_golden("t3")]
+        result = deduplicate(goldens, existing_file)
+        # t1 recognized as existing; malformed t2 line skipped so t2 treated as new.
+        assert {g.thread_id for g in result} == {"t2", "t3"}
+
+
+class _OneNewsletterProxy:
+    """Fake proxy surfacing one thread addressed to the newsletter recipient."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def list_messages(self, user_id="me", max_results=10, q=None, label_ids=None):
+        return {"messages": [{"id": "m2", "threadId": "t1"}]}
+
+    async def get_thread(self, thread_id, user_id="me", format="full"):
+        return {
+            "messages": [
+                _msg("m1", "1000", to_value=RECIPIENT, subject="First"),
+                _msg("m2", "2000", to_value=RECIPIENT, subject="Second"),
+            ]
+        }
+
+
+class _NonMatchingProxy(_OneNewsletterProxy):
+    async def get_thread(self, thread_id, user_id="me", format="full"):
+        return {
+            "messages": [_msg("m1", "1000", to_value="other@dm.org")]
+        }
+
+
+class TestHarvestNewsletters:
+    async def test_seeds_empty_unreviewed_newsletter(self):
+        proxy = _OneNewsletterProxy()
+        goldens = await harvest_newsletters(proxy, CONFIG, max_threads=10)
+        assert len(goldens) == 1
+        g = goldens[0]
+        assert g.stories == []
+        assert g.reviewed is False
+        assert g.seeded_from == ""
+
+    async def test_body_matches_format_thread_transcript(self):
+        proxy = _OneNewsletterProxy()
+        goldens = await harvest_newsletters(proxy, CONFIG, max_threads=10)
+        messages = [
+            _msg("m1", "1000", to_value=RECIPIENT, subject="First"),
+            _msg("m2", "2000", to_value=RECIPIENT, subject="Second"),
+        ]
+        messages.sort(key=lambda m: int(m["internalDate"]))
+        expected = format_thread_transcript(messages, 16000)
+        assert goldens[0].body == expected
+
+    async def test_captures_last_message_id_and_metadata(self):
+        proxy = _OneNewsletterProxy()
+        goldens = await harvest_newsletters(proxy, CONFIG, max_threads=10)
+        g = goldens[0]
+        assert g.thread_id == "t1"
+        assert g.message_id == "m2"  # last message chronologically
+        assert g.sender == "ministry@example.com"
+        assert g.subject == "First"  # first message subject
+
+    async def test_query_uses_recipient(self):
+        class RecordingProxy(_OneNewsletterProxy):
+            last_query = None
+
+            async def list_messages(self, user_id="me", max_results=10, q=None, label_ids=None):
+                RecordingProxy.last_query = q
+                return {"messages": []}
+
+        proxy = RecordingProxy()
+        await harvest_newsletters(proxy, CONFIG, max_threads=10)
+        assert proxy.last_query == f"to:{RECIPIENT}"
+
+    async def test_non_newsletter_thread_skipped(self):
+        proxy = _NonMatchingProxy()
+        goldens = await harvest_newsletters(proxy, CONFIG, max_threads=10)
+        assert goldens == []
+
+
+class TestWriteGoldenSet:
+    def _make_golden(self, thread_id: str) -> GoldenNewsletter:
+        return GoldenNewsletter(
+            thread_id=thread_id,
+            message_id="m1",
+            sender="ministry@example.com",
+            subject="Update",
+            body="body",
+        )
+
+    def test_appends_to_existing_file(self, tmp_path):
+        path = tmp_path / "golden.jsonl"
+        write_golden_set([self._make_golden("t1")], path)
+        write_golden_set([self._make_golden("t2")], path)
+        ids = [json.loads(line)["thread_id"] for line in path.read_text().splitlines() if line]
+        assert ids == ["t1", "t2"]
+
+
+class TestMainDeduplicates:
+    async def test_rerun_does_not_duplicate_thread(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(harvest_mod, "GmailProxyClient", _OneNewsletterProxy)
+        monkeypatch.setattr(harvest_mod, "load_eval_config", lambda config_path=None: CONFIG)
+        output = tmp_path / "golden.jsonl"
+        args = argparse.Namespace(
+            output=str(output),
+            max_threads=10,
+            recipient=None,
+            config=None,
+            proxy_url="http://x",
+        )
+        await harvest_mod.main(args)
+        await harvest_mod.main(args)
+        ids = [json.loads(line)["thread_id"] for line in output.read_text().splitlines() if line]
+        assert ids == ["t1"]

--- a/tests/test_eval_newsletter_harvest.py
+++ b/tests/test_eval_newsletter_harvest.py
@@ -50,6 +50,15 @@ class TestIsNewsletterGuard:
         assert is_newsletter(messages, RECIPIENT) is False
 
 
+class TestLoadEvalConfigReuse:
+    def test_reuses_email_harvest_helper(self):
+        """newsletter_harvest must reuse evals.harvest.load_eval_config, not
+        carry a byte-for-byte copy of it."""
+        import evals.harvest as email_harvest_mod
+
+        assert harvest_mod.load_eval_config is email_harvest_mod.load_eval_config
+
+
 class TestDeduplicate:
     def _make_golden(self, thread_id: str) -> GoldenNewsletter:
         return GoldenNewsletter(
@@ -199,6 +208,23 @@ class TestMainDeduplicates:
         ids = [json.loads(line)["thread_id"] for line in output.read_text().splitlines() if line]
         assert ids == ["t1"]
 
+    async def test_rerun_skips_fetching_existing_threads(self, tmp_path, monkeypatch):
+        """Threads already in the golden set must be skipped BEFORE get_thread,
+        so re-runs don't re-download every thread in the file."""
+        fetched: list[str] = []
+
+        class CountingProxy(_OneNewsletterProxy):
+            async def get_thread(self, thread_id, user_id="me", format="full"):
+                fetched.append(thread_id)
+                return await super().get_thread(thread_id, user_id=user_id, format=format)
+
+        monkeypatch.setattr(harvest_mod, "GmailProxyClient", CountingProxy)
+        monkeypatch.setattr(harvest_mod, "load_eval_config", lambda config_path=None: CONFIG)
+        args = _main_args(tmp_path / "golden.jsonl")
+        await harvest_mod.main(args)
+        await harvest_mod.main(args)
+        assert fetched == ["t1"]  # second run must not re-fetch t1
+
 
 class TestCliUx:
     """Help text shows defaults; the run is quiet and ends with a next-step hint."""
@@ -237,6 +263,15 @@ class TestCliUx:
         err = capsys.readouterr().err
         assert "PROXY_API_KEY" in err
         assert "Traceback" not in err
+
+    def test_quiet_http_logging_raises_httpx_loggers_to_warning(self, monkeypatch):
+        """quiet_http_logging() itself must set the httpx AND httpcore logger
+        levels to WARNING so per-request INFO lines are suppressed."""
+        for name in ("httpx", "httpcore"):
+            monkeypatch.setattr(logging.getLogger(name), "level", logging.NOTSET)
+        harvest_mod.quiet_http_logging()
+        assert logging.getLogger("httpx").level == logging.WARNING
+        assert logging.getLogger("httpcore").level == logging.WARNING
 
     async def test_main_silences_httpx_request_logs(self, tmp_path, monkeypatch):
         """daemon's import-time basicConfig(INFO) lets httpx spam 'HTTP Request'

--- a/tests/test_eval_newsletter_harvest.py
+++ b/tests/test_eval_newsletter_harvest.py
@@ -2,6 +2,9 @@
 
 import argparse
 import json
+import logging
+
+import pytest
 
 import evals.newsletter_harvest as harvest_mod
 from daemon import format_thread_transcript
@@ -175,19 +178,73 @@ class TestWriteGoldenSet:
         assert ids == ["t1", "t2"]
 
 
+def _main_args(output):
+    return argparse.Namespace(
+        output=str(output),
+        max_threads=10,
+        recipient=None,
+        config=None,
+        proxy_url="http://x",
+    )
+
+
 class TestMainDeduplicates:
     async def test_rerun_does_not_duplicate_thread(self, tmp_path, monkeypatch):
         monkeypatch.setattr(harvest_mod, "GmailProxyClient", _OneNewsletterProxy)
         monkeypatch.setattr(harvest_mod, "load_eval_config", lambda config_path=None: CONFIG)
         output = tmp_path / "golden.jsonl"
-        args = argparse.Namespace(
-            output=str(output),
-            max_threads=10,
-            recipient=None,
-            config=None,
-            proxy_url="http://x",
-        )
+        args = _main_args(output)
         await harvest_mod.main(args)
         await harvest_mod.main(args)
         ids = [json.loads(line)["thread_id"] for line in output.read_text().splitlines() if line]
         assert ids == ["t1"]
+
+
+class TestCliUx:
+    """Help text shows defaults; the run is quiet and ends with a next-step hint."""
+
+    def test_help_shows_output_and_max_threads_defaults(self):
+        help_text = harvest_mod.build_parser().format_help()
+        assert "evals/newsletter_golden_set.jsonl" in help_text
+        assert "default: 50" in help_text
+
+    async def test_main_prints_next_step_hint(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(harvest_mod, "GmailProxyClient", _OneNewsletterProxy)
+        monkeypatch.setattr(harvest_mod, "load_eval_config", lambda config_path=None: CONFIG)
+        output = tmp_path / "golden.jsonl"
+        await harvest_mod.main(_main_args(output))
+        err = capsys.readouterr().err
+        assert "evals.newsletter_label" in err
+        assert f"--golden-set {output}" in err
+
+    async def test_missing_proxy_api_key_exits_with_one_line_error(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        """GmailProxyClient raises ProxyAuthError at construction when
+        PROXY_API_KEY is unset; main() must print one actionable line and
+        exit 1 instead of a 20-line traceback."""
+        from proxy_client import ProxyAuthError
+
+        class _NoKeyProxy:
+            def __init__(self, *a, **kw):
+                raise ProxyAuthError("PROXY_API_KEY environment variable is not set")
+
+        monkeypatch.setattr(harvest_mod, "GmailProxyClient", _NoKeyProxy)
+        monkeypatch.setattr(harvest_mod, "load_eval_config", lambda config_path=None: CONFIG)
+        with pytest.raises(SystemExit) as excinfo:
+            await harvest_mod.main(_main_args(tmp_path / "golden.jsonl"))
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "PROXY_API_KEY" in err
+        assert "Traceback" not in err
+
+    async def test_main_silences_httpx_request_logs(self, tmp_path, monkeypatch):
+        """daemon's import-time basicConfig(INFO) lets httpx spam 'HTTP Request'
+        lines; main() must raise the httpx/httpcore loggers to WARNING."""
+        for name in ("httpx", "httpcore"):
+            monkeypatch.setattr(logging.getLogger(name), "level", logging.NOTSET)
+        monkeypatch.setattr(harvest_mod, "GmailProxyClient", _OneNewsletterProxy)
+        monkeypatch.setattr(harvest_mod, "load_eval_config", lambda config_path=None: CONFIG)
+        await harvest_mod.main(_main_args(tmp_path / "golden.jsonl"))
+        assert logging.getLogger("httpx").level == logging.WARNING
+        assert logging.getLogger("httpcore").level == logging.WARNING

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -26,6 +26,7 @@ from evals.newsletter_label import (
     format_theme_legend,
     label_progress,
     load_golden_set,
+    newsletter_exclude_status,
     restore_snapshot,
     row_for_body_line,
     save_golden_set,
@@ -34,6 +35,7 @@ from evals.newsletter_label import (
     seed_outcome_message,
     seed_stories,
     select_label_newsletters,
+    toggle_newsletter_excluded,
     unlabeled_story_count,
     wrap_text,
 )
@@ -136,6 +138,42 @@ class TestSelectLabelNewsletters:
         ]
         selected = select_label_newsletters(nls, unreviewed_only=True)
         assert [n.thread_id for n in selected] == ["keep"]
+
+    def test_include_excluded_queues_excluded_newsletters(self):
+        nls = [_newsletter("a"), _newsletter("b", excluded=True)]
+        selected = select_label_newsletters(nls, include_excluded=True)
+        assert [n.thread_id for n in selected] == ["a", "b"]
+
+    def test_include_excluded_still_honors_unreviewed_only(self):
+        nls = [
+            _newsletter("a", reviewed=True),
+            _newsletter("b", excluded=True, reviewed=False),
+        ]
+        selected = select_label_newsletters(
+            nls, unreviewed_only=True, include_excluded=True,
+        )
+        assert [n.thread_id for n in selected] == ["b"]
+
+
+class TestToggleNewsletterExcluded:
+    def test_toggles_on_and_off(self):
+        nl = _newsletter("t")
+        assert toggle_newsletter_excluded(nl) is True
+        assert nl.excluded is True
+        assert toggle_newsletter_excluded(nl) is False
+        assert nl.excluded is False
+
+    def test_leaves_reviewed_untouched(self):
+        nl = _newsletter("t", reviewed=True)
+        toggle_newsletter_excluded(nl)
+        assert nl.reviewed is True
+
+    def test_status_messages(self):
+        nl = _newsletter("t", excluded=True)
+        assert "restore" in newsletter_exclude_status(nl).lower()  # X to restore
+        assert "excluded" in newsletter_exclude_status(nl).lower()
+        nl.excluded = False
+        assert "restored" in newsletter_exclude_status(nl).lower()
 
 
 class TestUndo:
@@ -613,6 +651,28 @@ class TestFormatListRow:
     def test_reviewed_flag_leads_the_row(self):
         nl = _newsletter("t", reviewed=True)
         assert format_list_row(nl).startswith("Y")
+
+    def test_excluded_marker_takes_precedence(self):
+        nl = _newsletter("t", reviewed=True, excluded=True)
+        assert format_list_row(nl).startswith("X")
+
+
+class TestNewsletterExclusionVisibility:
+    def test_detail_rows_flag_excluded_newsletter(self):
+        nl = _newsletter("t", body="b0", excluded=True)
+        rows = build_detail_rows(nl, 0, 1, 80)
+        joined = " ".join(text for text, _ in rows)
+        assert "Excluded:" in joined
+
+    def test_detail_rows_omit_excluded_line_when_not_excluded(self):
+        nl = _newsletter("t", body="b0")
+        rows = build_detail_rows(nl, 0, 1, 80)
+        joined = " ".join(text for text, _ in rows)
+        assert "Excluded:" not in joined
+
+    def test_help_mentions_newsletter_exclude_hotkey(self):
+        joined = "  ".join(format_help_lines(500))
+        assert "[X]" in joined
 
 
 class TestFormatThemeLegend:

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -74,6 +74,16 @@ class TestSeedStories:
         assert nl.reviewed is False  # seeding is not confirmation
         assert all(not s.reviewed for s in nl.stories)
 
+    def test_seeding_a_reviewed_newsletter_clears_reviewed(self):
+        # Re-seeding replaces the confirmed story list with an uncurated
+        # machine seed — it must NOT stay authoritative extraction truth for
+        # reviewed-only runs. Undo still restores via the snapshot.
+        nl = _newsletter("tS", reviewed=True)
+
+        seed_stories(nl, [("A", "text a")])
+
+        assert nl.reviewed is False
+
     def test_seeding_replaces_prior_candidates(self):
         nl = _newsletter("tS")
         nl.stories = [_story("tS:0", title="old")]
@@ -408,18 +418,64 @@ class TestConfirmStoryList:
 
         assert nl.reviewed is True
 
-    def test_confirm_reindexes_story_ids_after_edits(self):
-        # Delete leaves a gap in ids; confirming makes them contiguous.
+    def test_confirm_preserves_existing_ids_after_delete(self):
+        # Confirm must NOT positionally renumber: deleting a story and
+        # re-confirming would rename all later stories, breaking the stable
+        # story_id contract that cross-run comparisons key on.
         nl = _newsletter("tC")
         seed_stories(nl, [("A", "a"), ("B", "b"), ("C", "c")])
-        delete_story(nl, 1)  # remove B -> ids may be stale
+        delete_story(nl, 1)  # remove B -> gap in ids is fine
 
         confirm_story_list(nl)
 
-        assert [s.story_id for s in nl.stories] == ["tC:0", "tC:1"]
+        assert [s.story_id for s in nl.stories] == ["tC:0", "tC:2"]
+
+    def test_confirm_repairs_duplicate_ids_with_fresh_unique_ones(self):
+        # Only duplicates/collisions get a fresh id; the first holder keeps its.
+        nl = _newsletter("tC")
+        nl.stories = [
+            _story("tC:0", title="A"),
+            _story("tC:0", title="A-dup"),
+            _story("tC:1", title="B"),
+        ]
+
+        confirm_story_list(nl)
+
+        ids = [s.story_id for s in nl.stories]
+        assert len(set(ids)) == len(ids)  # unique
+        assert ids[0] == "tC:0"  # first holder kept
+        assert ids[2] == "tC:1"  # untouched non-duplicate kept
+        assert ids[1] == "tC:2"  # dup repaired via the next-id helper
 
 
 class TestAddStory:
+    def test_add_after_delete_never_duplicates_an_existing_id(self):
+        # Deleting story 0 of [t1:0, t1:1, t1:2] then adding must NOT mint a
+        # second "t1:2" — downstream dicts keyed by story_id would silently
+        # collapse two stories. The next id comes from max(suffix)+1.
+        nl = _newsletter("t1")
+        seed_stories(nl, [("A", "a"), ("B", "b"), ("C", "c")])
+        delete_story(nl, 0)
+
+        added = add_story(nl, "D", "d")
+
+        ids = [s.story_id for s in nl.stories]
+        assert len(set(ids)) == len(ids)  # all unique
+        assert added.story_id == "t1:3"
+
+    def test_create_from_body_after_delete_never_duplicates_an_existing_id(self):
+        # Same defect via the body-span path: it must share add_story's id
+        # derivation instead of re-deriving from len(stories).
+        nl = _newsletter("t1", body="l0\nl1")
+        seed_stories(nl, [("A", "a"), ("B", "b"), ("C", "c")])
+        delete_story(nl, 0)
+
+        story = create_story_from_body(nl, 0, 0, "T")
+
+        ids = [s.story_id for s in nl.stories]
+        assert len(set(ids)) == len(ids)
+        assert story.story_id == "t1:3"
+
     def test_appends_story_with_stable_id_and_leaves_unreviewed(self):
         nl = _newsletter("tXY")
         nl.stories = [_story("tXY:0")]
@@ -773,6 +829,42 @@ class TestSeedFromExtractorRaw:
         assert [s.title for s in stories] == ["One"]
 
 
+class TestBuildExtractorClientConfig:
+    def test_passes_config_timeout_and_1024_max_tokens_default(self, monkeypatch):
+        # Must match daemon.run_daemon / newsletter_run.build_classifier:
+        # timeout=nl_llm.get("timeout", 60) and max_tokens default 1024.
+        import llm_client as llm_client_module
+        from evals.newsletter_label import build_extractor
+
+        captured = {}
+        real_client = llm_client_module.LLMClient
+
+        def spy(*args, **kwargs):
+            captured.update(kwargs)
+            return real_client(*args, **kwargs)
+
+        monkeypatch.setattr(llm_client_module, "LLMClient", spy)
+        monkeypatch.setenv("NEWSLETTER_LLM_URL", "http://llm.example")
+        monkeypatch.setenv("NEWSLETTER_LLM_API_KEY", "k")
+        prompt = {"system": "s", "user_template": "{body}"}
+        quality = {"system": "s", "user_template": "{title}{text}"}
+        config = {
+            "newsletter": {
+                "llm": {"model": "m", "timeout": 123},  # no max_tokens
+                "prompts": {
+                    "story_extraction": prompt,
+                    "quality_assessment": quality,
+                    "theme_classification": quality,
+                },
+            }
+        }
+
+        build_extractor(config)
+
+        assert captured["timeout"] == 123
+        assert captured["max_tokens"] == 1024
+
+
 class TestBuildExtractorPreflight:
     def test_missing_endpoint_fails_fast_naming_env_vars(self, monkeypatch):
         from evals.newsletter_label import build_extractor
@@ -991,6 +1083,72 @@ class TestDetailCursorAnchor:
             w[2] for w in screen.frames[-1] if w[3] == curses.A_REVERSE and w[1] <= 1
         ]
         assert any("para two" in text for text in reversed_rows)
+
+
+class TestDetailRowCache:
+    def _counting(self, monkeypatch):
+        import evals.newsletter_label as label
+
+        calls = {"rows": 0, "covered": 0}
+        real_rows = label.build_detail_rows
+        real_covered = label.covered_body_lines
+
+        def counting_rows(*args, **kwargs):
+            calls["rows"] += 1
+            return real_rows(*args, **kwargs)
+
+        def counting_covered(*args, **kwargs):
+            calls["covered"] += 1
+            return real_covered(*args, **kwargs)
+
+        monkeypatch.setattr(label, "build_detail_rows", counting_rows)
+        monkeypatch.setattr(label, "covered_body_lines", counting_covered)
+        return calls
+
+    def test_pure_cursor_movement_reuses_cached_rows(self, tmp_path, monkeypatch):
+        # Rows + covered-lines are expensive (full display-width wrap of the
+        # body); pure navigation keys must reuse the cache, not rebuild.
+        import curses
+
+        calls = self._counting(monkeypatch)
+        nl = _newsletter("tP", body="b0\nb1\nb2\nb3")
+
+        keys = [curses.KEY_DOWN] * 4 + [curses.KEY_UP] * 2 + ["q"]
+        _run_detail(keys, [nl], tmp_path)
+
+        assert calls["rows"] == 1
+        assert calls["covered"] == 1
+
+    def test_mutation_rebuilds_rows(self, tmp_path, monkeypatch):
+        calls = self._counting(monkeypatch)
+        nl = _newsletter("tP", body="b0\nb1")
+        seed_stories(nl, [("A", "b0")])
+
+        _run_detail(["d", "0", "\n", "q"], [nl], tmp_path)  # delete story 0
+
+        assert calls["rows"] == 2  # initial build + rebuild after the delete
+
+    def test_resize_rewraps_body(self, tmp_path):
+        # A terminal resize must invalidate the cache: the body is rewrapped
+        # to the new width so no content is lost to addnstr truncation.
+        import curses
+
+        from evals.newsletter_label import _newsletter_detail
+
+        words = [f"word{i:02d}" for i in range(24)]
+        nl = _newsletter("tP", body=" ".join(words))
+
+        class ResizingScreen(FakeScreen):
+            def getch(self):
+                self.width = 40  # shrink before the next frame renders
+                return super().getch()
+
+        screen = ResizingScreen([curses.KEY_DOWN, "q"], width=100)
+        _newsletter_detail(screen, [nl], 0, [nl], tmp_path / "golden.jsonl")
+
+        final = " ".join(w[2] for w in screen.frames[-1])
+        for word in words:
+            assert word in final
 
 
 class TestDetailSelection:

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -10,19 +10,20 @@ import sys
 from evals.newsletter_label import (
     add_story,
     assign_scores_and_themes,
+    build_detail_rows,
     capture_snapshot,
     confirm_story_list,
+    create_story_from_body,
     delete_story,
     edit_story,
     exclude_story,
     load_golden_set,
-    merge_stories,
     restore_snapshot,
     save_golden_set,
     seed_from_extractor,
     seed_stories,
     select_label_newsletters,
-    split_story,
+    wrap_text,
 )
 from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
 from newsletter import NewsletterTier, compute_tier
@@ -210,38 +211,119 @@ class TestEditStory:
         assert nl.stories[0].text == "a"  # unchanged
 
 
-class TestSplitStory:
-    def test_split_replaces_one_candidate_with_two(self):
-        nl = _newsletter("tSp")
-        seed_stories(nl, [("Merged", "part one\npart two")])
+class TestWrapText:
+    def test_long_line_wraps_to_multiple_lines(self):
+        wrapped = wrap_text("aaaa bbbb cccc", 5)
+        assert len(wrapped) >= 2
+        assert all(len(line) <= 5 for line in wrapped)
 
-        split_story(nl, 0, "part two")
+    def test_newlines_preserved(self):
+        wrapped = wrap_text("one\ntwo", 80)
+        assert wrapped == ["one", "two"]
 
-        assert len(nl.stories) == 2
-        assert nl.stories[0].text == "part one"
-        assert nl.stories[1].text == "part two"
+    def test_width_zero_leaves_unchanged(self):
+        wrapped = wrap_text("a very long line here", 0)
+        assert wrapped == ["a very long line here"]
 
-    def test_split_second_half_starts_at_marker(self):
-        nl = _newsletter("tSp")
-        seed_stories(nl, [("M", "aaa BREAK bbb")])
-
-        split_story(nl, 0, "BREAK bbb")
-
-        assert nl.stories[0].text == "aaa"
-        assert nl.stories[1].text == "BREAK bbb"
+    def test_empty_text_yields_single_empty_string(self):
+        assert wrap_text("", 80) == [""]
 
 
-class TestMergeStories:
-    def test_merge_combines_candidate_with_successor(self):
-        nl = _newsletter("tM")
-        seed_stories(nl, [("A", "a"), ("B", "b"), ("C", "c")])
+class TestCreateStoryFromBody:
+    def test_multi_line_inclusive_span_joined_with_newlines(self):
+        nl = _newsletter("tB", body="l0\nl1\nl2\nl3")
 
-        merge_stories(nl, 0)
+        story = create_story_from_body(nl, 1, 2, "Title")
 
-        assert len(nl.stories) == 2
-        assert nl.stories[0].title == "A"
-        assert nl.stories[0].text == "a\nb"
-        assert nl.stories[1].title == "C"
+        assert story.text == "l1\nl2"
+        assert nl.stories[-1] is story
+
+    def test_single_line_span(self):
+        nl = _newsletter("tB", body="l0\nl1\nl2")
+
+        story = create_story_from_body(nl, 1, 1, "T")
+
+        assert story.text == "l1"
+
+    def test_start_greater_than_end_normalized(self):
+        nl = _newsletter("tB", body="l0\nl1\nl2\nl3")
+
+        story = create_story_from_body(nl, 3, 1, "T")
+
+        assert story.text == "l1\nl2\nl3"
+
+    def test_out_of_range_clamped(self):
+        nl = _newsletter("tB", body="l0\nl1\nl2")
+
+        story = create_story_from_body(nl, -5, 99, "T")
+
+        assert story.text == "l0\nl1\nl2"
+
+    def test_small_negative_start_clamps_to_zero_not_from_end(self):
+        # Guards the *lower* clamp specifically: without max(0, ...) a small
+        # negative start would slice from the end (Python slice semantics),
+        # silently dropping the leading body lines.
+        nl = _newsletter("tB", body="l0\nl1\nl2")
+
+        story = create_story_from_body(nl, -1, 1, "T")
+
+        assert story.text == "l0\nl1"
+
+    def test_stable_story_id_and_reviewed_untouched(self):
+        nl = _newsletter("tB", body="l0\nl1")
+        nl.stories = [_story("tB:0")]
+
+        story = create_story_from_body(nl, 0, 0, "T")
+
+        assert story.story_id == "tB:1"
+        assert nl.reviewed is False
+
+    def test_empty_title_auto_derived_from_first_words(self):
+        body = " ".join(f"w{i}" for i in range(20))
+        nl = _newsletter("tB", body=body)
+
+        story = create_story_from_body(nl, 0, 0, "")
+
+        # First ~8 words, single line, trimmed, non-empty.
+        assert story.title
+        assert "\n" not in story.title
+        assert story.title.startswith("w0 w1 w2")
+        assert len(story.title.split()) <= 8
+
+    def test_empty_title_on_whitespace_only_segment_is_non_empty(self):
+        # Selecting blank/whitespace-only body lines (common: blank separator
+        # rows) with a blank title must still yield a usable, non-empty title.
+        nl = _newsletter("tB", body="   \n\t\n  ")
+
+        story = create_story_from_body(nl, 0, 2, "")
+
+        assert story.title.strip()  # non-empty after stripping
+
+
+class TestBuildDetailRows:
+    def test_header_rows_have_none_body_idx(self):
+        nl = _newsletter("tR", body="body line one\nbody line two")
+        rows = build_detail_rows(nl, 0, 1, 80)
+
+        # The first rows (subject/sender/etc.) are header rows.
+        assert rows[0][1] is None
+        assert any(idx is None for _, idx in rows)
+
+    def test_long_body_line_wraps_sharing_body_idx(self):
+        nl = _newsletter("tR", body="aaaa bbbb cccc dddd")
+        rows = build_detail_rows(nl, 0, 1, 6)
+
+        body_rows = [r for r in rows if r[1] == 0]
+        assert len(body_rows) >= 2
+        assert all(len(text) <= 6 for text, _ in body_rows)
+
+    def test_distinct_body_idx_count_matches_body_lines(self):
+        body = "line0\nline1\nline2"
+        nl = _newsletter("tR", body=body)
+        rows = build_detail_rows(nl, 0, 1, 80)
+
+        distinct = {idx for _, idx in rows if idx is not None}
+        assert len(distinct) == len(body.splitlines())
 
 
 class TestConfirmStoryList:

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -7,22 +7,34 @@ tests exercise the labeling logic without a terminal.
 
 import sys
 
+import pytest
+
 from evals.newsletter_label import (
     add_story,
     assign_scores_and_themes,
     build_detail_rows,
     capture_snapshot,
+    confirm_status_message,
     confirm_story_list,
+    covered_body_lines,
     create_story_from_body,
     delete_story,
     edit_story,
     exclude_story,
+    format_help_lines,
+    format_list_row,
+    format_theme_legend,
+    label_progress,
     load_golden_set,
     restore_snapshot,
+    row_for_body_line,
     save_golden_set,
+    seed_confirmation_message,
     seed_from_extractor,
+    seed_outcome_message,
     seed_stories,
     select_label_newsletters,
+    unlabeled_story_count,
     wrap_text,
 )
 from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
@@ -449,6 +461,593 @@ class TestSeedFromExtractor:
         assert nl.seeded_from == "parse_stories"
 
 
+class TestFormatHelpLines:
+    def test_documents_space_seed_and_paging_hotkeys(self):
+        # The Space (LLM-seed) key is Phase A's entry point and PgUp/PgDn exist;
+        # both must be discoverable from the on-screen help.
+        joined = " ".join(format_help_lines(200))
+        assert "Space" in joined
+        assert "seed" in joined.lower()
+        assert "PgUp" in joined
+
+    def test_wide_terminal_fits_on_one_line(self):
+        assert len(format_help_lines(500)) == 1
+
+    def test_narrow_terminal_wraps_to_multiple_full_lines(self):
+        lines = format_help_lines(60)
+        assert len(lines) >= 2
+        assert all(len(line) <= 60 for line in lines)
+        # Nothing is lost by wrapping: every key listed wide is listed narrow.
+        assert set(" ".join(lines).split()) == set(" ".join(format_help_lines(500)).split())
+
+
+class TestSeedConfirmationMessage:
+    def test_no_confirmation_needed_for_empty_story_list(self):
+        assert seed_confirmation_message(_newsletter("t")) is None
+
+    def test_warns_with_story_count_when_stories_exist(self):
+        nl = _newsletter("t")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+        msg = seed_confirmation_message(nl)
+        assert msg is not None
+        assert "2" in msg
+        assert "y/N" in msg
+
+    def test_mentions_labeled_stories_at_risk(self):
+        nl = _newsletter("t")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+        assign_scores_and_themes(
+            nl.stories[0], {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}, []
+        )
+        msg = seed_confirmation_message(nl)
+        assert "1 labeled" in msg
+
+    def test_singular_story_in_warning(self):
+        nl = _newsletter("t")
+        seed_stories(nl, [("A", "a")])
+        msg = seed_confirmation_message(nl)
+        assert "Replace 1 story " in msg
+        assert "stories" not in msg
+
+
+class TestConfirmStatusMessage:
+    def test_all_labeled_confirms_plainly(self):
+        nl = _newsletter("t")
+        seed_stories(nl, [("A", "a")])
+        assign_scores_and_themes(
+            nl.stories[0], {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}, []
+        )
+        assert confirm_status_message(nl) == "Story list confirmed."
+
+    def test_singular_unlabeled(self):
+        nl = _newsletter("t")
+        seed_stories(nl, [("A", "a")])
+        msg = confirm_status_message(nl)
+        assert "1 story still unlabeled" in msg
+        assert "stories" not in msg
+
+    def test_plural_unlabeled(self):
+        nl = _newsletter("t")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+        assert "2 stories still unlabeled" in confirm_status_message(nl)
+
+
+class TestSeedOutcomeMessage:
+    def test_reports_story_count_on_success(self):
+        assert "2" in seed_outcome_message("TITLE: A\nTEXT: a\n\nTITLE: B\nTEXT: b", 2)
+
+    def test_singular_story_count(self):
+        assert seed_outcome_message("TITLE: A\nTEXT: a", 1) == "Seeded 1 story."
+
+    def test_distinguishes_no_stories_verdict(self):
+        msg = seed_outcome_message("NO_STORIES", 0)
+        assert "NO_STORIES" in msg
+
+    def test_distinguishes_unparseable_output(self):
+        msg = seed_outcome_message("TITLE: dangling title with no text", 0)
+        assert "NO_STORIES" not in msg
+        assert "no parseable" in msg.lower()
+
+
+class TestRowForBodyLine:
+    def test_finds_first_row_carrying_body_idx(self):
+        rows = [("hdr", None), ("a", 0), ("b wrapped", 1), ("b wrapped2", 1), ("c", 2)]
+        assert row_for_body_line(rows, 1) == 2
+
+    def test_missing_body_idx_falls_back_to_last_row(self):
+        rows = [("hdr", None), ("a", 0)]
+        assert row_for_body_line(rows, 99) == 1
+
+    def test_empty_rows_fall_back_to_zero(self):
+        assert row_for_body_line([], 3) == 0
+
+
+class TestCoveredBodyLines:
+    def test_lines_verbatim_in_a_story_are_covered(self):
+        nl = _newsletter("t", body="greeting\nstory line one\nstory line two\nsign-off")
+        nl.stories = [_story("t:0", text="story line one\nstory line two")]
+        assert covered_body_lines(nl) == {1, 2}
+
+    def test_blank_lines_are_never_marked(self):
+        nl = _newsletter("t", body="story line\n\nother")
+        nl.stories = [_story("t:0", text="story line\n\nother")]
+        assert 1 not in covered_body_lines(nl)
+
+    def test_no_stories_means_nothing_covered(self):
+        nl = _newsletter("t", body="a\nb")
+        assert covered_body_lines(nl) == set()
+
+
+class TestLabelProgress:
+    def test_counts_labeled_over_total_excluding_excluded(self):
+        nl = _newsletter("t")
+        seed_stories(nl, [("A", "a"), ("B", "b"), ("C", "c")])
+        assign_scores_and_themes(
+            nl.stories[0], {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}, []
+        )
+        nl.stories[2].excluded = True
+        assert label_progress(nl) == (1, 2)
+
+    def test_unlabeled_story_count_ignores_excluded(self):
+        nl = _newsletter("t")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+        nl.stories[1].excluded = True
+        assert unlabeled_story_count(nl) == 1
+
+
+class TestFormatListRow:
+    def test_shows_labeled_over_total_and_sender(self):
+        nl = _newsletter("t", sender="paul@dm.org", subject="Fall update")
+        seed_stories(nl, [("A", "a"), ("B", "b"), ("C", "c")])
+        assign_scores_and_themes(
+            nl.stories[0], {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}, []
+        )
+        assign_scores_and_themes(
+            nl.stories[1], {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}, []
+        )
+        row = format_list_row(nl)
+        assert "2/3" in row
+        assert "paul@dm.org" in row
+        assert "Fall update" in row
+
+    def test_reviewed_flag_leads_the_row(self):
+        nl = _newsletter("t", reviewed=True)
+        assert format_list_row(nl).startswith("Y")
+
+
+class TestFormatThemeLegend:
+    def test_full_legend_when_it_fits(self):
+        legend = format_theme_legend([], 200)
+        assert "[s]scripture" in legend
+        assert "[d]disciple_making" in legend
+        assert "Enter=done" in legend
+
+    def test_narrow_terminal_gets_compact_legend_with_all_keys(self):
+        legend = format_theme_legend(["scripture"], 60)
+        assert len(legend) <= 60
+        for key in "schvd":
+            assert f"[{key}]" in legend
+        assert "Enter" in legend
+
+
+class TestLineBuffer:
+    def _buf(self, initial=""):
+        from evals.newsletter_label import LineBuffer
+        return LineBuffer(initial)
+
+    def test_prefill_places_cursor_at_end_and_keeps_text(self):
+        buf = self._buf("existing note")
+        assert buf.text() == "existing note"
+        buf.insert("!")
+        assert buf.text() == "existing note!"
+
+    def test_insert_backspace_and_cursor_movement(self):
+        buf = self._buf("ab")
+        buf.left()
+        buf.insert("X")
+        assert buf.text() == "aXb"
+        buf.backspace()
+        assert buf.text() == "ab"
+        buf.right()
+        buf.insert("Y")
+        assert buf.text() == "abY"
+
+    def test_control_characters_are_rejected(self):
+        buf = self._buf()
+        buf.insert("\x1b")  # Esc must never end up in the golden set
+        buf.insert("\n")
+        buf.insert("a")
+        assert buf.text() == "a"
+
+    def test_visible_scrolls_horizontally_so_input_is_never_truncated(self):
+        buf = self._buf("abcdefghij")  # 10 chars, window of 4
+        text, cur = buf.visible(4)
+        assert "j" in text  # window follows the cursor at the end
+        assert len(text) <= 4
+        assert 0 <= cur <= 4
+        for _ in range(10):
+            buf.left()
+        text, cur = buf.visible(4)
+        assert text.startswith("a")  # window follows the cursor back to the start
+        assert cur == 0
+
+
+class TestWrapTextDisplayWidth:
+    def test_emoji_wrap_respects_display_width(self):
+        # Each emoji occupies 2 terminal cells; 4 cells fit only 2 of them.
+        wrapped = wrap_text("🎉🎉🎉🎉", 4)
+        assert wrapped == ["🎉🎉", "🎉🎉"]
+
+    def test_no_characters_are_lost_when_wrapping_wide_text(self):
+        text = "José y Anaïs 🎉🎊✨ celebraron juntos"
+        wrapped = wrap_text(text, 10)
+        assert "".join("".join(line.split()) for line in wrapped) == "".join(text.split())
+
+
+class TestBuildDetailRowsLabels:
+    def test_assigned_scores_are_shown_on_the_story(self):
+        nl = _newsletter("tS", body="b0")
+        nl.stories = [_story("tS:0")]
+        assign_scores_and_themes(
+            nl.stories[0], {"simple": 4, "concrete": 4, "personal": 5, "dynamic": 3}, []
+        )
+        joined = " ".join(text for text, _ in build_detail_rows(nl, 0, 1, 80))
+        assert "4/4/5/3" in joined
+
+    def test_divider_fits_narrow_terminals(self):
+        nl = _newsletter("tS", body="b0")
+        rows = build_detail_rows(nl, 0, 1, 30)
+        dividers = [text for text, _ in rows if set(text) == {"="}]
+        # A single divider row sized to the terminal — not a 60-char rule
+        # wrapped into multiple ragged rows.
+        assert len(dividers) == 1
+        assert len(dividers[0]) <= 30
+
+
+class TestSeedFromExtractorRaw:
+    def test_returns_stories_and_raw_output_for_status_reporting(self):
+        nl = _newsletter("tX")
+        raw = "TITLE: One\nTEXT: first story"
+        stories, returned_raw = seed_from_extractor(nl, lambda body: raw)
+        assert returned_raw == raw
+        assert [s.title for s in stories] == ["One"]
+
+
+class TestBuildExtractorPreflight:
+    def test_missing_endpoint_fails_fast_naming_env_vars(self, monkeypatch):
+        from evals.newsletter_label import build_extractor
+
+        monkeypatch.delenv("NEWSLETTER_LLM_URL", raising=False)
+        monkeypatch.delenv("CLOUD_LLM_URL", raising=False)
+        with pytest.raises(SystemExit) as exc_info:
+            build_extractor({"newsletter": {"llm": {"model": "m"}}})
+        msg = str(exc_info.value)
+        assert "NEWSLETTER_LLM_URL" in msg
+        assert "CLOUD_LLM_URL" in msg
+        assert "--edit" in msg
+
+
+class FakeScreen:
+    """Minimal curses-window stand-in: scripted keys, recorded frames.
+
+    ``clear()`` starts a new frame; every ``addnstr`` is recorded as
+    ``(y, x, text, attr)`` in the current frame, so tests can assert on both
+    transient messages (any frame) and the final rendered state (last frame).
+    """
+
+    def __init__(self, keys, height=30, width=100):
+        self._keys = list(keys)
+        self.height = height
+        self.width = width
+        self.frames = [[]]
+
+    def getmaxyx(self):
+        return (self.height, self.width)
+
+    def clear(self):
+        self.frames.append([])
+
+    def refresh(self):
+        pass
+
+    def keypad(self, flag):
+        pass
+
+    def move(self, y, x):
+        pass
+
+    def addnstr(self, y, x, text, n, attr=0):
+        self.frames[-1].append((y, x, text[:n], attr))
+
+    def _pop(self):
+        if not self._keys:
+            raise AssertionError("key script exhausted — the TUI asked for more input")
+        return self._keys.pop(0)
+
+    def getch(self):
+        key = self._pop()
+        return ord(key) if isinstance(key, str) else key
+
+    def get_wch(self):
+        return self._pop()
+
+    def all_writes(self):
+        return [w for frame in self.frames for w in frame]
+
+    def texts(self):
+        return " | ".join(w[2] for w in self.all_writes())
+
+
+def _run_detail(keys, newsletters, tmp_path, extract_fn=None, index=0):
+    from evals.newsletter_label import _newsletter_detail
+
+    screen = FakeScreen(keys)
+    path = tmp_path / "golden.jsonl"
+    result = _newsletter_detail(
+        screen, newsletters, index, newsletters, path, extract_fn=extract_fn
+    )
+    return screen, result
+
+
+def _scores(n=4):
+    return {"simple": n, "concrete": n, "personal": n, "dynamic": n}
+
+
+class TestDetailSeedGuard:
+    def test_reseed_over_existing_stories_requires_confirmation(self, tmp_path):
+        nl = _newsletter("tg", body="b0\nb1")
+        seed_stories(nl, [("Keep", "b0")])
+        assign_scores_and_themes(nl.stories[0], _scores(), ["scripture"])
+
+        screen, _ = _run_detail(
+            [" ", "n", "q"], [nl], tmp_path, extract_fn=lambda body: "TITLE: New\nTEXT: b1"
+        )
+
+        # 'n' at the y/N prompt keeps the curated story AND its labels.
+        assert [s.title for s in nl.stories] == ["Keep"]
+        assert nl.stories[0].expected_scores == _scores()
+
+    def test_confirmed_reseed_replaces_and_reports_count(self, tmp_path):
+        nl = _newsletter("tg", body="b0\nb1")
+        seed_stories(nl, [("Old", "b0")])
+
+        screen, _ = _run_detail(
+            [" ", "y", "q"], [nl], tmp_path, extract_fn=lambda body: "TITLE: New\nTEXT: b1"
+        )
+
+        assert [s.title for s in nl.stories] == ["New"]
+        assert "Seeded 1" in screen.texts()
+
+    def test_empty_story_list_seeds_without_confirmation(self, tmp_path):
+        nl = _newsletter("tg", body="b0")
+
+        _run_detail([" ", "q"], [nl], tmp_path, extract_fn=lambda body: "TITLE: A\nTEXT: b0")
+
+        assert [s.title for s in nl.stories] == ["A"]
+
+    def test_no_stories_verdict_is_reported_distinctly(self, tmp_path):
+        nl = _newsletter("tg", body="admin only")
+
+        screen, _ = _run_detail([" ", "q"], [nl], tmp_path, extract_fn=lambda body: "NO_STORIES")
+
+        assert "NO_STORIES" in screen.texts()
+
+    def test_edit_mode_space_reports_seeding_disabled(self, tmp_path):
+        nl = _newsletter("tg", body="b0")
+        seed_stories(nl, [("Keep", "b0")])
+
+        screen, _ = _run_detail([" ", "q"], [nl], tmp_path, extract_fn=None)
+
+        assert [s.title for s in nl.stories] == ["Keep"]
+        assert "edit mode" in screen.texts().lower()
+
+    def test_seed_failure_keeps_stories_and_undo_clean(self, tmp_path):
+        def boom(body):
+            raise RuntimeError("connection dropped")
+
+        nl = _newsletter("tg", body="b0")
+        # Space (empty list, no confirm) -> failure hint (any key) -> z -> q
+        screen, _ = _run_detail([" ", "x", "z", "q"], [nl], tmp_path, extract_fn=boom)
+
+        assert nl.stories == []
+        assert "Seed failed" in screen.texts()
+        assert "Nothing to undo" in screen.texts()
+
+
+class TestDetailUndo:
+    def test_undo_stack_restores_multiple_edits(self, tmp_path):
+        nl = _newsletter("tU", body="b0")
+        seed_stories(nl, [("A", "a"), ("B", "b"), ("C", "c")])
+
+        keys = ["d", "0", "\n", "d", "0", "\n", "z", "z", "q"]
+        _run_detail(keys, [nl], tmp_path)
+
+        assert [s.title for s in nl.stories] == ["A", "B", "C"]
+
+    def test_cancelled_prompt_does_not_clobber_undo(self, tmp_path):
+        nl = _newsletter("tU", body="b0")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+
+        # Delete B, then open E and cancel it with Esc, then undo.
+        keys = ["d", "1", "\n", "E", "\x1b", "z", "q"]
+        _run_detail(keys, [nl], tmp_path)
+
+        assert [s.title for s in nl.stories] == ["A", "B"]
+
+    def test_undo_with_empty_stack_reports_nothing_to_undo(self, tmp_path):
+        nl = _newsletter("tU", body="b0")
+        screen, _ = _run_detail(["z", "q"], [nl], tmp_path)
+        assert "Nothing to undo" in screen.texts()
+
+
+class TestDetailDelete:
+    def test_deleting_labeled_story_requires_confirmation(self, tmp_path):
+        nl = _newsletter("tD", body="b0")
+        seed_stories(nl, [("Labeled", "a")])
+        assign_scores_and_themes(nl.stories[0], _scores(), [])
+
+        _run_detail(["d", "0", "\n", "n", "q"], [nl], tmp_path)
+
+        assert [s.title for s in nl.stories] == ["Labeled"]
+
+    def test_confirmed_delete_of_labeled_story_reports_what_was_deleted(self, tmp_path):
+        nl = _newsletter("tD", body="b0")
+        seed_stories(nl, [("Labeled", "a")])
+        assign_scores_and_themes(nl.stories[0], _scores(), [])
+
+        screen, _ = _run_detail(["d", "0", "\n", "y", "q"], [nl], tmp_path)
+
+        assert nl.stories == []
+        assert "Labeled" in screen.texts()
+        assert "Deleted" in screen.texts()
+
+    def test_invalid_index_reports_instead_of_silent_noop(self, tmp_path):
+        nl = _newsletter("tD", body="b0")
+        seed_stories(nl, [("A", "a")])
+
+        screen, _ = _run_detail(["d", "9", "\n", "q"], [nl], tmp_path)
+
+        assert [s.title for s in nl.stories] == ["A"]
+        assert "story #" in screen.texts().lower()
+
+
+class TestDetailCursorAnchor:
+    # Header rows before the body: title, divider, subject, sender, reviewed,
+    # seeded, blank, "--- Stories (0) ---", blank, "--- Body ---" = 10 rows.
+    BODY_START = 10
+
+    def test_cursor_stays_on_its_body_line_after_making_a_story(self, tmp_path):
+        import curses
+
+        nl = _newsletter("tA", body="para one\npara two\npara three")
+        keys = [curses.KEY_DOWN] * (self.BODY_START + 1) + ["s", 10, "\n", "q"]
+        screen, _ = _run_detail(keys, [nl], tmp_path)
+
+        assert len(nl.stories) == 1
+        assert nl.stories[0].text == "para two"
+        # Final frame: the cursor (reverse video) is still on "para two", even
+        # though the story list above grew and shifted every row down.
+        reversed_rows = [
+            w[2] for w in screen.frames[-1] if w[3] == curses.A_REVERSE and w[1] <= 1
+        ]
+        assert any("para two" in text for text in reversed_rows)
+
+
+class TestDetailSelection:
+    def test_esc_clears_selection_before_leaving(self, tmp_path):
+        import curses
+
+        nl = _newsletter("tE", body="para one\npara two")
+        keys = [curses.KEY_DOWN] * TestDetailCursorAnchor.BODY_START + ["s", 27, 27]
+        screen, result = _run_detail(keys, [nl], tmp_path)
+
+        assert result == "back"  # second Esc leaves; first only cleared
+        assert "election cleared" in screen.texts()
+
+    def test_esc_at_title_prompt_cancels_story_creation(self, tmp_path):
+        import curses
+
+        nl = _newsletter("tE", body="para one")
+        keys = [curses.KEY_DOWN] * TestDetailCursorAnchor.BODY_START + ["s", 10, "\x1b", "q"]
+        _run_detail(keys, [nl], tmp_path)
+
+        assert nl.stories == []  # no story, and certainly no "\x1b" title
+
+
+class TestDetailNotes:
+    def test_notes_prompt_prefills_existing_note(self, tmp_path):
+        nl = _newsletter("tN", body="b0", notes="important note")
+
+        _run_detail(["n", "\n", "q"], [nl], tmp_path)
+
+        assert nl.notes == "important note"  # Enter keeps, does not wipe
+
+
+class TestDetailLabeling:
+    def test_label_flow_assigns_scores_and_saves(self, tmp_path):
+        nl = _newsletter("tL", body="b0")
+        seed_stories(nl, [("A", "a")])
+
+        keys = ["l", "0", "\n", "4", "4", "5", "3", "\n", "q"]
+        _run_detail(keys, [nl], tmp_path)
+
+        assert nl.stories[0].expected_scores == {
+            "simple": 4, "concrete": 4, "personal": 5, "dynamic": 3,
+        }
+        assert nl.stories[0].reviewed is True
+
+    def test_score_entry_echoes_accepted_digits(self):
+        from evals.newsletter_label import _prompt_scores
+
+        screen = FakeScreen(["4", "4", "5", "3"])
+        scores = _prompt_scores(screen)
+
+        assert scores == {"simple": 4, "concrete": 4, "personal": 5, "dynamic": 3}
+        # By the last prompt the three accepted digits are visible.
+        assert any("4/4/5" in w[2] for w in screen.all_writes())
+
+    def test_relabeling_shows_current_scores(self):
+        from evals.newsletter_label import _prompt_scores
+
+        screen = FakeScreen(["x"])  # cancel immediately; only the prompt matters
+        _prompt_scores(screen, current={"simple": 2, "concrete": 3, "personal": 4, "dynamic": 5})
+
+        assert any("now 2" in w[2] for w in screen.all_writes())
+
+    def test_cancelled_score_entry_reports_it(self, tmp_path):
+        nl = _newsletter("tL", body="b0")
+        seed_stories(nl, [("A", "a")])
+
+        screen, _ = _run_detail(["l", "0", "\n", "4", "x", "q"], [nl], tmp_path)
+
+        assert nl.stories[0].expected_scores is None
+        assert "cancelled" in screen.texts().lower()
+
+    def test_confirm_warns_about_unlabeled_stories(self, tmp_path):
+        nl = _newsletter("tL", body="b0")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+
+        screen, _ = _run_detail(["c", "q"], [nl], tmp_path)
+
+        assert nl.reviewed is True
+        assert "2" in screen.texts() and "unlabeled" in screen.texts().lower()
+
+
+class TestDetailHelp:
+    def test_space_seed_hotkey_is_on_screen(self, tmp_path):
+        nl = _newsletter("tH", body="b0")
+        screen, _ = _run_detail(["q"], [nl], tmp_path)
+        assert "Space:seed" in screen.texts()
+
+
+class TestListView:
+    def test_page_down_moves_by_a_page(self, tmp_path):
+        import curses
+
+        from evals.newsletter_label import _list_view
+
+        nls = [_newsletter(f"t{i}", subject=f"subject-{i}") for i in range(10)]
+        screen = FakeScreen([curses.KEY_NPAGE, "q"], height=8, width=100)
+        _list_view(screen, nls, nls, tmp_path / "golden.jsonl")
+
+        final_reversed = [w[2] for w in screen.frames[-1] if w[3] == curses.A_REVERSE]
+        assert any("subject-5" in text for text in final_reversed)
+
+
+class TestLabelLoopEnvironment:
+    def test_escdelay_configured_for_snappy_esc(self, monkeypatch):
+        import curses
+        import os
+
+        from evals.newsletter_label import label_loop
+
+        monkeypatch.delenv("ESCDELAY", raising=False)
+        monkeypatch.setattr(curses, "wrapper", lambda *a, **kw: None)
+        label_loop([_newsletter("t")], [_newsletter("t")], "unused-path")
+
+        assert os.environ.get("ESCDELAY")
+
+
 class TestCli:
     def test_excluded_not_queued_and_preserved_on_save(self, tmp_path, monkeypatch):
         import evals.newsletter_label as label
@@ -480,6 +1079,24 @@ class TestCli:
         assert set(saved) == {"normal", "excluded"}
         assert saved["excluded"].excluded is True
         assert saved["normal"].reviewed is True
+
+    def test_missing_golden_set_hint_mentions_matching_harvest_output(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        import evals.newsletter_label as label
+
+        monkeypatch.setattr(
+            sys, "argv",
+            ["newsletter_label", "--golden-set", str(tmp_path / "nope.jsonl"), "--edit"],
+        )
+        with pytest.raises(SystemExit):
+            label.cli()
+
+        err = capsys.readouterr().err
+        # The harvest hint must say the harvest --output has to match this
+        # tool's --golden-set path, or the user harvests into the wrong file.
+        assert "--output" in err
+        assert "--golden-set" in err
 
     def test_unreviewed_only_flag_filters_queue(self, tmp_path, monkeypatch):
         import evals.newsletter_label as label

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -325,6 +325,28 @@ class TestBuildDetailRows:
         distinct = {idx for _, idx in rows if idx is not None}
         assert len(distinct) == len(body.splitlines())
 
+    def test_story_text_shown_inline_wrapped(self):
+        nl = _newsletter("tT", body="b0")
+        nl.stories = [
+            _story(
+                story_id="tT:0",
+                title="Alpha",
+                text="the quick brown fox jumped over the lazy dog",
+            )
+        ]
+        rows = build_detail_rows(nl, 0, 1, 20)
+        header_rows = [text for text, idx in rows if idx is None]
+        joined = " ".join(header_rows)
+
+        # Title still shown, and the FULL parsed text is shown inline (not truncated).
+        assert "Alpha" in joined
+        for word in ("quick", "brown", "fox", "lazy", "dog"):
+            assert word in joined
+        # Wrapped within the width and spanning multiple rows.
+        assert all(len(text) <= 20 for text in header_rows)
+        text_rows = [t for t in header_rows if any(w in t for w in ("quick", "fox", "lazy"))]
+        assert len(text_rows) >= 2
+
 
 class TestConfirmStoryList:
     def test_confirm_marks_newsletter_reviewed(self):

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -1,0 +1,404 @@
+"""Tests for evals.newsletter_label — pure state-transition functions.
+
+The curses UI is untested here by design; every behavior lives in a pure
+function that mutates a GoldenNewsletter / GoldenStory in place, so these
+tests exercise the labeling logic without a terminal.
+"""
+
+import sys
+
+from evals.newsletter_label import (
+    add_story,
+    assign_scores_and_themes,
+    capture_snapshot,
+    confirm_story_list,
+    delete_story,
+    edit_story,
+    exclude_story,
+    load_golden_set,
+    merge_stories,
+    restore_snapshot,
+    save_golden_set,
+    seed_from_extractor,
+    seed_stories,
+    select_label_newsletters,
+    split_story,
+)
+from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
+from newsletter import NewsletterTier, compute_tier
+
+
+def _newsletter(thread_id="t1", **kw):
+    base = dict(
+        thread_id=thread_id,
+        message_id="m1",
+        sender="a@dm.org",
+        subject="Subj",
+        body="raw body",
+    )
+    base.update(kw)
+    return GoldenNewsletter(**base)
+
+
+def _story(story_id="t1:0", **kw):
+    base = dict(story_id=story_id, title="Title", text="Text")
+    base.update(kw)
+    return GoldenStory(**base)
+
+
+class TestSeedStories:
+    def test_seeds_candidates_with_stable_ids_and_provenance(self):
+        nl = _newsletter("tS")
+        pairs = [("A", "text a"), ("B", "text b")]
+
+        seed_stories(nl, pairs)
+
+        assert [s.story_id for s in nl.stories] == ["tS:0", "tS:1"]
+        assert [(s.title, s.text) for s in nl.stories] == pairs
+        assert nl.seeded_from == "parse_stories"
+        assert nl.reviewed is False  # seeding is not confirmation
+        assert all(not s.reviewed for s in nl.stories)
+
+    def test_seeding_replaces_prior_candidates(self):
+        nl = _newsletter("tS")
+        nl.stories = [_story("tS:0", title="old")]
+
+        seed_stories(nl, [("new", "new text")])
+
+        assert [s.title for s in nl.stories] == ["new"]
+        assert nl.stories[0].story_id == "tS:0"
+
+
+class TestAssignScoresAndThemes:
+    def test_assigns_scores_themes_reviewed_and_derives_tier(self):
+        story = _story()
+        scores = {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}
+
+        assign_scores_and_themes(story, scores, ["scripture", "church"])
+
+        assert story.expected_scores == scores
+        assert story.expected_themes == ["scripture", "church"]
+        assert story.reviewed is True
+        # tier auto-derived from scores (avg 4.0 -> excellent)
+        assert story.expected_tier == compute_tier(scores).value
+        assert story.expected_tier == NewsletterTier.EXCELLENT.value
+
+    def test_derives_fair_tier_for_midrange_scores(self):
+        story = _story()
+        # avg 2.5 -> fair (>=2.0, <3.0)
+        scores = {"simple": 2, "concrete": 3, "personal": 2, "dynamic": 3}
+
+        assign_scores_and_themes(story, scores, [])
+
+        assert story.expected_tier == "fair"
+
+    def test_scores_are_copied_not_aliased(self):
+        story = _story()
+        scores = {"simple": 1, "concrete": 1, "personal": 1, "dynamic": 1}
+
+        assign_scores_and_themes(story, scores, [])
+        scores["simple"] = 5  # mutate caller's dict
+
+        assert story.expected_scores["simple"] == 1  # snapshot, not alias
+
+
+class TestSelectLabelNewsletters:
+    def test_excludes_excluded_newsletters(self):
+        nls = [_newsletter("keep"), _newsletter("drop", excluded=True)]
+        selected = select_label_newsletters(nls)
+        assert [n.thread_id for n in selected] == ["keep"]
+
+    def test_unreviewed_only_drops_reviewed(self):
+        nls = [
+            _newsletter("a", reviewed=False),
+            _newsletter("b", reviewed=True),
+        ]
+        selected = select_label_newsletters(nls, unreviewed_only=True)
+        assert [n.thread_id for n in selected] == ["a"]
+
+    def test_excluded_skipped_even_when_unreviewed(self):
+        nls = [
+            _newsletter("keep", reviewed=False),
+            _newsletter("drop", reviewed=False, excluded=True),
+        ]
+        selected = select_label_newsletters(nls, unreviewed_only=True)
+        assert [n.thread_id for n in selected] == ["keep"]
+
+
+class TestUndo:
+    def test_undo_restores_prior_story_list_and_reviewed(self):
+        nl = _newsletter("tU")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+        snap = capture_snapshot(nl)
+
+        # Mutate: delete a story, edit another, confirm the list.
+        delete_story(nl, 1)
+        edit_story(nl, 0, title="A-edited")
+        confirm_story_list(nl)
+        assert nl.reviewed is True
+        assert [s.title for s in nl.stories] == ["A-edited"]
+
+        restore_snapshot(nl, snap)
+
+        assert nl.reviewed is False
+        assert [(s.title, s.text) for s in nl.stories] == [("A", "a"), ("B", "b")]
+
+    def test_undo_restores_per_story_labels(self):
+        nl = _newsletter("tU")
+        seed_stories(nl, [("A", "a")])
+        snap = capture_snapshot(nl)
+
+        assign_scores_and_themes(
+            nl.stories[0],
+            {"simple": 5, "concrete": 5, "personal": 5, "dynamic": 5},
+            ["scripture"],
+        )
+        assert nl.stories[0].reviewed is True
+
+        restore_snapshot(nl, snap)
+
+        assert nl.stories[0].reviewed is False
+        assert nl.stories[0].expected_scores is None
+        assert nl.stories[0].expected_themes == []
+
+    def test_snapshot_is_independent_of_later_mutations(self):
+        # Capturing then mutating a story must not bleed into the snapshot.
+        nl = _newsletter("tU")
+        seed_stories(nl, [("A", "a")])
+        snap = capture_snapshot(nl)
+        nl.stories[0].title = "changed"
+
+        restore_snapshot(nl, snap)
+
+        assert nl.stories[0].title == "A"
+
+
+class TestExcludeStory:
+    def test_exclude_sets_flag(self):
+        story = _story()
+        exclude_story(story)
+        assert story.excluded is True
+
+
+class TestDeleteStory:
+    def test_delete_removes_candidate(self):
+        nl = _newsletter("tD")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+
+        delete_story(nl, 0)
+
+        assert [s.title for s in nl.stories] == ["B"]
+
+
+class TestEditStory:
+    def test_edit_updates_title_and_text(self):
+        nl = _newsletter("tE")
+        seed_stories(nl, [("A", "a")])
+
+        edit_story(nl, 0, title="A2", text="a2")
+
+        assert nl.stories[0].title == "A2"
+        assert nl.stories[0].text == "a2"
+
+    def test_edit_leaves_unspecified_field_untouched(self):
+        nl = _newsletter("tE")
+        seed_stories(nl, [("A", "a")])
+
+        edit_story(nl, 0, title="A2")
+
+        assert nl.stories[0].title == "A2"
+        assert nl.stories[0].text == "a"  # unchanged
+
+
+class TestSplitStory:
+    def test_split_replaces_one_candidate_with_two(self):
+        nl = _newsletter("tSp")
+        seed_stories(nl, [("Merged", "part one\npart two")])
+
+        split_story(nl, 0, "part two")
+
+        assert len(nl.stories) == 2
+        assert nl.stories[0].text == "part one"
+        assert nl.stories[1].text == "part two"
+
+    def test_split_second_half_starts_at_marker(self):
+        nl = _newsletter("tSp")
+        seed_stories(nl, [("M", "aaa BREAK bbb")])
+
+        split_story(nl, 0, "BREAK bbb")
+
+        assert nl.stories[0].text == "aaa"
+        assert nl.stories[1].text == "BREAK bbb"
+
+
+class TestMergeStories:
+    def test_merge_combines_candidate_with_successor(self):
+        nl = _newsletter("tM")
+        seed_stories(nl, [("A", "a"), ("B", "b"), ("C", "c")])
+
+        merge_stories(nl, 0)
+
+        assert len(nl.stories) == 2
+        assert nl.stories[0].title == "A"
+        assert nl.stories[0].text == "a\nb"
+        assert nl.stories[1].title == "C"
+
+
+class TestConfirmStoryList:
+    def test_confirm_marks_newsletter_reviewed(self):
+        nl = _newsletter("tC")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+        assert nl.reviewed is False
+
+        confirm_story_list(nl)
+
+        assert nl.reviewed is True
+
+    def test_confirm_reindexes_story_ids_after_edits(self):
+        # Delete leaves a gap in ids; confirming makes them contiguous.
+        nl = _newsletter("tC")
+        seed_stories(nl, [("A", "a"), ("B", "b"), ("C", "c")])
+        delete_story(nl, 1)  # remove B -> ids may be stale
+
+        confirm_story_list(nl)
+
+        assert [s.story_id for s in nl.stories] == ["tC:0", "tC:1"]
+
+
+class TestAddStory:
+    def test_appends_story_with_stable_id_and_leaves_unreviewed(self):
+        nl = _newsletter("tXY")
+        nl.stories = [_story("tXY:0")]
+
+        add_story(nl, title="New", text="New text")
+
+        assert len(nl.stories) == 2
+        added = nl.stories[1]
+        assert added.story_id == "tXY:1"  # stable f"{thread_id}:{index}"
+        assert added.title == "New"
+        assert added.text == "New text"
+        assert added.reviewed is False
+        assert nl.reviewed is False  # adding does not confirm the list
+
+
+
+class TestLoadSaveRoundTrip:
+    def test_save_then_load_preserves_nested_stories(self, tmp_path):
+        path = tmp_path / "golden.jsonl"
+        nl = _newsletter("t1")
+        seed_stories(nl, [("A", "a"), ("B", "b")])
+        assign_scores_and_themes(
+            nl.stories[0],
+            {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
+            ["scripture"],
+        )
+        confirm_story_list(nl)
+
+        save_golden_set([nl], path)
+        loaded = load_golden_set(path)
+
+        assert len(loaded) == 1
+        assert loaded[0].thread_id == "t1"
+        assert [s.title for s in loaded[0].stories] == ["A", "B"]
+        assert loaded[0].stories[0].expected_tier == "excellent"
+        assert loaded[0].reviewed is True
+
+    def test_load_tolerates_blank_lines(self, tmp_path):
+        path = tmp_path / "golden.jsonl"
+        nl = _newsletter("t1")
+        save_golden_set([nl], path)
+        with open(path, "a") as f:
+            f.write("\n")  # trailing blank line
+
+        loaded = load_golden_set(path)
+        assert len(loaded) == 1
+
+
+class TestSeedFromExtractor:
+    def test_runs_extractor_output_through_parse_stories(self):
+        # The injected extractor returns the *raw* LLM extraction string; the
+        # tool must parse it with the production parse_stories, so tests never
+        # hit a network.
+        nl = _newsletter("tX")
+        raw = "TITLE: One\nTEXT: first story\n\nTITLE: Two\nTEXT: second story"
+
+        captured = {}
+
+        def fake_extract(body):
+            captured["body"] = body
+            return raw
+
+        seed_from_extractor(nl, fake_extract)
+
+        assert captured["body"] == "raw body"  # body fed verbatim
+        assert [(s.title, s.text) for s in nl.stories] == [
+            ("One", "first story"),
+            ("Two", "second story"),
+        ]
+        assert nl.seeded_from == "parse_stories"
+        assert nl.reviewed is False
+
+    def test_no_stories_seeds_empty_list(self):
+        nl = _newsletter("tX")
+        seed_from_extractor(nl, lambda body: "NO_STORIES")
+        assert nl.stories == []
+        assert nl.seeded_from == "parse_stories"
+
+
+class TestCli:
+    def test_excluded_not_queued_and_preserved_on_save(self, tmp_path, monkeypatch):
+        import evals.newsletter_label as label
+
+        path = tmp_path / "golden.jsonl"
+        save_golden_set(
+            [
+                _newsletter("normal", reviewed=False),
+                _newsletter("excluded", reviewed=True, excluded=True),
+            ],
+            path,
+        )
+
+        seen = {}
+
+        def fake_loop(newsletters, all_newsletters, p, **kwargs):
+            seen["ids"] = [n.thread_id for n in newsletters]
+            for n in newsletters:
+                n.reviewed = True
+
+        monkeypatch.setattr(label, "label_loop", fake_loop)
+        monkeypatch.setattr(
+            sys, "argv", ["newsletter_label", "--golden-set", str(path), "--edit"]
+        )
+        label.cli()
+
+        assert seen["ids"] == ["normal"]  # excluded never queued
+        saved = {n.thread_id: n for n in load_golden_set(path)}
+        assert set(saved) == {"normal", "excluded"}
+        assert saved["excluded"].excluded is True
+        assert saved["normal"].reviewed is True
+
+    def test_unreviewed_only_flag_filters_queue(self, tmp_path, monkeypatch):
+        import evals.newsletter_label as label
+
+        path = tmp_path / "golden.jsonl"
+        save_golden_set(
+            [
+                _newsletter("done", reviewed=True),
+                _newsletter("todo", reviewed=False),
+            ],
+            path,
+        )
+
+        seen = {}
+
+        def fake_loop(newsletters, all_newsletters, p, **kwargs):
+            seen["ids"] = [n.thread_id for n in newsletters]
+
+        monkeypatch.setattr(label, "label_loop", fake_loop)
+        monkeypatch.setattr(
+            sys, "argv",
+            ["newsletter_label", "--golden-set", str(path), "--unreviewed-only", "--edit"],
+        )
+        label.cli()
+
+        assert seen["ids"] == ["todo"]

--- a/tests/test_eval_newsletter_report.py
+++ b/tests/test_eval_newsletter_report.py
@@ -1,8 +1,16 @@
 """Tests for evals.newsletter_report — newsletter eval metrics on hand-built fixtures."""
 
+import json
+import sys
+
+import pytest
+
 from evals.newsletter_report import (
     THEMES,
     TIERS,
+    _format_dim_table,
+    build_trend_rows,
+    cli,
     compute_all_metrics,
     compute_dimension_exact_match,
     compute_dimension_mae,
@@ -12,9 +20,42 @@ from evals.newsletter_report import (
     compute_tier_metrics,
     format_mae_delta,
     format_metric_delta,
+    load_story_titles,
     match_stories,
+    match_stories_detailed,
+    print_comparison,
+    print_report,
+    print_trend,
+    theme_parse_anomalies,
 )
-from evals.newsletter_schemas import ExtractionPrediction, StoryPrediction
+from evals.newsletter_schemas import (
+    ExtractionPrediction,
+    NewsletterRunMeta,
+    StoryPrediction,
+)
+
+
+def _write_results(path, meta, rows=()):
+    with open(path, "w") as f:
+        f.write(json.dumps(meta.to_dict()) + "\n")
+        for row in rows:
+            f.write(json.dumps(row.to_dict()) + "\n")
+
+
+def _meta(mode="all", **kwargs) -> NewsletterRunMeta:
+    defaults = dict(
+        run_id="abcdef0123456789",
+        timestamp="2026-07-03T00:00:00+00:00",
+        config_hash="cfg",
+        config_path="config.toml",
+        newsletter_model="test-model",
+        golden_set_path="golden.jsonl",
+        golden_set_count=1,
+        story_count=1,
+        mode=mode,
+    )
+    defaults.update(kwargs)
+    return NewsletterRunMeta(**defaults)
 
 
 def _pred(
@@ -130,13 +171,16 @@ class TestTierMetrics:
         assert abs(m["per_class"]["good"]["precision"] - 0.5) < 1e-9
 
     def test_parse_failure_counted_as_error_excluded_from_matrix(self):
+        # parse failure: quality was attempted (scores_raw captured) but
+        # predicted_scores is None -> error, excluded from matrix.
+        # A stray predicted_tier is present but must be ignored because scores
+        # failed to parse (guards exclusion-by-None-scores, not by None-tier).
+        failed = _pred(predicted_scores=None, expected_tier="good", predicted_tier="good")
+        failed.scores_raw = "garbage the parser rejected"
         results = [
             _pred(predicted_scores={"simple": 5}, expected_tier="excellent",
                   predicted_tier="excellent"),
-            # parse failure: predicted_scores is None -> error, excluded from matrix.
-            # A stray predicted_tier is present but must be ignored because scores
-            # failed to parse (guards exclusion-by-None-scores, not by None-tier).
-            _pred(predicted_scores=None, expected_tier="good", predicted_tier="good"),
+            failed,
         ]
         m = compute_tier_metrics(results)
         assert m["errors"] == 1
@@ -292,6 +336,602 @@ class TestExtractionMetrics:
         assert abs(m["macro_recall"] - 1.0) < 1e-9
 
 
+
+
+class TestMatchStoriesUsesText:
+    def test_vague_title_verbatim_text_still_matches(self):
+        # The mangle scenario: the model invents a vague title but the extracted
+        # text is a verbatim span of the golden story. Matching must be on TEXT,
+        # not title wording.
+        golden_text = ("Priya's junior year started with a broken ankle and a "
+                       "cancelled semester abroad, and she joined our Thursday "
+                       "study out of boredom and stayed out of conviction.")
+        predicted = [{"title": "Ministry Moments", "text": golden_text}]
+        golden = [{"story_id": "g:2", "title": "Priya's Injury and the Thursday Study",
+                   "text": golden_text}]
+        matched, _, _ = match_stories(predicted, golden)
+        assert matched == 1
+
+    def test_copied_title_garbled_text_does_not_match(self):
+        # Converse: a plausible copied title must not mask a garbled text span.
+        predicted = [{"title": "Marcus the Skeptic",
+                      "text": "completely unrelated words about the annual budget"}]
+        golden = [{"story_id": "g:0", "title": "Marcus the Skeptic",
+                   "text": "Marcus came to our Tuesday night dinner in January "
+                           "as a self-described skeptic and left praying aloud."}]
+        matched, _, _ = match_stories(predicted, golden)
+        assert matched == 0
+
+
+class TestMatchStoriesDetailed:
+    def test_reports_pairs_and_unmatched(self):
+        predicted = [
+            {"title": "P0", "text": "the quick brown fox jumped over the dog"},
+            {"title": "P1", "text": "a spurious donation appeal paragraph"},
+        ]
+        golden = [
+            {"story_id": "g:0", "title": "G0",
+             "text": "the quick brown fox jumped over the cat"},
+            {"story_id": "g:1", "title": "G1",
+             "text": "an entirely different account of the retreat weekend"},
+        ]
+        detail = match_stories_detailed(predicted, golden)
+        assert len(detail["matched"]) == 1
+        pair = detail["matched"][0]
+        assert pair["pred_index"] == 0
+        assert pair["gold_index"] == 0
+        assert 0.6 <= pair["ratio"] <= 1.0
+        assert detail["unmatched_predicted"] == [1]
+        assert detail["unmatched_golden"] == [1]
+
+    def test_respects_threshold(self):
+        predicted = [{"title": "", "text": "the quick brown fox"}]
+        golden = [{"story_id": "g:0", "title": "", "text": "an unrelated gardening story"}]
+        strict = match_stories_detailed(predicted, golden, threshold=0.9)
+        assert strict["matched"] == []
+        loose = match_stories_detailed(predicted, golden, threshold=0.0)
+        assert len(loose["matched"]) == 1
+
+
+class TestExtractionAbstention:
+    def test_correct_no_stories_scores_perfect(self):
+        # A newsletter with 0 predicted and 0 golden stories is a CORRECT
+        # abstention -> per-newsletter precision/recall 1.0, not 0.0.
+        nl_empty = ExtractionPrediction(thread_id="C", golden_stories=[],
+                                        predicted_stories=[])
+        nl_good = ExtractionPrediction(
+            thread_id="A",
+            golden_stories=[{"story_id": "A:0", "title": "", "text": "alpha faith"}],
+            predicted_stories=[{"title": "", "text": "alpha faith"}],
+        )
+        m = compute_extraction_metrics([nl_good, nl_empty])
+        assert m["macro_precision"] == 1.0
+        assert m["macro_recall"] == 1.0
+        empty_row = next(r for r in m["per_newsletter"] if r["thread_id"] == "C")
+        assert empty_row["precision"] == 1.0
+        assert empty_row["recall"] == 1.0
+
+    def test_empty_results_yield_none_not_zero(self):
+        m = compute_extraction_metrics([])
+        assert m["count"] == 0
+        for key in ("micro_precision", "micro_recall", "micro_f1",
+                    "macro_precision", "macro_recall", "macro_f1"):
+            assert m[key] is None
+
+
+class TestThemeMetricsGating:
+    def test_quality_parse_failure_does_not_drop_theme_row(self):
+        # Story with malformed quality response (predicted_scores None) but a
+        # perfectly parsed theme prediction must still count in theme metrics.
+        results = [
+            _pred(story_id="ok", expected_themes=["church"], predicted_themes=["church"],
+                  predicted_scores={"simple": 3}),
+        ]
+        failed = _pred(story_id="priya", expected_themes=["christlikeness"],
+                       predicted_themes=[], predicted_scores=None)
+        failed.themes_raw = "NONE"
+        results.append(failed)
+        m = compute_multilabel_metrics(results, THEMES)
+        assert m["count"] == 2
+        # christlikeness expected but not predicted -> FN -> recall 0
+        assert m["per_theme"]["christlikeness"]["recall"] == 0.0
+
+    def test_error_rows_still_excluded(self):
+        errored = _pred(story_id="down", expected_themes=["church"],
+                        error="connection refused")
+        m = compute_multilabel_metrics([errored], THEMES)
+        assert m["count"] == 0
+
+    def test_empty_scored_yields_none_not_zero(self):
+        m = compute_multilabel_metrics([], THEMES)
+        assert m["count"] == 0
+        for key in ("micro_precision", "micro_recall", "micro_f1", "macro_f1"):
+            assert m[key] is None
+        assert m["exact_set_match"] is None
+
+
+class TestTierErrorStories:
+    def test_error_story_ids_listed(self):
+        failed = _pred(story_id="t:2", predicted_scores=None, expected_tier="good")
+        failed.scores_raw = "unparseable quality response"
+        results = [
+            _pred(story_id="fine", predicted_scores={"simple": 3},
+                  expected_tier="good", predicted_tier="good"),
+            failed,
+        ]
+        m = compute_tier_metrics(results)
+        assert m["errors"] == 1
+        assert m["error_stories"] == ["t:2"]
+
+
+class TestTierQualityNotAttempted:
+    def test_themes_mode_rows_are_skipped_not_errors(self):
+        # A --mode themes run never attempts the quality call: error=None AND
+        # scores_raw=None. Those rows are "quality not attempted", not parse
+        # failures — the tier section must not render as "0 stories, N errors".
+        row = _pred(story_id="t:0", expected_tier="good",
+                    expected_themes=["church"], predicted_themes=["church"])
+        row.themes_raw = "CHURCH"
+        m = compute_tier_metrics([row])
+        assert m["errors"] == 0
+        assert m["error_stories"] == []
+        assert m["count"] == 0
+
+    def test_network_error_rows_still_count_as_errors(self):
+        # error rows have scores_raw=None too, but must stay errors.
+        m = compute_tier_metrics([
+            _pred(story_id="down", expected_tier="good", error="connection refused"),
+        ])
+        assert m["errors"] == 1
+        assert m["error_stories"] == ["down"]
+
+    def test_verbose_failures_section_excludes_not_attempted(self, capsys):
+        row = _pred(story_id="t:0", expected_themes=["church"],
+                    predicted_themes=["church"])
+        row.themes_raw = "CHURCH"
+        metrics = compute_all_metrics([row])
+        print_report(_meta(mode="themes"), metrics, verbose=True, story_results=[row])
+        out = capsys.readouterr().out
+        assert "Parse/Network Failures" not in out
+
+
+class TestThemeParseAnomalies:
+    def test_invalid_token_and_empty_parse_detected(self):
+        marcus = _pred(story_id="g:0", predicted_themes=["church"],
+                       predicted_scores={"simple": 3})
+        marcus.themes_raw = "FELLOWSHIP\nCHURCH"
+        alina = _pred(story_id="g:1", predicted_themes=[],
+                      predicted_scores={"simple": 3})
+        alina.themes_raw = "The themes of hope and belonging shine through this piece."
+        clean_none = _pred(story_id="g:2", predicted_themes=[],
+                           predicted_scores={"simple": 3})
+        clean_none.themes_raw = "NONE"
+        clean = _pred(story_id="g:3", predicted_themes=["scripture"],
+                      predicted_scores={"simple": 3})
+        clean.themes_raw = "SCRIPTURE"
+        anomalies = theme_parse_anomalies([marcus, alina, clean_none, clean])
+        by_id = {a["story_id"]: a for a in anomalies}
+        assert set(by_id) == {"g:0", "g:1"}
+        assert by_id["g:0"]["kind"] == "invalid_tokens"
+        assert by_id["g:0"]["invalid_tokens"] == ["FELLOWSHIP"]
+        assert by_id["g:1"]["kind"] == "empty_parse"
+        assert by_id["g:1"]["themes_raw"].startswith("The themes")
+
+    def test_rows_without_raw_are_skipped(self):
+        # Legacy rows / error rows carry no themes_raw -> no anomaly.
+        anomalies = theme_parse_anomalies([_pred(story_id="x", predicted_themes=[])])
+        assert anomalies == []
+
+
+class TestComputeAllMetricsBundleKeys:
+    def test_story_count_and_anomalies_present(self):
+        m = compute_all_metrics([], [])
+        assert m["story_count"] == 0
+        assert m["theme_anomalies"] == []
+
+
+class TestPrintReportSections:
+    def _extraction_only_metrics(self):
+        extraction = [
+            ExtractionPrediction(
+                thread_id="A",
+                golden_stories=[{"story_id": "A:0", "title": "", "text": "alpha faith"}],
+                predicted_stories=[{"title": "", "text": "alpha faith"}],
+            ),
+        ]
+        return compute_all_metrics([], extraction), extraction
+
+    def test_extraction_only_run_omits_quality_and_theme_sections(self, capsys):
+        metrics, _ = self._extraction_only_metrics()
+        print_report(_meta(mode="extraction"), metrics)
+        out = capsys.readouterr().out
+        assert "Themes (multi-label)" not in out
+        assert "Quality Dimensions" not in out
+        assert "Extraction" in out
+
+    def test_header_shows_golden_set_path(self, capsys):
+        metrics, _ = self._extraction_only_metrics()
+        print_report(_meta(golden_set_path="/data/golden.jsonl"), metrics)
+        out = capsys.readouterr().out
+        assert "/data/golden.jsonl" in out
+
+    def test_extraction_section_shows_count_and_threshold(self, capsys):
+        metrics, extraction = self._extraction_only_metrics()
+        print_report(_meta(), metrics, extraction_results=extraction,
+                     match_threshold=0.4)
+        out = capsys.readouterr().out
+        assert "1 newsletter" in out
+        assert "0.4" in out
+
+    def test_single_error_pluralized_and_named(self, capsys):
+        failed = _pred(story_id="t:2", predicted_scores=None, expected_tier="good")
+        failed.scores_raw = "unparseable quality response"
+        story_results = [
+            _pred(story_id="ok", predicted_scores={"simple": 3},
+                  expected_tier="good", predicted_tier="good"),
+            failed,
+        ]
+        metrics = compute_all_metrics(story_results)
+        print_report(_meta(), metrics, story_results=story_results)
+        out = capsys.readouterr().out
+        assert "1 error)" in out
+        assert "1 errors" not in out
+        assert "t:2" in out  # the failing story is named
+
+    def test_story_count_pluralizes_as_stories(self, capsys):
+        story_results = [
+            _pred(story_id=f"s{i}", predicted_scores={"simple": 3},
+                  expected_tier="good", predicted_tier="good")
+            for i in range(2)
+        ]
+        metrics = compute_all_metrics(story_results)
+        print_report(_meta(), metrics, story_results=story_results)
+        out = capsys.readouterr().out
+        assert "2 stories" in out
+        assert "storys" not in out
+
+    def test_theme_anomaly_count_shown(self, capsys):
+        row = _pred(story_id="g:0", predicted_themes=["church"],
+                    predicted_scores={"simple": 3})
+        row.themes_raw = "FELLOWSHIP\nCHURCH"
+        metrics = compute_all_metrics([row])
+        print_report(_meta(), metrics, story_results=[row])
+        out = capsys.readouterr().out
+        assert "anomal" in out.lower()
+
+
+class TestPrintReportVerbose:
+    def _mangled_extraction(self):
+        return ExtractionPrediction(
+            thread_id="thread-g",
+            golden_stories=[
+                {"story_id": "g:0", "title": "Marcus the Skeptic",
+                 "text": "Marcus came to dinner as a skeptic and left praying aloud."},
+                {"story_id": "g:1", "title": "Nine Freshmen",
+                 "text": "Nine freshmen showed up to the cookout with no idea."},
+            ],
+            predicted_stories=[
+                {"title": "Supporting the Mission",
+                 "text": "Would you consider a year-end gift to keep this going?"},
+            ],
+        )
+
+    def test_verbose_lists_unmatched_titles(self, capsys):
+        extraction = [self._mangled_extraction()]
+        metrics = compute_all_metrics([], extraction)
+        print_report(_meta(mode="extraction"), metrics, verbose=True,
+                     extraction_results=extraction)
+        out = capsys.readouterr().out
+        assert "Supporting the Mission" in out  # unmatched predicted title
+        assert "Marcus the Skeptic" in out  # unmatched golden title
+        assert "Nine Freshmen" in out
+
+    def test_verbose_lists_matched_pairs_with_ratio_on_mismatch(self, capsys):
+        extraction = [
+            ExtractionPrediction(
+                thread_id="t",
+                golden_stories=[
+                    {"story_id": "t:0", "title": "G0",
+                     "text": "the quick brown fox jumped over the lazy dog"},
+                    {"story_id": "t:1", "title": "G1",
+                     "text": "a wholly different story about the retreat"},
+                ],
+                predicted_stories=[
+                    {"title": "P0",
+                     "text": "the quick brown fox jumped over the lazy cat"},
+                ],
+            ),
+        ]
+        metrics = compute_all_metrics([], extraction)
+        print_report(_meta(mode="extraction"), metrics, verbose=True,
+                     extraction_results=extraction)
+        out = capsys.readouterr().out
+        assert "P0" in out and "G0" in out  # the matched pair is shown
+        assert "0.9" in out  # its ratio
+
+    def test_verbose_diffs_respect_match_threshold(self, capsys):
+        # At a permissive threshold everything matches; the diff lines must
+        # agree with the headline metrics computed at the same threshold.
+        extraction = [self._mangled_extraction()]
+        metrics = compute_all_metrics([], extraction, match_threshold=0.0)
+        print_report(_meta(mode="extraction"), metrics, verbose=True,
+                     extraction_results=extraction, match_threshold=0.0)
+        out = capsys.readouterr().out
+        assert "matched=1" in out
+
+    def test_verbose_lists_parse_failures_with_raw(self, capsys):
+        failed = _pred(story_id="g:2", predicted_scores=None, expected_tier="good")
+        failed.scores_raw = "SIMPLE: 4\nCONCRETE: 4\nPERSONAL: 5"
+        metrics = compute_all_metrics([failed])
+        print_report(_meta(), metrics, verbose=True, story_results=[failed])
+        out = capsys.readouterr().out
+        assert "g:2" in out
+        assert "SIMPLE: 4" in out
+
+    def test_verbose_disagreements_include_quality_parse_failure_with_theme_diff(
+        self, capsys,
+    ):
+        # Quality parse failed but themes parsed fine and disagree -> the story
+        # must still appear in Story Disagreements.
+        failed = _pred(story_id="g:2", predicted_scores=None,
+                       expected_themes=["christlikeness"], predicted_themes=[])
+        failed.themes_raw = "NONE"
+        metrics = compute_all_metrics([failed])
+        print_report(_meta(), metrics, verbose=True, story_results=[failed])
+        out = capsys.readouterr().out
+        section = out.split("Story Disagreements")[1]
+        assert "g:2" in section
+        assert "christlikeness" in section
+
+    def test_verbose_shows_theme_anomaly_raw(self, capsys):
+        row = _pred(story_id="g:1", predicted_themes=[],
+                    predicted_scores={"simple": 3})
+        row.themes_raw = "The themes of hope and belonging shine through."
+        metrics = compute_all_metrics([row])
+        print_report(_meta(), metrics, verbose=True, story_results=[row])
+        out = capsys.readouterr().out
+        assert "hope and belonging" in out
+
+    def test_verbose_disagreements_show_titles_from_golden_set(self, tmp_path, capsys):
+        golden = tmp_path / "golden.jsonl"
+        golden.write_text(json.dumps({
+            "type": "golden_newsletter", "thread_id": "t", "message_id": "m",
+            "sender": "s", "subject": "subj", "body": "b",
+            "stories": [{"story_id": "t:1", "title": "Alina at the Welcome Table",
+                         "text": "x"}],
+        }) + "\n")
+        row = _pred(story_id="t:1", predicted_scores={"simple": 3},
+                    expected_tier="good", predicted_tier="fair")
+        metrics = compute_all_metrics([row])
+        print_report(_meta(golden_set_path=str(golden)), metrics, verbose=True,
+                     story_results=[row])
+        out = capsys.readouterr().out
+        assert "Alina at the Welcome Table" in out
+
+
+class TestLoadStoryTitles:
+    def test_reads_titles_by_story_id(self, tmp_path):
+        golden = tmp_path / "golden.jsonl"
+        golden.write_text(json.dumps({
+            "type": "golden_newsletter", "thread_id": "t", "message_id": "m",
+            "sender": "s", "subject": "subj", "body": "b",
+            "stories": [{"story_id": "t:0", "title": "Marcus", "text": "x"}],
+        }) + "\n")
+        assert load_story_titles(str(golden)) == {"t:0": "Marcus"}
+
+    def test_missing_file_returns_empty(self):
+        assert load_story_titles("/nope/does-not-exist.jsonl") == {}
+
+
+class TestDimTableAlignment:
+    def test_data_rows_align_with_header(self):
+        mae = {d: 0.5 for d in ["simple", "concrete", "personal", "dynamic"]}
+        exact = {d: 0.5 for d in mae}
+        within = {d: 1.0 for d in mae}
+        lines = _format_dim_table(mae, exact, within).splitlines()
+        header, first_row = lines[0], lines[2]
+        # The MAE column must start at the same offset in header and data rows.
+        assert first_row.index("0.50") == header.index("MAE")
+
+
+class TestPrintComparisonModes:
+    def _story_metrics(self):
+        results = [
+            _pred(story_id="s", predicted_scores={"simple": 3},
+                  expected_tier="good", predicted_tier="good",
+                  expected_themes=["church"], predicted_themes=["church"]),
+        ]
+        return compute_all_metrics(results)
+
+    def _extraction_metrics(self):
+        extraction = [
+            ExtractionPrediction(
+                thread_id="A",
+                golden_stories=[{"story_id": "A:0", "title": "", "text": "alpha faith"}],
+                predicted_stories=[{"title": "", "text": "alpha faith"}],
+            ),
+        ]
+        return compute_all_metrics([], extraction)
+
+    def test_header_shows_each_runs_mode(self, capsys):
+        m = self._story_metrics()
+        print_comparison(_meta(mode="quality"), m, _meta(mode="quality"), m)
+        out = capsys.readouterr().out
+        header = out.split("--- Tier ---")[0]
+        assert "mode=quality" in header
+
+    def test_mode_mismatch_warns(self, capsys):
+        print_comparison(
+            _meta(mode="quality"), self._story_metrics(),
+            _meta(mode="extraction"), self._extraction_metrics(),
+        )
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert "quality" in out and "extraction" in out
+
+    def test_same_mode_does_not_warn(self, capsys):
+        m = self._story_metrics()
+        print_comparison(_meta(mode="quality"), m, _meta(mode="quality"), m)
+        assert "WARNING" not in capsys.readouterr().out
+
+    def test_empty_sections_render_na_not_minus_100pct(self, capsys):
+        # Quality-mode run A vs extraction-mode run B: B has no tier/theme data,
+        # so per-class F1 and theme F1 must be N/A, never a -100.0% "regression".
+        print_comparison(
+            _meta(mode="quality"), self._story_metrics(),
+            _meta(mode="extraction"), self._extraction_metrics(),
+        )
+        out = capsys.readouterr().out
+        assert "-100.0%" not in out
+        # e.g. the "good F1" row: Run A 100%, Run B N/A, delta N/A
+        good_row = next(ln for ln in out.splitlines() if "good F1" in ln)
+        assert "N/A" in good_row
+
+
+class TestTrendRows:
+    def _write_two_runs(self, tmp_path):
+        story = _pred(story_id="s", predicted_scores={"simple": 3},
+                      expected_tier="good", predicted_tier="good",
+                      predicted_themes=["church"], expected_themes=["church"])
+        # File names sort in the OPPOSITE order of their timestamps, so
+        # chronological ordering must come from run_meta.timestamp.
+        _write_results(
+            tmp_path / "a_newest.jsonl",
+            _meta(run_id="b" * 16, timestamp="2026-07-02T00:00:00+00:00",
+                  prompt_hash="hash-newer", tag="newer"),
+            [story],
+        )
+        _write_results(
+            tmp_path / "z_oldest.jsonl",
+            _meta(run_id="a" * 16, timestamp="2026-07-01T00:00:00+00:00",
+                  prompt_hash="hash-older", tag="older"),
+            [story],
+        )
+
+    def test_rows_sorted_chronologically_with_timestamp_and_prompt_hash(self, tmp_path):
+        self._write_two_runs(tmp_path)
+        rows, errors = build_trend_rows(tmp_path)
+        assert errors == []
+        assert [r["timestamp"] for r in rows] == [
+            "2026-07-01T00:00:00+00:00", "2026-07-02T00:00:00+00:00",
+        ]
+        assert rows[0]["prompt_hash"] == "hash-older"
+        assert rows[0]["tier_accuracy"] == 1.0
+
+    def test_print_trend_has_timestamp_column_in_order(self, tmp_path, capsys):
+        self._write_two_runs(tmp_path)
+        print_trend(tmp_path)
+        out = capsys.readouterr().out
+        assert "Timestamp" in out
+        assert out.index("older") < out.index("newer")
+
+
+class TestCliJsonAndErrors:
+    def _write_run(self, path, **meta_kwargs):
+        story = _pred(story_id="s", predicted_scores={"simple": 3},
+                      expected_tier="good", predicted_tier="good",
+                      predicted_themes=["church"], expected_themes=["church"])
+        _write_results(path, _meta(**meta_kwargs), [story])
+
+    def test_compare_format_json_emits_json(self, tmp_path, monkeypatch, capsys):
+        a, b = tmp_path / "a.jsonl", tmp_path / "b.jsonl"
+        self._write_run(a, run_id="a" * 16)
+        self._write_run(b, run_id="b" * 16)
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--compare", str(a), str(b), "--format", "json",
+        ])
+        cli()
+        data = json.loads(capsys.readouterr().out)
+        assert data["run_a"]["meta"]["run_id"] == "a" * 16
+        assert data["run_b"]["metrics"]["tier"]["accuracy"] == 1.0
+
+    def test_results_dir_format_json_emits_json(self, tmp_path, monkeypatch, capsys):
+        self._write_run(tmp_path / "r.jsonl")
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--results-dir", str(tmp_path), "--format", "json",
+        ])
+        cli()
+        data = json.loads(capsys.readouterr().out)
+        assert isinstance(data, list)
+        assert data[0]["run_id"] == "abcdef0123456789"
+
+    def test_results_dir_verbose_warns_it_is_unsupported(self, tmp_path, monkeypatch, capsys):
+        self._write_run(tmp_path / "r.jsonl")
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--results-dir", str(tmp_path), "--verbose",
+        ])
+        cli()
+        assert "--verbose" in capsys.readouterr().err
+
+    def test_missing_results_file_exits_cleanly(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--results", "/nope/missing.jsonl",
+        ])
+        with pytest.raises(SystemExit) as excinfo:
+            cli()
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "missing.jsonl" in err
+        assert "Traceback" not in err
+
+    def test_compare_ignores_cot_sidecars_from_globs(self, tmp_path, monkeypatch, capsys):
+        # The documented workflow globs *<tag>*.jsonl, which also matches the
+        # .cot.jsonl sidecar every thinking run writes. --compare must ignore
+        # sidecars and compare the two real results files.
+        a, b = tmp_path / "20260701_all_baseline_aaaa.jsonl", tmp_path / "20260702_all_variant_bbbb.jsonl"
+        self._write_run(a, run_id="a" * 16)
+        self._write_run(b, run_id="b" * 16)
+        a_cot = tmp_path / "20260701_all_baseline_aaaa.cot.jsonl"
+        b_cot = tmp_path / "20260702_all_variant_bbbb.cot.jsonl"
+        a_cot.write_text(json.dumps({"type": "thinking", "story_id": "s"}) + "\n")
+        b_cot.write_text(json.dumps({"type": "thinking", "story_id": "s"}) + "\n")
+        # Shell-glob expansion order: cot file sorts before its results file.
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--compare",
+            str(a_cot), str(a), str(b_cot), str(b),
+        ])
+        cli()
+        captured = capsys.readouterr()
+        assert "Newsletter Comparison Report" in captured.out
+        assert "aaaaaaaa" in captured.out
+        assert "bbbbbbbb" in captured.out
+        assert "sidecar" in captured.err  # tells the user what was skipped
+
+    def test_compare_errors_when_not_two_results_files_remain(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        a = tmp_path / "run_a.jsonl"
+        self._write_run(a, run_id="a" * 16)
+        cot = tmp_path / "run_a.cot.jsonl"
+        cot.write_text(json.dumps({"type": "thinking", "story_id": "s"}) + "\n")
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--compare", str(a), str(cot),
+        ])
+        with pytest.raises(SystemExit) as excinfo:
+            cli()
+        assert excinfo.value.code != 0
+        assert "Traceback" not in capsys.readouterr().err
+
+    def test_results_on_cot_sidecar_hints_at_main_file(self, tmp_path, monkeypatch, capsys):
+        cot = tmp_path / "run.cot.jsonl"
+        cot.write_text(json.dumps({"type": "thinking", "story_id": "s"}) + "\n")
+        monkeypatch.setattr(sys, "argv", ["newsletter_report", "--results", str(cot)])
+        with pytest.raises(SystemExit) as excinfo:
+            cli()
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "chain-of-thought sidecar" in err
+        assert "Traceback" not in err
+
+    def test_meta_less_file_exits_cleanly(self, tmp_path, monkeypatch, capsys):
+        bad = tmp_path / "no_meta.jsonl"
+        bad.write_text(json.dumps({"type": "story_prediction", "story_id": "s",
+                                   "thread_id": "t"}) + "\n")
+        monkeypatch.setattr(sys, "argv", ["newsletter_report", "--results", str(bad)])
+        with pytest.raises(SystemExit) as excinfo:
+            cli()
+        assert excinfo.value.code == 1
+        assert "no_meta.jsonl" in capsys.readouterr().err
 
 
 class TestComparisonDeltaSign:

--- a/tests/test_eval_newsletter_report.py
+++ b/tests/test_eval_newsletter_report.py
@@ -1,0 +1,334 @@
+"""Tests for evals.newsletter_report — newsletter eval metrics on hand-built fixtures."""
+
+from evals.newsletter_report import (
+    THEMES,
+    TIERS,
+    compute_all_metrics,
+    compute_dimension_exact_match,
+    compute_dimension_mae,
+    compute_dimension_within1,
+    compute_extraction_metrics,
+    compute_multilabel_metrics,
+    compute_tier_metrics,
+    format_mae_delta,
+    format_metric_delta,
+    match_stories,
+)
+from evals.newsletter_schemas import ExtractionPrediction, StoryPrediction
+
+
+def _pred(
+    story_id="s",
+    expected_scores=None,
+    expected_tier=None,
+    expected_themes=None,
+    predicted_scores=None,
+    predicted_tier=None,
+    predicted_themes=None,
+    error=None,
+) -> StoryPrediction:
+    return StoryPrediction(
+        story_id=story_id,
+        thread_id="t",
+        expected_scores=expected_scores,
+        expected_tier=expected_tier,
+        expected_themes=expected_themes or [],
+        predicted_scores=predicted_scores,
+        predicted_tier=predicted_tier,
+        predicted_themes=predicted_themes or [],
+        error=error,
+    )
+
+
+class TestMatchStories:
+    def test_exact_match(self):
+        predicted = [{"title": "A", "text": "the quick brown fox"}]
+        golden = [{"story_id": "t:0", "title": "A", "text": "the quick brown fox"}]
+        matched, n_pred, n_gold = match_stories(predicted, golden)
+        assert matched == 1
+        assert n_pred == 1
+        assert n_gold == 1
+
+    def test_fuzzy_match_above_threshold(self):
+        # Same story with a couple words changed — ratio stays well above 0.6.
+        predicted = [{"title": "", "text": "the quick brown fox jumped over the lazy dog"}]
+        golden = [{"story_id": "t:0", "title": "",
+                   "text": "the quick brown fox jumped over the lazy cat"}]
+        matched, _, _ = match_stories(predicted, golden)
+        assert matched == 1
+
+    def test_below_threshold_no_match(self):
+        predicted = [{"title": "", "text": "completely unrelated content here"}]
+        golden = [{"story_id": "t:0", "title": "",
+                   "text": "an entirely different subject about gardening"}]
+        matched, n_pred, n_gold = match_stories(predicted, golden)
+        assert matched == 0
+        assert n_pred == 1
+        assert n_gold == 1
+
+    def test_one_to_one_greedy(self):
+        # One predicted story is similar to two golden stories; it may match only one.
+        predicted = [{"title": "", "text": "alpha beta gamma delta"}]
+        golden = [
+            {"story_id": "t:0", "title": "", "text": "alpha beta gamma delta"},
+            {"story_id": "t:1", "title": "", "text": "alpha beta gamma delta epsilon"},
+        ]
+        matched, n_pred, n_gold = match_stories(predicted, golden)
+        assert matched == 1  # cannot match both golden stories
+        assert n_pred == 1
+        assert n_gold == 2
+
+    def test_extra_predicted_drops_precision(self):
+        # 2 predicted, 1 golden -> 1 match -> precision 1/2, recall 1/1.
+        predicted = [
+            {"title": "", "text": "the quick brown fox"},
+            {"title": "", "text": "spurious hallucinated story"},
+        ]
+        golden = [{"story_id": "t:0", "title": "", "text": "the quick brown fox"}]
+        matched, n_pred, n_gold = match_stories(predicted, golden)
+        assert matched == 1
+        assert n_pred == 2
+        assert n_gold == 1
+
+    def test_missing_predicted_drops_recall(self):
+        # 1 predicted, 2 golden -> 1 match -> precision 1/1, recall 1/2.
+        predicted = [{"title": "", "text": "the quick brown fox"}]
+        golden = [
+            {"story_id": "t:0", "title": "", "text": "the quick brown fox"},
+            {"story_id": "t:1", "title": "", "text": "a wholly separate tale of woe"},
+        ]
+        matched, n_pred, n_gold = match_stories(predicted, golden)
+        assert matched == 1
+        assert n_pred == 1
+        assert n_gold == 2
+
+
+class TestTierMetrics:
+    def test_confusion_and_prf(self):
+        results = [
+            _pred(predicted_scores={"simple": 5}, expected_tier="excellent",
+                  predicted_tier="excellent"),
+            _pred(predicted_scores={"simple": 4}, expected_tier="excellent",
+                  predicted_tier="good"),  # off-diagonal
+            _pred(predicted_scores={"simple": 3}, expected_tier="good",
+                  predicted_tier="good"),
+            _pred(predicted_scores={"simple": 1}, expected_tier="poor",
+                  predicted_tier="poor"),
+        ]
+        m = compute_tier_metrics(results)
+        assert m["errors"] == 0
+        assert m["count"] == 4
+        assert abs(m["accuracy"] - 0.75) < 1e-9
+        cm = m["confusion_matrix"]
+        assert cm["excellent"]["excellent"] == 1
+        assert cm["excellent"]["good"] == 1
+        assert cm["good"]["good"] == 1
+        assert cm["poor"]["poor"] == 1
+        # excellent recall = 1 TP / (1 TP + 1 FN) = 0.5
+        assert abs(m["per_class"]["excellent"]["recall"] - 0.5) < 1e-9
+        # good precision = 1 TP / (1 TP + 1 FP) = 0.5
+        assert abs(m["per_class"]["good"]["precision"] - 0.5) < 1e-9
+
+    def test_parse_failure_counted_as_error_excluded_from_matrix(self):
+        results = [
+            _pred(predicted_scores={"simple": 5}, expected_tier="excellent",
+                  predicted_tier="excellent"),
+            # parse failure: predicted_scores is None -> error, excluded from matrix.
+            # A stray predicted_tier is present but must be ignored because scores
+            # failed to parse (guards exclusion-by-None-scores, not by None-tier).
+            _pred(predicted_scores=None, expected_tier="good", predicted_tier="good"),
+        ]
+        m = compute_tier_metrics(results)
+        assert m["errors"] == 1
+        assert m["count"] == 1
+        assert m["accuracy"] == 1.0
+        # The good-row must NOT appear in the matrix despite predicted_tier="good"
+        assert m["confusion_matrix"]["good"]["good"] == 0
+        assert sum(
+            m["confusion_matrix"][e][p] for e in TIERS for p in TIERS
+        ) == 1
+
+
+
+
+class TestDimensionMetrics:
+    def test_mae_and_exact_and_within1(self):
+        results = [
+            _pred(
+                expected_scores={"simple": 5, "concrete": 3, "personal": 4, "dynamic": 2},
+                predicted_scores={"simple": 5, "concrete": 1, "personal": 5, "dynamic": 2},
+            ),
+            _pred(
+                expected_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
+                predicted_scores={"simple": 4, "concrete": 2, "personal": 2, "dynamic": 2},
+            ),
+        ]
+        mae = compute_dimension_mae(results)
+        # simple: |5-5|=0, |2-4|=2 -> mean 1.0
+        assert abs(mae["simple"] - 1.0) < 1e-9
+        # concrete: |3-1|=2, |2-2|=0 -> mean 1.0
+        assert abs(mae["concrete"] - 1.0) < 1e-9
+        # personal: |4-5|=1, |2-2|=0 -> mean 0.5
+        assert abs(mae["personal"] - 0.5) < 1e-9
+        # dynamic: 0, 0 -> 0.0
+        assert abs(mae["dynamic"] - 0.0) < 1e-9
+
+        exact = compute_dimension_exact_match(results)
+        # simple: exact on row1 only -> 1/2
+        assert abs(exact["simple"] - 0.5) < 1e-9
+        # dynamic: both exact -> 1.0
+        assert abs(exact["dynamic"] - 1.0) < 1e-9
+        # concrete: row1 wrong, row2 exact -> 1/2
+        assert abs(exact["concrete"] - 0.5) < 1e-9
+
+        within1 = compute_dimension_within1(results)
+        # personal: diff 1 and 0 both within 1 -> 1.0
+        assert abs(within1["personal"] - 1.0) < 1e-9
+        # simple: diff 0 (within) and 2 (not) -> 1/2
+        assert abs(within1["simple"] - 0.5) < 1e-9
+
+    def test_only_over_stories_with_both_scores(self):
+        results = [
+            _pred(
+                expected_scores={"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
+                predicted_scores={"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
+            ),
+            # parse failure -> excluded entirely
+            _pred(expected_scores={"simple": 1}, predicted_scores=None),
+            # no expected -> excluded
+            _pred(expected_scores=None, predicted_scores={"simple": 1}),
+        ]
+        mae = compute_dimension_mae(results)
+        assert mae["simple"] == 0.0
+        exact = compute_dimension_exact_match(results)
+        assert exact["simple"] == 1.0
+
+
+
+
+class TestMultilabelThemeMetrics:
+    def test_per_theme_micro_macro_and_exact_set(self):
+        # Story 1: expected {scripture, church}, predicted {scripture}
+        #   scripture: TP; church: FN
+        # Story 2: expected {christlikeness}, predicted {christlikeness, church}
+        #   christlikeness: TP; church: FP
+        results = [
+            _pred(expected_themes=["scripture", "church"], predicted_themes=["scripture"],
+                  predicted_scores={"simple": 3}),
+            _pred(expected_themes=["christlikeness"],
+                  predicted_themes=["christlikeness", "church"],
+                  predicted_scores={"simple": 3}),
+        ]
+        m = compute_multilabel_metrics(results, THEMES)
+
+        # scripture: TP=1, FP=0, FN=0 -> P=R=F1=1
+        assert m["per_theme"]["scripture"]["f1"] == 1.0
+        # church: TP=0, FP=1, FN=1 -> P=0, R=0, F1=0
+        assert m["per_theme"]["church"]["precision"] == 0.0
+        assert m["per_theme"]["church"]["recall"] == 0.0
+        # christlikeness: TP=1 -> F1=1
+        assert m["per_theme"]["christlikeness"]["f1"] == 1.0
+
+        # Micro: TP=2, FP=1, FN=1 -> P=2/3, R=2/3, F1=2/3
+        assert abs(m["micro_f1"] - (2 / 3)) < 1e-9
+
+        # Macro F1: mean over 5 themes.
+        # scripture=1, christlikeness=1, church=0, vocation_family=0(no support->0),
+        # disciple_making=0 -> (1+1+0+0+0)/5 = 0.4
+        assert abs(m["macro_f1"] - 0.4) < 1e-9
+
+        # Exact set match: neither story matches exactly -> 0/2
+        assert m["exact_set_match"] == 0.0
+
+    def test_exact_set_match_positive(self):
+        results = [
+            _pred(expected_themes=["scripture"], predicted_themes=["scripture"],
+                  predicted_scores={"simple": 3}),
+            _pred(expected_themes=["church", "scripture"],
+                  predicted_themes=["scripture", "church"],  # order-insensitive
+                  predicted_scores={"simple": 3}),
+        ]
+        m = compute_multilabel_metrics(results, THEMES)
+        assert m["exact_set_match"] == 1.0
+
+
+
+
+class TestExtractionMetrics:
+    def test_micro_and_macro(self):
+        # Newsletter A: 2 predicted, 2 golden, both match -> P=1, R=1
+        # Newsletter B: 2 predicted, 1 golden, 1 match -> P=1/2, R=1
+        nl_a = ExtractionPrediction(
+            thread_id="A",
+            golden_stories=[
+                {"story_id": "A:0", "title": "", "text": "alpha story about faith"},
+                {"story_id": "A:1", "title": "", "text": "beta story about hope"},
+            ],
+            predicted_stories=[
+                {"title": "", "text": "alpha story about faith"},
+                {"title": "", "text": "beta story about hope"},
+            ],
+        )
+        nl_b = ExtractionPrediction(
+            thread_id="B",
+            golden_stories=[
+                {"story_id": "B:0", "title": "", "text": "gamma story of grace"},
+            ],
+            predicted_stories=[
+                {"title": "", "text": "gamma story of grace"},
+                {"title": "", "text": "spurious hallucination unrelated"},
+            ],
+        )
+        m = compute_extraction_metrics([nl_a, nl_b])
+
+        # Micro: matched=3, predicted=4, golden=3 -> P=3/4, R=3/3=1
+        assert abs(m["micro_precision"] - 0.75) < 1e-9
+        assert abs(m["micro_recall"] - 1.0) < 1e-9
+        micro_f1 = 2 * 0.75 * 1.0 / (0.75 + 1.0)
+        assert abs(m["micro_f1"] - micro_f1) < 1e-9
+
+        # Macro precision: mean(1.0, 0.5) = 0.75; macro recall mean(1,1)=1
+        assert abs(m["macro_precision"] - 0.75) < 1e-9
+        assert abs(m["macro_recall"] - 1.0) < 1e-9
+
+
+
+
+class TestComparisonDeltaSign:
+    def test_f1_improvement_positive(self):
+        # Run B has higher tier accuracy than Run A -> positive delta.
+        assert format_metric_delta(0.5, 0.75).startswith("+")
+        assert format_metric_delta(0.75, 0.5).startswith("-")
+
+    def test_mae_decrease_is_improvement(self):
+        # MAE dropped from 1.0 to 0.5 -> improvement -> flagged as improvement (+).
+        improved = format_mae_delta(1.0, 0.5)
+        assert "improve" in improved.lower() or improved.strip().startswith("-")
+        # The raw delta must reflect the decrease (b - a = -0.5).
+        assert "-0.5" in improved
+        # MAE increase is a regression.
+        worsened = format_mae_delta(0.5, 1.0)
+        assert "+0.5" in worsened
+        assert "improve" not in worsened.lower()
+
+    def test_compute_all_metrics_bundles_sections(self):
+        results = [
+            _pred(
+                expected_scores={"simple": 5, "concrete": 5, "personal": 5, "dynamic": 5},
+                predicted_scores={"simple": 5, "concrete": 5, "personal": 5, "dynamic": 5},
+                expected_tier="excellent", predicted_tier="excellent",
+                expected_themes=["scripture"], predicted_themes=["scripture"],
+            ),
+        ]
+        extraction = [
+            ExtractionPrediction(
+                thread_id="A",
+                golden_stories=[{"story_id": "A:0", "title": "", "text": "alpha faith"}],
+                predicted_stories=[{"title": "", "text": "alpha faith"}],
+            ),
+        ]
+        m = compute_all_metrics(results, extraction)
+        assert m["tier"]["accuracy"] == 1.0
+        assert m["themes"]["micro_f1"] == 1.0
+        assert m["dimension_mae"]["simple"] == 0.0
+        assert m["extraction"]["micro_f1"] == 1.0

--- a/tests/test_eval_newsletter_report.py
+++ b/tests/test_eval_newsletter_report.py
@@ -11,6 +11,7 @@ from evals.newsletter_report import (
     _format_dim_table,
     build_trend_rows,
     cli,
+    comparison_as_json,
     compute_all_metrics,
     compute_dimension_exact_match,
     compute_dimension_mae,
@@ -26,6 +27,7 @@ from evals.newsletter_report import (
     print_comparison,
     print_report,
     print_trend,
+    report_as_json,
     theme_parse_anomalies,
 )
 from evals.newsletter_schemas import (
@@ -418,6 +420,25 @@ class TestExtractionAbstention:
                     "macro_precision", "macro_recall", "macro_f1"):
             assert m[key] is None
 
+    def test_fully_errored_run_surfaces_errors_in_report(self, capsys):
+        # Every extraction call failed: the metrics must count the errors and
+        # the report must still render an Extraction section naming them,
+        # mirroring the tier section — not silently vanish.
+        errored = ExtractionPrediction(thread_id="A", golden_stories=[],
+                                       predicted_stories=[],
+                                       error="connection refused")
+        m = compute_extraction_metrics([errored])
+        assert m["count"] == 0
+        assert m["errors"] == 1
+        assert m["error_threads"] == ["A"]
+        metrics = compute_all_metrics([], [errored])
+        print_report(_meta(mode="extraction"), metrics,
+                     extraction_results=[errored])
+        out = capsys.readouterr().out
+        assert "--- Extraction ---" in out
+        assert "1 error" in out
+        assert "A" in out.split("--- Extraction ---")[1]
+
 
 class TestThemeMetricsGating:
     def test_quality_parse_failure_does_not_drop_theme_row(self):
@@ -485,6 +506,23 @@ class TestTierQualityNotAttempted:
         assert m["errors"] == 1
         assert m["error_stories"] == ["down"]
 
+    def test_themes_mode_error_row_does_not_resurrect_tier_section(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        # In a --mode themes run the quality call is never in play, so a theme
+        # call's network error must not render a misleading tier section
+        # ("0 stories, 1 error"). The run's mode comes from RunMeta.
+        errored = _pred(story_id="down", expected_themes=["church"],
+                        error="connection refused")
+        path = tmp_path / "themes_run.jsonl"
+        _write_results(path, _meta(mode="themes"), [errored])
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--results", str(path),
+        ])
+        cli()
+        out = capsys.readouterr().out
+        assert "Tier Classification" not in out
+
     def test_verbose_failures_section_excludes_not_attempted(self, capsys):
         row = _pred(story_id="t:0", expected_themes=["church"],
                     predicted_themes=["church"])
@@ -521,6 +559,15 @@ class TestThemeParseAnomalies:
         # Legacy rows / error rows carry no themes_raw -> no anomaly.
         anomalies = theme_parse_anomalies([_pred(story_id="x", predicted_themes=[])])
         assert anomalies == []
+
+
+class TestThemeListSingleSource:
+    def test_report_themes_match_newsletter_valid_themes(self):
+        # The report's theme list is derived from the pipeline's canonical set
+        # so the two can never drift.
+        from newsletter import _VALID_THEMES
+        assert set(THEMES) == {t.lower() for t in _VALID_THEMES}
+        assert len(THEMES) == len(set(THEMES))
 
 
 class TestComputeAllMetricsBundleKeys:
@@ -788,6 +835,27 @@ class TestPrintComparisonModes:
         assert "N/A" in good_row
 
 
+class TestVerboseCompareThemesMode:
+    def test_theme_flip_shown_when_quality_never_ran(self, capsys):
+        # --mode themes rows never have predicted_scores; a theme flip between
+        # runs must still be listed (not "None!") under Per-story Flips.
+        def row(themes):
+            r = _pred(story_id="s", expected_themes=["church"],
+                      predicted_themes=themes)
+            r.themes_raw = "\n".join(t.upper() for t in themes) or "NONE"
+            return r
+
+        story1, story2 = [row(["church"])], [row(["scripture"])]
+        m1 = compute_all_metrics(story1)
+        m2 = compute_all_metrics(story2)
+        print_comparison(_meta(mode="themes"), m1, _meta(mode="themes"), m2,
+                         verbose=True, story1=story1, story2=story2)
+        out = capsys.readouterr().out
+        flips = out.split("Per-story Flips")[1]
+        assert "None!" not in flips
+        assert "church" in flips and "scripture" in flips
+
+
 class TestTrendRows:
     def _write_two_runs(self, tmp_path):
         story = _pred(story_id="s", predicted_scores={"simple": 3},
@@ -824,6 +892,71 @@ class TestTrendRows:
         out = capsys.readouterr().out
         assert "Timestamp" in out
         assert out.index("older") < out.index("newer")
+
+
+class TestJsonOutput:
+    def _story_and_extraction(self):
+        story = _pred(story_id="s", predicted_scores={"simple": 3},
+                      expected_tier="good", predicted_tier="good",
+                      expected_themes=["church"], predicted_themes=["church"])
+        extraction = ExtractionPrediction(
+            thread_id="A",
+            golden_stories=[{"story_id": "A:0", "title": "", "text": "alpha faith"}],
+            predicted_stories=[{"title": "", "text": "alpha faith"}],
+        )
+        return [story], [extraction]
+
+    def test_report_as_json_emits_valid_json_with_expected_keys(self, capsys):
+        stories, extraction = self._story_and_extraction()
+        metrics = compute_all_metrics(stories, extraction)
+        report_as_json(_meta(), metrics)
+        data = json.loads(capsys.readouterr().out)
+        assert set(data) == {"meta", "metrics"}
+        assert data["meta"]["run_id"] == "abcdef0123456789"
+        for key in ("story_count", "tier", "dimension_mae", "dimension_exact",
+                    "dimension_within1", "themes", "theme_anomalies", "extraction"):
+            assert key in data["metrics"]
+        assert data["metrics"]["tier"]["accuracy"] == 1.0
+        assert data["metrics"]["extraction"]["micro_f1"] == 1.0
+
+    def test_comparison_as_json_emits_valid_json_with_expected_keys(self, capsys):
+        stories, extraction = self._story_and_extraction()
+        metrics = compute_all_metrics(stories, extraction)
+        comparison_as_json(_meta(run_id="a" * 16), metrics,
+                           _meta(run_id="b" * 16), metrics)
+        data = json.loads(capsys.readouterr().out)
+        assert set(data) == {"run_a", "run_b"}
+        assert data["run_a"]["meta"]["run_id"] == "a" * 16
+        assert data["run_b"]["meta"]["run_id"] == "b" * 16
+        assert data["run_b"]["metrics"]["themes"]["micro_f1"] == 1.0
+
+    def test_cli_single_run_format_json_emits_json(self, tmp_path, monkeypatch, capsys):
+        stories, _ = self._story_and_extraction()
+        path = tmp_path / "run.jsonl"
+        _write_results(path, _meta(), stories)
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--results", str(path), "--format", "json",
+        ])
+        cli()
+        data = json.loads(capsys.readouterr().out)
+        assert data["meta"]["run_id"] == "abcdef0123456789"
+        assert data["metrics"]["tier"]["accuracy"] == 1.0
+
+    def test_cli_trend_format_json_rows_have_expected_keys(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        stories, _ = self._story_and_extraction()
+        _write_results(tmp_path / "run.jsonl", _meta(), stories)
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--results-dir", str(tmp_path), "--format", "json",
+        ])
+        cli()
+        data = json.loads(capsys.readouterr().out)
+        assert isinstance(data, list) and len(data) == 1
+        for key in ("file", "run_id", "timestamp", "mode", "tag", "prompt_hash",
+                    "tier_accuracy", "theme_micro_f1", "mae_simple",
+                    "extraction_micro_f1"):
+            assert key in data[0]
 
 
 class TestCliJsonAndErrors:
@@ -872,6 +1005,19 @@ class TestCliJsonAndErrors:
         assert excinfo.value.code == 1
         err = capsys.readouterr().err
         assert "missing.jsonl" in err
+        assert "Traceback" not in err
+
+    def test_results_on_directory_exits_cleanly(self, tmp_path, monkeypatch, capsys):
+        # --results pointed at a directory raises IsADirectoryError from open();
+        # the friendly-errors path must catch it (OSError), not traceback.
+        monkeypatch.setattr(sys, "argv", [
+            "newsletter_report", "--results", str(tmp_path),
+        ])
+        with pytest.raises(SystemExit) as excinfo:
+            cli()
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert str(tmp_path) in err
         assert "Traceback" not in err
 
     def test_compare_ignores_cot_sidecars_from_globs(self, tmp_path, monkeypatch, capsys):

--- a/tests/test_eval_newsletter_run.py
+++ b/tests/test_eval_newsletter_run.py
@@ -552,6 +552,25 @@ class TestBuildMeta:
         )
         assert meta.story_count == 1
 
+    def test_extraction_mode_counts_all_golden_stories(self):
+        """An extraction-only run matches predictions against EVERY golden
+        story (evaluate_extraction does not filter on story.reviewed), so an
+        --include-unreviewed extraction run must not record story_count=0 —
+        the header would disagree with what the run actually evaluated."""
+        golden = [_newsletter(
+            "nl1", reviewed=False,
+            stories=[
+                _story("nl1:0", reviewed=False),
+                _story("nl1:1", reviewed=False),
+            ],
+        )]
+        meta = build_meta(
+            config=_full_config(), config_path="config.toml", golden_path="g.jsonl",
+            golden_set=golden, mode="extraction", tag="", parallelism=1,
+        )
+        assert meta.golden_set_count == 1
+        assert meta.story_count == 2
+
 
 class TestBuildOutputPath:
     def test_filename_has_mode_tag_and_runid(self):
@@ -924,6 +943,27 @@ class TestReportForwarding:
         logging.getLogger("httpx").setLevel(logging.NOTSET)
         newsletter_run.cli()
         assert logging.getLogger("httpx").level == logging.WARNING
+
+
+class TestCliParallelismValidation:
+    def test_cli_rejects_non_positive_parallelism(self, monkeypatch, capsys):
+        """--parallelism 0 would build asyncio.Semaphore(0): every task blocks
+        forever and the run hangs silently after preflight. The parser must
+        reject it up front instead."""
+        import sys as _sys
+        called = {}
+
+        async def fake_main(args):
+            called["ran"] = True
+
+        monkeypatch.setattr(newsletter_run, "main", fake_main)
+        for bad in ("0", "-2"):
+            monkeypatch.setattr(_sys, "argv", ["prog", "--parallelism", bad])
+            with pytest.raises(SystemExit) as excinfo:
+                newsletter_run.cli()
+            assert excinfo.value.code == 2  # argparse usage error
+            assert "parallelism" in capsys.readouterr().err
+        assert "ran" not in called
 
 
 class TestProgress:

--- a/tests/test_eval_newsletter_run.py
+++ b/tests/test_eval_newsletter_run.py
@@ -72,7 +72,9 @@ def _newsletter(thread_id, stories=None, **kw):
 
 
 def _story(story_id, **kw):
-    base = dict(story_id=story_id, title="t", text="x")
+    # Tests model Phase-B-labeled stories by default; pass reviewed=False for
+    # a Phase-A-only (confirmed but never labeled) story.
+    base = dict(story_id=story_id, title="t", text="x", reviewed=True)
     base.update(kw)
     return GoldenStory(**base)
 
@@ -142,7 +144,7 @@ class TestLoadGoldenSet:
             _newsletter("keep", reviewed=True),
             _newsletter("drop", reviewed=False),
         ])
-        loaded = load_golden_set(path, reviewed_only=True)
+        loaded, _stats = load_golden_set(path, reviewed_only=True)
         assert [n.thread_id for n in loaded] == ["keep"]
 
     def test_excluded_dropped_even_when_unreviewed_included(self, tmp_path):
@@ -151,15 +153,62 @@ class TestLoadGoldenSet:
             _newsletter("keep", reviewed=False),
             _newsletter("drop", reviewed=False, excluded=True),
         ])
-        loaded = load_golden_set(path, reviewed_only=False)
+        loaded, _stats = load_golden_set(path, reviewed_only=False)
         assert [n.thread_id for n in loaded] == ["keep"]
 
     def test_tolerates_blank_lines(self, tmp_path):
         path = tmp_path / "g.jsonl"
         content = json.dumps(_newsletter("keep", reviewed=True).to_dict()) + "\n\n"
         path.write_text(content)
-        loaded = load_golden_set(path, reviewed_only=True)
+        loaded, _stats = load_golden_set(path, reviewed_only=True)
         assert [n.thread_id for n in loaded] == ["keep"]
+
+    def test_returns_filter_breakdown_stats(self, tmp_path):
+        path = tmp_path / "g.jsonl"
+        _write_golden(path, [
+            _newsletter("a", reviewed=True),
+            _newsletter("b", reviewed=False),
+            _newsletter("c", reviewed=False, excluded=True),
+        ])
+        loaded, stats = load_golden_set(path, reviewed_only=True)
+        assert [n.thread_id for n in loaded] == ["a"]
+        assert stats == {"total": 3, "excluded": 1, "unreviewed": 1}
+
+
+class TestFormatLoadSummary:
+    """The load message must explain WHY newsletters were dropped, not dead-end."""
+
+    def test_all_unreviewed_names_the_fix(self):
+        from evals.newsletter_run import format_load_summary
+        msg = format_load_summary(
+            0, {"total": 6, "excluded": 0, "unreviewed": 6}, "gs.jsonl")
+        assert "No newsletters to evaluate" in msg
+        assert "6 unreviewed" in msg
+        assert "newsletter_label" in msg
+        assert "--include-unreviewed" in msg
+
+    def test_empty_file_points_at_harvest(self):
+        from evals.newsletter_run import format_load_summary
+        msg = format_load_summary(
+            0, {"total": 0, "excluded": 0, "unreviewed": 0}, "gs.jsonl")
+        assert "No newsletters to evaluate" in msg
+        assert "empty" in msg
+        assert "newsletter_harvest" in msg
+
+    def test_success_reports_skip_breakdown(self):
+        from evals.newsletter_run import format_load_summary
+        msg = format_load_summary(
+            5, {"total": 7, "excluded": 1, "unreviewed": 1}, "gs.jsonl")
+        assert "5 of 7" in msg
+        assert "1 unreviewed" in msg
+        assert "1 excluded" in msg
+
+    def test_success_with_no_skips_is_terse(self):
+        from evals.newsletter_run import format_load_summary
+        msg = format_load_summary(
+            3, {"total": 3, "excluded": 0, "unreviewed": 0}, "gs.jsonl")
+        assert "Loaded 3 newsletters" in msg
+        assert "unreviewed" not in msg
 
 
 class TestEvaluateExtraction:
@@ -173,7 +222,7 @@ class TestEvaluateExtraction:
                 _story("nl1:1", title="Gold Two", text="gold body two"),
             ],
         )
-        pred = _run(evaluate_extraction(newsletter, _classifier(llm)))
+        pred, _thinking = _run(evaluate_extraction(newsletter, _classifier(llm)))
 
         assert pred.thread_id == "nl1"
         assert pred.predicted_stories == [
@@ -264,7 +313,10 @@ class TestRunEvaluation:
         assert len(extractions) == 1
         assert len(stories) == 1
         assert stories[0].predicted_tier == "good"  # avg 3.0
-        assert thinking[0].quality_cot == "qcot"
+        story_entries = [t for t in thinking if t.story_id]
+        assert story_entries[0].quality_cot == "qcot"
+        # all-mode also carries a newsletter-level extraction thinking entry
+        assert [t.thread_id for t in thinking if t.extraction_cot or not t.story_id]
 
     def test_second_identical_run_records_cache_hits(self, tmp_path):
         cache = tmp_path / "cache.jsonl"
@@ -300,6 +352,60 @@ class TestRunEvaluation:
         assert all(isinstance(r, StoryPrediction) for r in rows)
         assert not any(isinstance(r, ExtractionPrediction) for r in rows)
 
+    def test_quality_mode_fires_no_theme_llm_calls(self):
+        """--mode quality must not pay for theme calls (and vice versa)."""
+        llm = _full_llm()
+        rows, _thinking = _run(run_evaluation(
+            self._golden(), _classifier(llm), mode="quality", parallelism=1,
+        ))
+        assert not any("THEME" in user for _sys, user in llm.calls)
+        assert rows[0].predicted_scores is not None
+        assert rows[0].predicted_themes == []
+        assert rows[0].themes_raw is None
+
+    def test_themes_mode_fires_no_quality_llm_calls(self):
+        llm = _full_llm()
+        rows, _thinking = _run(run_evaluation(
+            self._golden(), _classifier(llm), mode="themes", parallelism=1,
+        ))
+        assert not any("QUALITY" in user for _sys, user in llm.calls)
+        assert rows[0].predicted_themes == ["scripture"]
+        assert rows[0].predicted_scores is None
+        assert rows[0].predicted_tier is None
+        assert rows[0].scores_raw is None
+
+    def test_unlabeled_story_skipped_in_story_modes(self):
+        """A Phase-A-only story (reviewed=False) has no ground truth: don't
+        spend LLM calls on it or score its empty expected_themes."""
+        golden = [_newsletter(
+            "nl1", reviewed=True,
+            stories=[
+                _story("nl1:0", title="S", text="body", reviewed=True),
+                _story("nl1:1", title="U", text="v", reviewed=False),
+            ],
+        )]
+        rows, _thinking = _run(run_evaluation(
+            golden, _classifier(_full_llm()), mode="quality", parallelism=1,
+        ))
+        assert [r.story_id for r in rows] == ["nl1:0"]
+
+
+class TestSelectStories:
+    def test_counts_excluded_and_unlabeled_skips(self):
+        from evals.newsletter_run import select_stories
+        golden = [_newsletter(
+            "nl1", reviewed=True,
+            stories=[
+                _story("nl1:0", reviewed=True),
+                _story("nl1:1", reviewed=False),
+                _story("nl1:2", excluded=True),
+            ],
+        )]
+        pairs, n_excluded, n_unlabeled = select_stories(golden)
+        assert [(s.story_id, tid) for s, tid in pairs] == [("nl1:0", "nl1")]
+        assert n_excluded == 1
+        assert n_unlabeled == 1
+
     def test_excluded_story_skipped_in_quality_mode(self, tmp_path):
         cache = tmp_path / "cache.jsonl"
         cached = CachedLLMClient(_full_llm(), cache)
@@ -314,6 +420,87 @@ class TestRunEvaluation:
             golden, _classifier(cached), mode="quality", parallelism=1,
         ))
         assert [r.story_id for r in rows] == ["nl1:0"]
+
+
+class TestFormatRunSummary:
+    """The run summary must surface silent failures, not just .error rows."""
+
+    def _story_row(self, **kw):
+        from evals.newsletter_schemas import StoryPrediction
+        base = dict(story_id="nl1:0", thread_id="nl1")
+        base.update(kw)
+        return StoryPrediction(**base)
+
+    def test_quality_parse_failure_counted(self):
+        from evals.newsletter_run import format_run_summary
+        rows = [self._story_row(scores_raw="garbage output", predicted_scores=None,
+                                themes_raw="NONE")]
+        summary = format_run_summary(rows)
+        assert "1 quality parse failure" in summary
+        assert "no errors" not in summary
+
+    def test_skipped_quality_is_not_a_parse_failure(self):
+        from evals.newsletter_run import format_run_summary
+        # themes-mode row: quality never attempted (scores_raw None)
+        rows = [self._story_row(scores_raw=None, predicted_scores=None,
+                                themes_raw="NONE")]
+        assert "quality parse failure" not in format_run_summary(rows)
+
+    def test_garbage_theme_response_is_a_parse_failure(self):
+        from evals.newsletter_run import format_run_summary
+        rows = [self._story_row(
+            scores_raw="SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3",
+            predicted_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+            themes_raw="just some prose, no labels", predicted_themes=[],
+        )]
+        assert "1 theme parse failure" in format_run_summary(rows)
+
+    def test_none_theme_response_is_not_a_failure(self):
+        from evals.newsletter_run import format_run_summary
+        rows = [self._story_row(
+            scores_raw="SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3",
+            predicted_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+            themes_raw="NONE", predicted_themes=[],
+        )]
+        assert "theme parse failure" not in format_run_summary(rows)
+
+    def test_clamped_scores_surfaced(self):
+        from evals.newsletter_run import format_run_summary
+        rows = [self._story_row(
+            scores_raw="SIMPLE: 9\nCONCRETE: 4\nPERSONAL: 3\nDYNAMIC: 2",
+            predicted_scores={"simple": 5, "concrete": 4, "personal": 3, "dynamic": 2},
+            themes_raw="NONE",
+        )]
+        summary = format_run_summary(rows)
+        assert "clamped" in summary
+        assert "SIMPLE" in summary
+
+    def test_dropped_theme_tokens_surfaced(self):
+        from evals.newsletter_run import format_run_summary
+        rows = [self._story_row(
+            scores_raw="SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3",
+            predicted_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+            themes_raw="FELLOWSHIP\nCHURCH", predicted_themes=["church"],
+        )]
+        assert "FELLOWSHIP" in format_run_summary(rows)
+
+    def test_error_grammar_is_singular(self):
+        from evals.newsletter_run import format_run_summary
+        rows = [self._story_row(error="boom")]
+        summary = format_run_summary(rows)
+        assert "1 error" in summary
+        assert "1 errors" not in summary
+
+    def test_clean_run_reports_no_errors(self):
+        from evals.newsletter_run import format_run_summary
+        rows = [self._story_row(
+            scores_raw="SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3",
+            predicted_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+            themes_raw="SCRIPTURE", predicted_themes=["scripture"],
+        )]
+        summary = format_run_summary(rows)
+        assert "Rows: 1" in summary
+        assert "no errors" in summary
 
 
 def _full_config():
@@ -347,6 +534,23 @@ class TestBuildMeta:
         assert meta.max_tokens == 1024
         # seeded_from pulled from the golden set
         assert meta.seeded_from == "parse_stories"
+
+    def test_story_count_counts_only_labeled_stories(self):
+        """story_count must match what a story-mode run actually evaluates,
+        so the report header can't disagree with metric denominators."""
+        golden = [_newsletter(
+            "nl1", reviewed=True,
+            stories=[
+                _story("nl1:0", reviewed=True),
+                _story("nl1:1", reviewed=False),
+                _story("nl1:2", excluded=True),
+            ],
+        )]
+        meta = build_meta(
+            config=_full_config(), config_path="config.toml", golden_path="g.jsonl",
+            golden_set=golden, mode="all", tag="", parallelism=1,
+        )
+        assert meta.story_count == 1
 
 
 class TestBuildOutputPath:
@@ -406,6 +610,50 @@ class TestWriteThinkingSidecar:
         path = tmp_path / "out.jsonl"
         write_thinking_sidecar(path, [NewsletterThinkingEntry(story_id="a")])
         assert not path.with_suffix(".cot.jsonl").exists()
+
+    def test_returns_sidecar_path_when_written_else_none(self, tmp_path):
+        """main() needs the path back so the run summary can mention the sidecar."""
+        from evals.newsletter_schemas import NewsletterThinkingEntry
+        path = tmp_path / "out.jsonl"
+        written = write_thinking_sidecar(
+            path, [NewsletterThinkingEntry(story_id="a", quality_cot="q")])
+        assert written == path.with_suffix(".cot.jsonl")
+        assert write_thinking_sidecar(
+            tmp_path / "empty.jsonl", [NewsletterThinkingEntry(story_id="b")]) is None
+
+    def test_sidecar_written_for_extraction_only_entry(self, tmp_path):
+        """Extraction CoT alone must qualify an entry for the sidecar."""
+        from evals.newsletter_schemas import NewsletterThinkingEntry
+        path = tmp_path / "out.jsonl"
+        entry = NewsletterThinkingEntry(thread_id="t1", extraction_cot="why I split it so")
+        assert write_thinking_sidecar(path, [entry]) == path.with_suffix(".cot.jsonl")
+        line = json.loads(path.with_suffix(".cot.jsonl").read_text().splitlines()[0])
+        assert line["thread_id"] == "t1"
+        assert line["extraction_cot"] == "why I split it so"
+
+
+class TestExtractionThinking:
+    def test_evaluate_extraction_returns_thinking_entry(self):
+        llm = FakeLLM([("body text", "TITLE: A\nTEXT: a", "extraction reasoning")])
+        newsletter = _newsletter(
+            "nl1", reviewed=True, stories=[_story("nl1:0")],
+        )
+        pred, entry = _run(evaluate_extraction(newsletter, _classifier(llm)))
+        assert pred.thread_id == "nl1"
+        assert pred.predicted_stories == [{"title": "A", "text": "a"}]
+        assert entry.thread_id == "nl1"
+        assert entry.extraction_cot == "extraction reasoning"
+        assert entry.story_id == ""
+
+    def test_run_evaluation_collects_extraction_thinking(self):
+        llm = FakeLLM([("body text", "TITLE: A\nTEXT: a", "xcot")])
+        golden = [_newsletter("nl1", reviewed=True, stories=[_story("nl1:0")])]
+        rows, thinking = _run(run_evaluation(
+            golden, _classifier(llm), mode="extraction", parallelism=1,
+        ))
+        assert any(
+            t.extraction_cot == "xcot" and t.thread_id == "nl1" for t in thinking
+        )
 
 
 def _main_args(**kw):
@@ -486,6 +734,219 @@ class TestMainPromptsOverride:
                 golden_set=str(golden), output_dir=str(tmp_path / "r"),
             )))
         assert excinfo.value.code == 1
+
+
+class TestUnreviewedExtractionNote:
+    """--include-unreviewed extraction must warn that uncurated newsletters'
+    empty story lists are not real ground truth."""
+
+    def test_note_when_unreviewed_newsletters_in_extraction_mode(self):
+        from evals.newsletter_run import format_unreviewed_note
+        golden = [_newsletter("a", reviewed=True), _newsletter("b", reviewed=False)]
+        note = format_unreviewed_note(golden, "extraction")
+        assert note is not None
+        assert "1" in note
+        assert "false positive" in note
+
+    def test_no_note_when_all_reviewed_or_story_mode(self):
+        from evals.newsletter_run import format_unreviewed_note
+        golden = [_newsletter("a", reviewed=True)]
+        assert format_unreviewed_note(golden, "extraction") is None
+        unrev = [_newsletter("b", reviewed=False)]
+        assert format_unreviewed_note(unrev, "quality") is None
+
+    def test_main_prints_note_with_include_unreviewed(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        def fake_build(config, no_cache):
+            llm = _full_llm()
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter("nl1", reviewed=False)])
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(tmp_path / "r"),
+            mode="extraction", include_unreviewed=True,
+        )))
+        assert "false positive" in capsys.readouterr().err
+
+
+class TestMainArgErrors:
+    """Typo-class mistakes must print one-line errors, not tracebacks."""
+
+    def test_missing_prompts_file_exits_cleanly(self, tmp_path, capsys):
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter("nl1", reviewed=True)])
+        with pytest.raises(SystemExit) as excinfo:
+            asyncio.run(newsletter_run.main(_main_args(
+                golden_set=str(golden), output_dir=str(tmp_path / "r"),
+                prompts=str(tmp_path / "nonexistent.toml"),
+            )))
+        assert excinfo.value.code == 1
+        assert "Error" in capsys.readouterr().err
+
+    def test_malformed_prompts_toml_exits_cleanly(self, tmp_path, capsys):
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter("nl1", reviewed=True)])
+        bad = tmp_path / "bad.toml"
+        bad.write_text("[newsletter\nnot toml")
+        with pytest.raises(SystemExit) as excinfo:
+            asyncio.run(newsletter_run.main(_main_args(
+                golden_set=str(golden), output_dir=str(tmp_path / "r"),
+                prompts=str(bad),
+            )))
+        assert excinfo.value.code == 1
+        assert "Error" in capsys.readouterr().err
+
+    def test_missing_golden_set_exits_cleanly(self, tmp_path, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            asyncio.run(newsletter_run.main(_main_args(
+                golden_set=str(tmp_path / "nonexistent.jsonl"),
+                output_dir=str(tmp_path / "r"),
+            )))
+        assert excinfo.value.code == 1
+        assert "Error" in capsys.readouterr().err
+
+
+class TestEndpointNaming:
+    def test_describe_endpoint_prefers_newsletter_var(self, monkeypatch):
+        from evals.newsletter_run import describe_endpoint
+        monkeypatch.setenv("NEWSLETTER_LLM_URL", "http://nl:1/v1")
+        assert describe_endpoint() == "http://nl:1/v1 (from NEWSLETTER_LLM_URL)"
+        monkeypatch.delenv("NEWSLETTER_LLM_URL")
+        monkeypatch.setenv("CLOUD_LLM_URL", "http://cloud:2/v1")
+        assert describe_endpoint() == "http://cloud:2/v1 (from CLOUD_LLM_URL)"
+
+    def test_per_row_error_names_endpoint(self):
+        class BoomLLM(FakeLLM):
+            base_url = "http://127.0.0.1:8499/v1/chat/completions"
+
+            async def complete(self, *a, **kw):
+                raise RuntimeError("LLM endpoint model-x unavailable")
+
+        story = _story("nl1:0", title="T", text="x")
+        pred, _thinking = _run(evaluate_story(story, "nl1", _classifier(BoomLLM([]))))
+        assert pred.error is not None
+        assert "http://127.0.0.1:8499" in pred.error
+
+    def test_preflight_error_names_url_and_env_var(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        class DeadLLM(FakeLLM):
+            async def is_available(self, timeout=None):
+                return False
+
+        def fake_build(config, no_cache):
+            llm = DeadLLM([])
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+        monkeypatch.setenv("NEWSLETTER_LLM_URL", "http://127.0.0.1:8499/v1")
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True, stories=[_story("nl1:0", title="S", text="body")],
+        )])
+        with pytest.raises(SystemExit):
+            asyncio.run(newsletter_run.main(_main_args(
+                golden_set=str(golden), output_dir=str(tmp_path / "r"),
+                skip_preflight=False,
+            )))
+        err = capsys.readouterr().err
+        assert "http://127.0.0.1:8499/v1" in err
+        assert "NEWSLETTER_LLM_URL" in err
+
+
+class TestReportForwarding:
+    def _meta(self):
+        from evals.newsletter_schemas import NewsletterRunMeta
+        return NewsletterRunMeta(
+            run_id="r", timestamp="t", config_hash="c", config_path="p",
+            newsletter_model="m", golden_set_path="g", golden_set_count=0,
+            story_count=0,
+        )
+
+    def test_maybe_report_forwards_verbose_and_threshold(self, monkeypatch):
+        from evals import newsletter_report
+        from evals.newsletter_run import maybe_report
+        calls = {}
+
+        def fake_compute(story, extraction, match_threshold=0.6):
+            calls["compute_thr"] = match_threshold
+            return {}
+
+        def fake_print_report(meta, metrics, verbose=False, story_results=None,
+                              extraction_results=None, match_threshold=0.6):
+            calls["verbose"] = verbose
+            calls["print_thr"] = match_threshold
+
+        monkeypatch.setattr(newsletter_report, "compute_all_metrics", fake_compute)
+        monkeypatch.setattr(newsletter_report, "print_report", fake_print_report)
+        maybe_report(self._meta(), [], True, None, verbose=True, match_threshold=0.9)
+        assert calls == {"compute_thr": 0.9, "verbose": True, "print_thr": 0.9}
+
+    def test_comparison_verbosity_follows_flag(self, tmp_path, monkeypatch):
+        from evals import newsletter_report
+        from evals.newsletter_run import maybe_report, write_results
+        calls = {}
+
+        def fake_print_comparison(meta1, metrics1, meta2, metrics2, verbose=False,
+                                  story1=None, story2=None):
+            calls["verbose"] = verbose
+
+        monkeypatch.setattr(newsletter_report, "print_comparison", fake_print_comparison)
+        prior = tmp_path / "prior.jsonl"
+        write_results(prior, self._meta(), [])
+        maybe_report(self._meta(), [], False, str(prior), verbose=False)
+        assert calls["verbose"] is False
+
+    def test_cli_accepts_verbose_and_match_threshold(self, monkeypatch):
+        import sys as _sys
+        seen = {}
+
+        async def fake_main(args):
+            seen["args"] = args
+
+        monkeypatch.setattr(newsletter_run, "main", fake_main)
+        monkeypatch.setattr(_sys, "argv",
+                            ["prog", "--verbose", "--match-threshold", "0.8"])
+        newsletter_run.cli()
+        assert seen["args"].verbose is True
+        assert seen["args"].match_threshold == 0.8
+
+    def test_cli_quiets_httpx_logging(self, monkeypatch):
+        import logging
+        import sys as _sys
+
+        async def fake_main(args):
+            return None
+
+        monkeypatch.setattr(newsletter_run, "main", fake_main)
+        monkeypatch.setattr(_sys, "argv", ["prog"])
+        logging.getLogger("httpx").setLevel(logging.NOTSET)
+        newsletter_run.cli()
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+
+class TestProgress:
+    def test_progress_lines_written_when_enabled(self, capsys):
+        golden = [_newsletter(
+            "nl1", reviewed=True,
+            stories=[_story("nl1:0", title="S", text="body")],
+        )]
+        _run(run_evaluation(
+            golden, _classifier(_full_llm()), mode="all", parallelism=1,
+            progress=True,
+        ))
+        err = capsys.readouterr().err
+        assert "[1/2]" in err
+        assert "[2/2]" in err
+
+    def test_no_progress_output_by_default(self, capsys):
+        golden = [_newsletter(
+            "nl1", reviewed=True,
+            stories=[_story("nl1:0", title="S", text="body")],
+        )]
+        _run(run_evaluation(golden, _classifier(_full_llm()), mode="all", parallelism=1))
+        assert "[1/2]" not in capsys.readouterr().err
 
 
 class TestMainPreflight:
@@ -595,3 +1056,61 @@ class TestMainReport:
         )))
         printed = capsys.readouterr().out
         assert "Newsletter Comparison Report" in printed
+
+    def test_compare_to_meta_less_file_does_not_crash_run(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A bad --compare-to file (e.g. a .cot.jsonl sidecar) must not raise
+        after the paid run, and the results path must still be printed."""
+        self._patch_classifier(monkeypatch)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True, stories=[_story("nl1:0", title="S", text="body")],
+        )])
+        bad = tmp_path / "bad.cot.jsonl"
+        bad.write_text('{"type": "thinking", "story_id": "x"}\n')
+        out = tmp_path / "r"
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out), mode="all",
+            compare_to=str(bad),
+        )))
+        err = capsys.readouterr().err
+        assert "Error" in err and "compare" in err
+        assert "Results written to" in err
+
+    def test_summary_mentions_cot_sidecar(self, tmp_path, monkeypatch, capsys):
+        # Patch with the needle-matching prompts config so the FakeLLM returns
+        # thinking content and the .cot.jsonl sidecar actually gets written.
+        def fake_build(config, no_cache):
+            llm = _full_llm()
+            return NewsletterClassifier(cloud_llm=llm, config=_prompts_config()), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True, stories=[_story("nl1:0", title="S", text="body")],
+        )])
+        out = tmp_path / "r"
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out), mode="all",
+        )))
+        err = capsys.readouterr().err
+        assert "Chain-of-thought written to" in err
+        assert ".cot.jsonl" in err
+
+    def test_main_reports_unlabeled_story_skips(self, tmp_path, monkeypatch, capsys):
+        self._patch_classifier(monkeypatch)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True,
+            stories=[
+                _story("nl1:0", title="S", text="body", reviewed=True),
+                _story("nl1:1", title="U", text="v", reviewed=False),
+            ],
+        )])
+        out = tmp_path / "r"
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out), mode="quality",
+        )))
+        err = capsys.readouterr().err
+        assert "1 story" in err
+        assert "unlabeled" in err or "never labeled" in err

--- a/tests/test_eval_newsletter_run.py
+++ b/tests/test_eval_newsletter_run.py
@@ -1,0 +1,597 @@
+"""Tests for the newsletter eval runner."""
+
+import argparse
+import asyncio
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from evals import newsletter_run
+from evals.llm_cache import CachedLLMClient
+from evals.newsletter_run import (
+    build_meta,
+    build_output_path,
+    compute_prompt_hash,
+    evaluate_extraction,
+    evaluate_story,
+    load_golden_set,
+    merge_prompts_override,
+    run_evaluation,
+    write_results,
+    write_thinking_sidecar,
+)
+from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
+from newsletter import NewsletterClassifier
+
+
+class FakeLLM:
+    """Fake inner LLMClient: returns canned (response, thinking) per prompt.
+
+    Keyed by a substring match on the user_content so a single instance can
+    answer extraction / quality / theme calls differently. Records every call.
+    """
+
+    def __init__(self, responses):
+        # responses: list of (needle, response, thinking); first needle-in-user wins
+        self.responses = responses
+        self.model = "fake-model"
+        self.temperature = 0.0
+        self.max_tokens = 100
+        self.extra_body = {}
+        self.calls = []
+
+    async def complete(self, system_prompt, user_content, include_thinking=False):
+        self.calls.append((system_prompt, user_content))
+        for needle, response, thinking in self.responses:
+            if needle in user_content:
+                return (response, thinking) if include_thinking else response
+        return ("", "") if include_thinking else ""
+
+    async def is_available(self, timeout=None):
+        return True
+
+
+def _classifier(llm):
+    config = _prompts_config()
+    return NewsletterClassifier(cloud_llm=llm, config=config)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _newsletter(thread_id, stories=None, **kw):
+    base = dict(
+        thread_id=thread_id, message_id=f"m-{thread_id}", sender="s@dm.org",
+        subject="subj", body="body text", stories=stories or [],
+    )
+    base.update(kw)
+    return GoldenNewsletter(**base)
+
+
+def _story(story_id, **kw):
+    base = dict(story_id=story_id, title="t", text="x")
+    base.update(kw)
+    return GoldenStory(**base)
+
+
+def _write_golden(path, newsletters):
+    path.write_text("".join(json.dumps(n.to_dict()) + "\n" for n in newsletters))
+
+
+def _prompts_config():
+    return {
+        "newsletter": {
+            "prompts": {
+                "story_extraction": {"system": "extract sys", "user_template": "EXTRACT {body}"},
+                "quality_assessment": {"system": "quality sys", "user_template": "QUALITY {title} {text}"},
+                "theme_classification": {"system": "theme sys", "user_template": "THEME {title} {text}"},
+            }
+        }
+    }
+
+
+class TestComputePromptHash:
+    def test_stable_for_identical_config(self):
+        a = compute_prompt_hash(_prompts_config())
+        b = compute_prompt_hash(_prompts_config())
+        assert a == b
+        assert len(a) == 16
+
+    def test_changes_when_a_prompt_string_changes(self):
+        base = _prompts_config()
+        mutated = copy.deepcopy(base)
+        mutated["newsletter"]["prompts"]["quality_assessment"]["system"] = "different"
+        assert compute_prompt_hash(base) != compute_prompt_hash(mutated)
+
+
+class TestMergePromptsOverride:
+    def test_deep_merges_and_changes_prompt_hash(self):
+        base = _prompts_config()
+        before = compute_prompt_hash(base)
+        override = {
+            "newsletter": {
+                "prompts": {"quality_assessment": {"system": "NEW quality sys"}}
+            }
+        }
+        merge_prompts_override(base, override)
+        # overridden key changed
+        assert base["newsletter"]["prompts"]["quality_assessment"]["system"] == "NEW quality sys"
+        # sibling keys in the same block preserved (deep merge, not replace)
+        qa = base["newsletter"]["prompts"]["quality_assessment"]
+        assert qa["user_template"] == "QUALITY {title} {text}"
+        # other prompt blocks untouched
+        assert base["newsletter"]["prompts"]["story_extraction"]["system"] == "extract sys"
+        # and the hash moved
+        assert compute_prompt_hash(base) != before
+
+    def test_only_touches_newsletter_prompts(self):
+        base = _prompts_config()
+        base["newsletter"]["llm"] = {"model": "keep-me"}
+        override = {"newsletter": {"llm": {"model": "IGNORED"}, "prompts": {}}}
+        merge_prompts_override(base, override)
+        assert base["newsletter"]["llm"]["model"] == "keep-me"
+
+
+class TestLoadGoldenSet:
+    def test_reviewed_only_filters_unreviewed(self, tmp_path):
+        path = tmp_path / "g.jsonl"
+        _write_golden(path, [
+            _newsletter("keep", reviewed=True),
+            _newsletter("drop", reviewed=False),
+        ])
+        loaded = load_golden_set(path, reviewed_only=True)
+        assert [n.thread_id for n in loaded] == ["keep"]
+
+    def test_excluded_dropped_even_when_unreviewed_included(self, tmp_path):
+        path = tmp_path / "g.jsonl"
+        _write_golden(path, [
+            _newsletter("keep", reviewed=False),
+            _newsletter("drop", reviewed=False, excluded=True),
+        ])
+        loaded = load_golden_set(path, reviewed_only=False)
+        assert [n.thread_id for n in loaded] == ["keep"]
+
+    def test_tolerates_blank_lines(self, tmp_path):
+        path = tmp_path / "g.jsonl"
+        content = json.dumps(_newsletter("keep", reviewed=True).to_dict()) + "\n\n"
+        path.write_text(content)
+        loaded = load_golden_set(path, reviewed_only=True)
+        assert [n.thread_id for n in loaded] == ["keep"]
+
+
+class TestEvaluateExtraction:
+    def test_records_predicted_and_golden_story_sets(self):
+        extraction_out = "TITLE: Pred One\nTEXT: pred body one\n\nTITLE: Pred Two\nTEXT: pred body two"
+        llm = FakeLLM([("EXTRACT", extraction_out, "")])
+        newsletter = _newsletter(
+            "nl1", reviewed=True,
+            stories=[
+                _story("nl1:0", title="Gold One", text="gold body one"),
+                _story("nl1:1", title="Gold Two", text="gold body two"),
+            ],
+        )
+        pred = _run(evaluate_extraction(newsletter, _classifier(llm)))
+
+        assert pred.thread_id == "nl1"
+        assert pred.predicted_stories == [
+            {"title": "Pred One", "text": "pred body one"},
+            {"title": "Pred Two", "text": "pred body two"},
+        ]
+        assert pred.golden_stories == [
+            {"story_id": "nl1:0", "title": "Gold One", "text": "gold body one"},
+            {"story_id": "nl1:1", "title": "Gold Two", "text": "gold body two"},
+        ]
+        assert pred.error is None
+
+
+class TestEvaluateStory:
+    def _story_llm(self):
+        quality_out = "SIMPLE: 4\nCONCRETE: 5\nPERSONAL: 4\nDYNAMIC: 3"
+        theme_out = "SCRIPTURE\nCHURCH"
+        return FakeLLM([
+            ("QUALITY", quality_out, "quality reasoning"),
+            ("THEME", theme_out, "theme reasoning"),
+        ])
+
+    def test_records_scores_themes_and_derives_tier(self):
+        llm = self._story_llm()
+        story = _story(
+            "nl1:0", title="A Story", text="the text",
+            expected_scores={"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
+            expected_tier="excellent", expected_themes=["scripture"],
+        )
+        pred, thinking = _run(evaluate_story(story, "nl1", _classifier(llm)))
+
+        assert pred.story_id == "nl1:0"
+        assert pred.thread_id == "nl1"
+        # expected_* carried from the golden story
+        assert pred.expected_scores == {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}
+        assert pred.expected_tier == "excellent"
+        assert pred.expected_themes == ["scripture"]
+        # predicted_*
+        assert pred.predicted_scores == {"simple": 4, "concrete": 5, "personal": 4, "dynamic": 3}
+        assert pred.predicted_themes == ["scripture", "church"]
+        # tier derived via compute_tier: avg = (4+5+4+3)/4 = 4.0 -> excellent
+        assert pred.predicted_tier == "excellent"
+        # raw captured
+        assert "SIMPLE: 4" in pred.scores_raw
+        assert "SCRIPTURE" in pred.themes_raw
+        assert pred.error is None
+        # thinking sidecar carries both cots
+        assert thinking.story_id == "nl1:0"
+        assert thinking.quality_cot == "quality reasoning"
+        assert thinking.theme_cot == "theme reasoning"
+
+    def test_predicted_tier_none_when_scores_unparseable(self):
+        llm = FakeLLM([
+            ("QUALITY", "garbage no scores", "q"),
+            ("THEME", "NONE", "t"),
+        ])
+        story = _story("nl2:0", title="T", text="x")
+        pred, _thinking = _run(evaluate_story(story, "nl2", _classifier(llm)))
+        assert pred.predicted_scores is None
+        assert pred.predicted_tier is None
+        assert pred.predicted_themes == []
+
+
+def _full_llm():
+    return FakeLLM([
+        ("EXTRACT", "TITLE: S\nTEXT: body", "ecot"),
+        ("QUALITY", "SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3", "qcot"),
+        ("THEME", "SCRIPTURE", "tcot"),
+    ])
+
+
+class TestRunEvaluation:
+    def _golden(self):
+        return [_newsletter(
+            "nl1", reviewed=True,
+            stories=[_story("nl1:0", title="S", text="body")],
+        )]
+
+    def test_all_mode_produces_extraction_and_story_rows(self, tmp_path):
+        cache = tmp_path / "cache.jsonl"
+        cached = CachedLLMClient(_full_llm(), cache)
+        rows, thinking = _run(run_evaluation(
+            self._golden(), _classifier(cached), mode="all", parallelism=1,
+        ))
+        from evals.newsletter_schemas import ExtractionPrediction, StoryPrediction
+        extractions = [r for r in rows if isinstance(r, ExtractionPrediction)]
+        stories = [r for r in rows if isinstance(r, StoryPrediction)]
+        assert len(extractions) == 1
+        assert len(stories) == 1
+        assert stories[0].predicted_tier == "good"  # avg 3.0
+        assert thinking[0].quality_cot == "qcot"
+
+    def test_second_identical_run_records_cache_hits(self, tmp_path):
+        cache = tmp_path / "cache.jsonl"
+        cached = CachedLLMClient(_full_llm(), cache)
+        _run(run_evaluation(self._golden(), _classifier(cached), mode="all", parallelism=1))
+        first_misses = cached.misses
+        assert first_misses > 0
+        cached.flush()
+
+        # Fresh cache client over the same on-disk cache: every call is now a hit.
+        cached2 = CachedLLMClient(_full_llm(), cache)
+        _run(run_evaluation(self._golden(), _classifier(cached2), mode="all", parallelism=1))
+        assert cached2.hits == first_misses
+        assert cached2.misses == 0
+
+    def test_extraction_mode_skips_story_scoring(self, tmp_path):
+        cache = tmp_path / "cache.jsonl"
+        cached = CachedLLMClient(_full_llm(), cache)
+        rows, _thinking = _run(run_evaluation(
+            self._golden(), _classifier(cached), mode="extraction", parallelism=1,
+        ))
+        from evals.newsletter_schemas import ExtractionPrediction, StoryPrediction
+        assert all(isinstance(r, ExtractionPrediction) for r in rows)
+        assert not any(isinstance(r, StoryPrediction) for r in rows)
+
+    def test_quality_mode_skips_extraction(self, tmp_path):
+        cache = tmp_path / "cache.jsonl"
+        cached = CachedLLMClient(_full_llm(), cache)
+        rows, _thinking = _run(run_evaluation(
+            self._golden(), _classifier(cached), mode="quality", parallelism=1,
+        ))
+        from evals.newsletter_schemas import ExtractionPrediction, StoryPrediction
+        assert all(isinstance(r, StoryPrediction) for r in rows)
+        assert not any(isinstance(r, ExtractionPrediction) for r in rows)
+
+    def test_excluded_story_skipped_in_quality_mode(self, tmp_path):
+        cache = tmp_path / "cache.jsonl"
+        cached = CachedLLMClient(_full_llm(), cache)
+        golden = [_newsletter(
+            "nl1", reviewed=True,
+            stories=[
+                _story("nl1:0", title="S", text="body"),
+                _story("nl1:1", title="X", text="y", excluded=True),
+            ],
+        )]
+        rows, _thinking = _run(run_evaluation(
+            golden, _classifier(cached), mode="quality", parallelism=1,
+        ))
+        assert [r.story_id for r in rows] == ["nl1:0"]
+
+
+def _full_config():
+    cfg = _prompts_config()
+    cfg["newsletter"]["llm"] = {
+        "model": "claude-x", "temperature": 0.0, "max_tokens": 1024, "extra_body": None,
+    }
+    return cfg
+
+
+class TestBuildMeta:
+    def test_records_prompt_hash_model_and_system_prompts(self):
+        cfg = _full_config()
+        golden = [_newsletter("nl1", reviewed=True, seeded_from="parse_stories",
+                              stories=[_story("nl1:0"), _story("nl1:1")])]
+        meta = build_meta(
+            config=cfg, config_path="config.toml", golden_path="g.jsonl",
+            golden_set=golden, mode="all", tag="baseline", parallelism=2,
+        )
+        assert meta.prompt_hash == compute_prompt_hash(cfg)
+        assert meta.newsletter_model == "claude-x"
+        assert meta.mode == "all"
+        assert meta.tag == "baseline"
+        assert meta.golden_set_count == 1
+        assert meta.story_count == 2
+        assert meta.parallelism == 2
+        assert meta.extraction_system_prompt == "extract sys"
+        assert meta.quality_system_prompt == "quality sys"
+        assert meta.theme_system_prompt == "theme sys"
+        assert meta.temperature == 0.0
+        assert meta.max_tokens == 1024
+        # seeded_from pulled from the golden set
+        assert meta.seeded_from == "parse_stories"
+
+
+class TestBuildOutputPath:
+    def test_filename_has_mode_tag_and_runid(self):
+        p = build_output_path(Path("/out"), "all", "baseline", "abcdef1234567890")
+        assert p.parent == Path("/out")
+        assert p.name.endswith(".jsonl")
+        assert "_all_" in p.name
+        assert "baseline" in p.name
+        assert "abcdef12" in p.name  # first 8 of run id
+
+    def test_omits_empty_tag(self):
+        p = build_output_path(Path("/out"), "quality", "", "abcdef1234567890")
+        assert "quality" in p.name
+        assert "__" not in p.name.replace(".jsonl", "")
+
+
+class TestWriteResults:
+    def test_meta_first_then_rows_roundtrip(self, tmp_path):
+        from evals.newsletter_schemas import (
+            ExtractionPrediction,
+            NewsletterRunMeta,
+            StoryPrediction,
+        )
+        meta = NewsletterRunMeta(
+            run_id="r", timestamp="t", config_hash="c", config_path="p",
+            newsletter_model="m", golden_set_path="g", golden_set_count=1, story_count=1,
+        )
+        rows = [
+            ExtractionPrediction(thread_id="nl1"),
+            StoryPrediction(story_id="nl1:0", thread_id="nl1"),
+        ]
+        path = tmp_path / "out.jsonl"
+        write_results(path, meta, rows)
+        lines = path.read_text().splitlines()
+        assert json.loads(lines[0])["type"] == "run_meta"
+        assert json.loads(lines[1])["type"] == "extraction_prediction"
+        assert json.loads(lines[2])["type"] == "story_prediction"
+
+
+class TestWriteThinkingSidecar:
+    def test_writes_only_nonempty_entries(self, tmp_path):
+        from evals.newsletter_schemas import NewsletterThinkingEntry
+        path = tmp_path / "out.jsonl"
+        entries = [
+            NewsletterThinkingEntry(story_id="a", quality_cot="q"),
+            NewsletterThinkingEntry(story_id="b"),  # empty -> skipped
+        ]
+        write_thinking_sidecar(path, entries)
+        sidecar = path.with_suffix(".cot.jsonl")
+        lines = sidecar.read_text().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["story_id"] == "a"
+
+    def test_no_sidecar_when_all_empty(self, tmp_path):
+        from evals.newsletter_schemas import NewsletterThinkingEntry
+        path = tmp_path / "out.jsonl"
+        write_thinking_sidecar(path, [NewsletterThinkingEntry(story_id="a")])
+        assert not path.with_suffix(".cot.jsonl").exists()
+
+
+def _main_args(**kw):
+    base = dict(
+        golden_set="", config=None, output_dir="", mode="all", tag=None,
+        no_cache=True, parallelism=None, include_unreviewed=False,
+        prompts=None, model=None, report=False, compare_to=None, skip_preflight=True,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _read_meta(output_dir):
+    files = sorted(Path(output_dir).glob("*.jsonl"))
+    files = [f for f in files if not f.name.endswith(".cot.jsonl")]
+    assert files, "no results file written"
+    return json.loads(files[-1].read_text().splitlines()[0])
+
+
+class TestMainPromptsOverride:
+    def _patch_classifier(self, monkeypatch):
+        """Route main through a FakeLLM-backed classifier so no network is hit."""
+        def fake_build(config, no_cache):
+            llm = _full_llm()
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+
+    def test_prompts_override_changes_recorded_prompt_hash(
+        self, tmp_path, monkeypatch
+    ):
+        self._patch_classifier(monkeypatch)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True, stories=[_story("nl1:0", title="S", text="body")],
+        )])
+        out = tmp_path / "results"
+
+        # Baseline run over the real config.toml
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out), mode="quality", tag="base",
+        )))
+        base_hash = _read_meta(out)["prompt_hash"]
+
+        # Variant run with a --prompts override that changes the quality system prompt
+        alt = tmp_path / "alt.toml"
+        alt.write_text(
+            '[newsletter.prompts.quality_assessment]\n'
+            'system = "A COMPLETELY DIFFERENT QUALITY PROMPT"\n'
+        )
+        out2 = tmp_path / "results2"
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out2), mode="quality",
+            tag="variant", prompts=str(alt),
+        )))
+        variant_meta = _read_meta(out2)
+        assert variant_meta["prompt_hash"] != base_hash
+        assert variant_meta["quality_system_prompt"] == "A COMPLETELY DIFFERENT QUALITY PROMPT"
+
+    def test_model_override_recorded(self, tmp_path, monkeypatch):
+        self._patch_classifier(monkeypatch)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True, stories=[_story("nl1:0", title="S", text="body")],
+        )])
+        out = tmp_path / "results"
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out), mode="extraction",
+            model="my-override-model",
+        )))
+        assert _read_meta(out)["newsletter_model"] == "my-override-model"
+
+    def test_no_newsletters_exits_1(self, tmp_path, monkeypatch):
+        self._patch_classifier(monkeypatch)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter("nl1", reviewed=False)])  # unreviewed only
+        with pytest.raises(SystemExit) as excinfo:
+            asyncio.run(newsletter_run.main(_main_args(
+                golden_set=str(golden), output_dir=str(tmp_path / "r"),
+            )))
+        assert excinfo.value.code == 1
+
+
+class TestMainPreflight:
+    def test_unreachable_endpoint_exits_1(self, tmp_path, monkeypatch):
+        class DeadLLM(FakeLLM):
+            async def is_available(self, timeout=None):
+                return False
+
+        def fake_build(config, no_cache):
+            llm = DeadLLM([])
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True, stories=[_story("nl1:0", title="S", text="body")],
+        )])
+        args = _main_args(golden_set=str(golden), output_dir=str(tmp_path / "r"),
+                          skip_preflight=False)
+        with pytest.raises(SystemExit) as excinfo:
+            asyncio.run(newsletter_run.main(args))
+        assert excinfo.value.code == 1
+
+    def test_skip_preflight_bypasses_check(self, tmp_path, monkeypatch):
+        class DeadLLM(FakeLLM):
+            async def is_available(self, timeout=None):
+                return False
+
+        def fake_build(config, no_cache):
+            llm = DeadLLM([
+                ("EXTRACT", "NO_STORIES", ""),
+                ("QUALITY", "SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3", ""),
+                ("THEME", "NONE", ""),
+            ])
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True, stories=[_story("nl1:0", title="S", text="body")],
+        )])
+        out = tmp_path / "r"
+        # Endpoint "down" but --skip-preflight -> main runs to completion and writes.
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out), skip_preflight=True,
+        )))
+        assert _read_meta(out)["type"] == "run_meta"
+
+
+class TestMainReport:
+    """--report / --compare-to must invoke the real newsletter_report API.
+
+    Guards against the maybe_report() shim drifting from newsletter_report
+    (which exposes compute_all_metrics + a 3-tuple load_results, not the
+    email report's compute_metrics + 2-tuple load_results).
+    """
+
+    def _patch_classifier(self, monkeypatch):
+        def fake_build(config, no_cache):
+            llm = _full_llm()
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+
+    def test_report_flag_prints_metrics(self, tmp_path, monkeypatch, capsys):
+        self._patch_classifier(monkeypatch)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True,
+            stories=[_story(
+                "nl1:0", title="S", text="body",
+                expected_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+                expected_tier="good", expected_themes=["scripture"],
+            )],
+        )])
+        out = tmp_path / "r"
+        # Must not raise (AttributeError on compute_metrics, tuple-unpack, etc.).
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out), mode="all", report=True,
+        )))
+        printed = capsys.readouterr().out
+        assert "Newsletter Evaluation Report" in printed
+
+    def test_compare_to_prints_comparison(self, tmp_path, monkeypatch, capsys):
+        self._patch_classifier(monkeypatch)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter(
+            "nl1", reviewed=True,
+            stories=[_story(
+                "nl1:0", title="S", text="body",
+                expected_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+                expected_tier="good", expected_themes=["scripture"],
+            )],
+        )])
+        # First run to produce a prior results file to compare against.
+        out1 = tmp_path / "r1"
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out1), mode="all",
+        )))
+        prior = sorted(
+            f for f in Path(out1).glob("*.jsonl") if not f.name.endswith(".cot.jsonl")
+        )[-1]
+
+        out2 = tmp_path / "r2"
+        asyncio.run(newsletter_run.main(_main_args(
+            golden_set=str(golden), output_dir=str(out2), mode="all",
+            compare_to=str(prior),
+        )))
+        printed = capsys.readouterr().out
+        assert "Newsletter Comparison Report" in printed

--- a/tests/test_eval_newsletter_schemas.py
+++ b/tests/test_eval_newsletter_schemas.py
@@ -221,6 +221,32 @@ class TestNewsletterThinkingEntry:
         t = NewsletterThinkingEntry.from_dict({"story_id": "x:0"})
         assert t.quality_cot == ""
         assert t.theme_cot == ""
+        assert t.thread_id == ""
+        assert t.extraction_cot == ""
+
+    def test_extraction_entry_round_trip_keyed_by_thread(self):
+        """An extraction cot entry is per-newsletter: thread_id set, no story_id."""
+        t = NewsletterThinkingEntry(
+            thread_id="t_001",
+            extraction_cot="reasoning about how to segment the newsletter",
+        )
+        d = t.to_dict()
+        assert d["type"] == "thinking"
+        restored = NewsletterThinkingEntry.from_dict(json.loads(json.dumps(d)))
+        assert restored.thread_id == "t_001"
+        assert restored.extraction_cot == "reasoning about how to segment the newsletter"
+        assert restored.story_id == ""
+        assert restored.quality_cot == ""
+        assert restored.theme_cot == ""
+
+    def test_from_dict_tolerates_missing_story_id(self):
+        """Older/extraction-only rows have no story_id key at all."""
+        t = NewsletterThinkingEntry.from_dict(
+            {"thread_id": "t_001", "extraction_cot": "seg cot"}
+        )
+        assert t.story_id == ""
+        assert t.thread_id == "t_001"
+        assert t.extraction_cot == "seg cot"
 
 
 class TestNewsletterRunMeta:

--- a/tests/test_eval_newsletter_schemas.py
+++ b/tests/test_eval_newsletter_schemas.py
@@ -1,0 +1,295 @@
+"""Tests for evals.newsletter_schemas — round-trip serialization + defaults."""
+
+import json
+
+from evals.newsletter_schemas import (
+    ExtractionPrediction,
+    GoldenNewsletter,
+    GoldenStory,
+    NewsletterRunMeta,
+    NewsletterThinkingEntry,
+    StoryPrediction,
+)
+
+
+class TestGoldenStory:
+    def test_round_trip_via_json(self):
+        s = GoldenStory(
+            story_id="t_001:0",
+            title="A missionary in Nairobi",
+            text="The full story text goes here.",
+            expected_scores={"simple": 4, "concrete": 5, "personal": 3, "dynamic": 2},
+            expected_tier="good",
+            expected_themes=["scripture", "church"],
+            reviewed=True,
+            notes="clear story",
+            excluded=False,
+        )
+        d = s.to_dict()
+        restored = GoldenStory.from_dict(json.loads(json.dumps(d)))
+        assert restored.story_id == "t_001:0"
+        assert restored.title == "A missionary in Nairobi"
+        assert restored.text == "The full story text goes here."
+        assert restored.expected_scores == {
+            "simple": 4,
+            "concrete": 5,
+            "personal": 3,
+            "dynamic": 2,
+        }
+        assert restored.expected_tier == "good"
+        assert restored.expected_themes == ["scripture", "church"]
+        assert restored.reviewed is True
+        assert restored.notes == "clear story"
+        assert restored.excluded is False
+
+    def test_defaults_when_keys_missing(self):
+        s = GoldenStory.from_dict({"story_id": "x:0", "title": "T", "text": "B"})
+        assert s.expected_scores is None
+        assert s.expected_tier is None
+        assert s.expected_themes == []
+        assert s.reviewed is False
+        assert s.notes == ""
+        assert s.excluded is False
+
+
+class TestGoldenNewsletter:
+    def test_round_trip_nested_stories_survive_json(self):
+        nl = GoldenNewsletter(
+            thread_id="t_001",
+            message_id="m_001",
+            sender="News <news@dm.org>",
+            subject="July update",
+            body="raw body verbatim",
+            stories=[
+                GoldenStory(story_id="t_001:0", title="First", text="one"),
+                GoldenStory(
+                    story_id="t_001:1",
+                    title="Second",
+                    text="two",
+                    expected_themes=["vocation-family"],
+                ),
+            ],
+            source="harvested",
+            harvested_at="2026-07-01T00:00:00+00:00",
+            seeded_from="parse_stories",
+            reviewed=True,
+            notes="good newsletter",
+            excluded=False,
+        )
+        d = nl.to_dict()
+        assert d["type"] == "golden_newsletter"
+        restored = GoldenNewsletter.from_dict(json.loads(json.dumps(d)))
+        assert restored.thread_id == "t_001"
+        assert restored.message_id == "m_001"
+        assert restored.sender == "News <news@dm.org>"
+        assert restored.subject == "July update"
+        assert restored.body == "raw body verbatim"
+        assert restored.source == "harvested"
+        assert restored.harvested_at == "2026-07-01T00:00:00+00:00"
+        assert restored.seeded_from == "parse_stories"
+        assert restored.reviewed is True
+        assert restored.notes == "good newsletter"
+        assert restored.excluded is False
+        # Nested stories survive as GoldenStory instances.
+        assert len(restored.stories) == 2
+        assert all(isinstance(s, GoldenStory) for s in restored.stories)
+        assert restored.stories[0].story_id == "t_001:0"
+        assert restored.stories[1].title == "Second"
+        assert restored.stories[1].expected_themes == ["vocation-family"]
+
+    def test_defaults_when_keys_missing(self):
+        nl = GoldenNewsletter.from_dict(
+            {
+                "thread_id": "t",
+                "message_id": "m",
+                "sender": "s",
+                "subject": "sub",
+                "body": "b",
+            }
+        )
+        assert nl.stories == []
+        assert nl.source == "harvested"
+        assert nl.harvested_at == ""
+        assert nl.seeded_from == ""
+        assert nl.reviewed is False
+        assert nl.notes == ""
+        assert nl.excluded is False
+
+
+class TestStoryPrediction:
+    def test_round_trip_via_json(self):
+        p = StoryPrediction(
+            story_id="t_001:0",
+            thread_id="t_001",
+            expected_scores={"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2},
+            expected_tier="good",
+            expected_themes=["scripture"],
+            predicted_scores={"simple": 3, "concrete": 3, "personal": 4, "dynamic": 2},
+            predicted_tier="fair",
+            predicted_themes=["scripture", "church"],
+            scores_raw="SIMPLE: 3 ...",
+            themes_raw="scripture, church",
+            duration_seconds=1.5,
+            error=None,
+        )
+        d = p.to_dict()
+        assert d["type"] == "story_prediction"
+        restored = StoryPrediction.from_dict(json.loads(json.dumps(d)))
+        assert restored.story_id == "t_001:0"
+        assert restored.thread_id == "t_001"
+        assert restored.expected_scores == {
+            "simple": 4,
+            "concrete": 3,
+            "personal": 5,
+            "dynamic": 2,
+        }
+        assert restored.expected_tier == "good"
+        assert restored.expected_themes == ["scripture"]
+        assert restored.predicted_scores == {
+            "simple": 3,
+            "concrete": 3,
+            "personal": 4,
+            "dynamic": 2,
+        }
+        assert restored.predicted_tier == "fair"
+        assert restored.predicted_themes == ["scripture", "church"]
+        assert restored.scores_raw == "SIMPLE: 3 ..."
+        assert restored.themes_raw == "scripture, church"
+        assert restored.duration_seconds == 1.5
+        assert restored.error is None
+
+    def test_defaults_when_keys_missing(self):
+        p = StoryPrediction.from_dict({"story_id": "x:0", "thread_id": "x"})
+        assert p.expected_scores is None
+        assert p.expected_tier is None
+        assert p.expected_themes == []
+        assert p.predicted_scores is None
+        assert p.predicted_tier is None
+        assert p.predicted_themes == []
+        assert p.scores_raw is None
+        assert p.themes_raw is None
+        assert p.duration_seconds == 0.0
+        assert p.error is None
+
+
+class TestExtractionPrediction:
+    def test_round_trip_via_json(self):
+        p = ExtractionPrediction(
+            thread_id="t_001",
+            golden_stories=[{"story_id": "t_001:0", "title": "A", "text": "aaa"}],
+            predicted_stories=[{"title": "A", "text": "aaa"}, {"title": "B", "text": "bbb"}],
+            duration_seconds=2.0,
+            error=None,
+        )
+        d = p.to_dict()
+        assert d["type"] == "extraction_prediction"
+        restored = ExtractionPrediction.from_dict(json.loads(json.dumps(d)))
+        assert restored.thread_id == "t_001"
+        assert restored.golden_stories == [
+            {"story_id": "t_001:0", "title": "A", "text": "aaa"}
+        ]
+        assert restored.predicted_stories == [
+            {"title": "A", "text": "aaa"},
+            {"title": "B", "text": "bbb"},
+        ]
+        assert restored.duration_seconds == 2.0
+        assert restored.error is None
+
+    def test_defaults_when_keys_missing(self):
+        p = ExtractionPrediction.from_dict({"thread_id": "x"})
+        assert p.golden_stories == []
+        assert p.predicted_stories == []
+        assert p.duration_seconds == 0.0
+        assert p.error is None
+
+
+class TestNewsletterThinkingEntry:
+    def test_round_trip_via_json(self):
+        t = NewsletterThinkingEntry(
+            story_id="t_001:0",
+            quality_cot="thinking about quality",
+            theme_cot="thinking about themes",
+        )
+        d = t.to_dict()
+        assert d["type"] == "thinking"
+        restored = NewsletterThinkingEntry.from_dict(json.loads(json.dumps(d)))
+        assert restored.story_id == "t_001:0"
+        assert restored.quality_cot == "thinking about quality"
+        assert restored.theme_cot == "thinking about themes"
+
+    def test_defaults_when_keys_missing(self):
+        t = NewsletterThinkingEntry.from_dict({"story_id": "x:0"})
+        assert t.quality_cot == ""
+        assert t.theme_cot == ""
+
+
+class TestNewsletterRunMeta:
+    def test_round_trip_via_json(self):
+        meta = NewsletterRunMeta(
+            run_id="run123456",
+            timestamp="2026-07-01T10:00:00+00:00",
+            config_hash="cfghash1234",
+            config_path="config.toml",
+            newsletter_model="claude-sonnet-4-6",
+            golden_set_path="evals/newsletter_golden_set.jsonl",
+            golden_set_count=12,
+            story_count=40,
+            mode="all",
+            prompt_hash="promptabc123",
+            temperature=0.3,
+            max_tokens=8096,
+            extra_body={"top_p": 0.9},
+            parallelism=4,
+            tag="baseline",
+            seeded_from="parse_stories",
+            extraction_system_prompt="extract prompt",
+            quality_system_prompt="quality prompt",
+            theme_system_prompt="theme prompt",
+        )
+        d = meta.to_dict()
+        assert d["type"] == "run_meta"
+        restored = NewsletterRunMeta.from_dict(json.loads(json.dumps(d)))
+        assert restored.run_id == "run123456"
+        assert restored.timestamp == "2026-07-01T10:00:00+00:00"
+        assert restored.config_hash == "cfghash1234"
+        assert restored.config_path == "config.toml"
+        assert restored.newsletter_model == "claude-sonnet-4-6"
+        assert restored.golden_set_path == "evals/newsletter_golden_set.jsonl"
+        assert restored.golden_set_count == 12
+        assert restored.story_count == 40
+        assert restored.mode == "all"
+        assert restored.prompt_hash == "promptabc123"
+        assert restored.temperature == 0.3
+        assert restored.max_tokens == 8096
+        assert restored.extra_body == {"top_p": 0.9}
+        assert restored.parallelism == 4
+        assert restored.tag == "baseline"
+        assert restored.seeded_from == "parse_stories"
+        assert restored.extraction_system_prompt == "extract prompt"
+        assert restored.quality_system_prompt == "quality prompt"
+        assert restored.theme_system_prompt == "theme prompt"
+
+    def test_defaults_when_keys_missing(self):
+        meta = NewsletterRunMeta.from_dict(
+            {
+                "run_id": "r",
+                "timestamp": "t",
+                "config_hash": "h",
+                "config_path": "p",
+                "newsletter_model": "m",
+                "golden_set_path": "g",
+                "golden_set_count": 5,
+                "story_count": 20,
+            }
+        )
+        assert meta.mode == "all"
+        assert meta.prompt_hash == ""
+        assert meta.temperature == 0.0
+        assert meta.max_tokens == 0
+        assert meta.extra_body is None
+        assert meta.parallelism == 1
+        assert meta.tag == ""
+        assert meta.seeded_from == ""
+        assert meta.extraction_system_prompt == ""
+        assert meta.quality_system_prompt == ""
+        assert meta.theme_system_prompt == ""

--- a/tests/test_eval_util.py
+++ b/tests/test_eval_util.py
@@ -1,0 +1,18 @@
+"""Tests for shared evals helpers."""
+
+from evals import plural
+
+
+class TestPlural:
+    def test_singular(self):
+        assert plural(1, "story", "stories") == "1 story"
+
+    def test_plural(self):
+        assert plural(2, "story", "stories") == "2 stories"
+
+    def test_zero_is_plural(self):
+        assert plural(0, "error", "errors") == "0 errors"
+
+    def test_default_plural_appends_s(self):
+        assert plural(3, "row") == "3 rows"
+        assert plural(1, "row") == "1 row"

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -292,6 +292,45 @@ class TestCorruptCacheFile:
         inner2.complete.assert_not_awaited()
 
 
+    async def test_current_entry_with_empty_thinking_is_a_hit(self, tmp_path: Path):
+        """An entry written by current code with thinking='' (model emitted no
+        <think> block) must be a cache hit under include_thinking=True — not a
+        legacy entry to re-fetch. Otherwise every terse response (NO_STORIES,
+        'NONE' themes) is re-billed on every run and re-appended to disk."""
+        cache_path = tmp_path / "cache.jsonl"
+
+        inner1 = _make_inner()
+        _set_return(inner1, "NO_STORIES", "")  # legitimately no thinking
+        cached1 = CachedLLMClient(inner1, cache_path)
+        await cached1.complete("sys", "usr", include_thinking=True)
+        cached1.flush()
+
+        inner2 = _make_inner()
+        cached2 = CachedLLMClient(inner2, cache_path)
+        response, thinking = await cached2.complete("sys", "usr", include_thinking=True)
+
+        assert response == "NO_STORIES"
+        assert thinking == ""
+        assert cached2.hits == 1
+        assert cached2.misses == 0
+        inner2.complete.assert_not_awaited()
+        # No duplicate entry appended to the cache file
+        cached2.flush()
+        assert len(cache_path.read_text().strip().splitlines()) == 1
+
+    async def test_same_session_empty_thinking_is_a_hit(self, tmp_path: Path):
+        """Within one session, a miss that returned no thinking must not
+        re-fire the LLM on the next include_thinking=True call."""
+        inner = _make_inner()
+        _set_return(inner, "NONE", "")
+        cached = CachedLLMClient(inner, tmp_path / "cache.jsonl")
+
+        await cached.complete("sys", "usr", include_thinking=True)  # miss
+        await cached.complete("sys", "usr", include_thinking=True)  # must hit
+
+        assert inner.complete.await_count == 1
+        assert cached.hits == 1
+
     async def test_old_cache_with_unstripped_double_bracket_think(self, tmp_path: Path):
         """Cache entries with <<think>> blocks in response are normalized on load."""
         cache_path = tmp_path / "cache.jsonl"

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -1,5 +1,6 @@
 """Tests for evals.llm_cache — CachedLLMClient wrapper."""
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -379,10 +380,9 @@ class TestLlmSeconds:
 
         await cached.complete("sys", "usr")
 
-        assert cached._llm_seconds > 0
         elapsed = cached.take_llm_seconds()
         assert elapsed > 0
-        assert cached._llm_seconds == 0.0  # reset after take
+        assert cached.take_llm_seconds() == 0.0  # reset after take
 
     async def test_hit_does_not_accumulate_time(self, tmp_path: Path):
         inner = _make_inner()
@@ -395,6 +395,54 @@ class TestLlmSeconds:
         await cached.complete("sys", "usr")  # cache hit
 
         assert cached.take_llm_seconds() == 0.0
+
+    async def test_llm_seconds_isolated_per_task(self, tmp_path: Path, monkeypatch):
+        """Each concurrent task must drain only ITS OWN miss time.
+
+        Under parallelism > 1, a shared accumulator lets the first row to
+        finish absorb every concurrent row's LLM time into its
+        duration_seconds while the others record ~0 — skewing the persisted
+        results JSONL and the web UI averages."""
+        import evals.llm_cache as llm_cache_mod
+
+        class _FakeTime:
+            def __init__(self):
+                self.t = 0.0
+
+            def monotonic(self):
+                return self.t
+
+        fake_time = _FakeTime()
+        monkeypatch.setattr(llm_cache_mod, "time", fake_time)
+
+        durations = {"usr-A": 5.0, "usr-B": 7.0}
+        inner = _make_inner()
+
+        async def fake_complete(system_prompt, user_content, include_thinking=False):
+            fake_time.t += durations[user_content]
+            return ("R", "")
+
+        inner.complete.side_effect = fake_complete
+        cached = CachedLLMClient(inner, tmp_path / "cache.jsonl")
+
+        both_done = asyncio.Event()
+        done = {"count": 0}
+        drained = {}
+
+        async def worker(user_content):
+            await cached.complete("sys", user_content)
+            done["count"] += 1
+            if done["count"] == 2:
+                both_done.set()
+            # Wait until BOTH tasks have accumulated before either drains, so a
+            # shared accumulator would hand everything to whichever drains first.
+            await both_done.wait()
+            drained[user_content] = cached.take_llm_seconds()
+
+        await asyncio.gather(worker("usr-A"), worker("usr-B"))
+
+        assert drained["usr-A"] == pytest.approx(5.0)
+        assert drained["usr-B"] == pytest.approx(7.0)
 
 
 class TestThinking:

--- a/tests/test_newsletter_eval_docs.py
+++ b/tests/test_newsletter_eval_docs.py
@@ -1,0 +1,78 @@
+"""Verify the newsletter eval sub-suite is documented in the technical README.
+
+The top-level ``README-technical.md`` is the project's structure/reference doc: it
+lists the project's modules under ``## Project Structure`` and maps each source
+module to its tests under ``## Test Coverage by Module``. The newsletter evaluation
+harness adds modules under ``evals/`` (``newsletter_harvest``, ``newsletter_run``,
+etc.); this guards against them — and their tests — being omitted from those
+references as the sub-suite grows.
+
+Expectations are DERIVED from disk rather than a hand-maintained list: each
+``evals/newsletter_*.py`` module must appear in the Project Structure section, and
+each must have a correspondingly-named ``tests/test_eval_<module>.py`` documented in
+the Test Coverage section. A newly added newsletter eval module therefore fails this
+test until it (and its test) are documented. Meta-tests without a source module
+(e.g. ``test_eval_newsletter_cli_docs.py``) are intentionally not required here,
+mirroring how the analogous ``test_eval_cli_docs.py`` is not listed either.
+
+Patterned after ``test_env_var_docs.py``. Uses pytest-subtests so each missing file
+is reported individually on failure.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+README_PATH = ROOT / "README-technical.md"
+EVALS_DIR = ROOT / "evals"
+TESTS_DIR = ROOT / "tests"
+
+
+def _newsletter_eval_modules() -> list[str]:
+    """Module filenames (e.g. 'newsletter_run.py') for the newsletter eval suite."""
+    return sorted(p.name for p in EVALS_DIR.glob("newsletter_*.py"))
+
+
+def _section(readme_text: str, heading: str) -> str:
+    """Extract a '## <heading>' section from the README (up to the next '## ')."""
+    match = re.search(
+        rf"## {re.escape(heading)}.*?(?=\n## |\Z)", readme_text, re.DOTALL
+    )
+    return match.group(0) if match else ""
+
+
+def test_newsletter_eval_modules_documented(subtests):
+    readme_text = README_PATH.read_text()
+    structure = _section(readme_text, "Project Structure")
+    modules = _newsletter_eval_modules()
+
+    assert modules, "No evals/newsletter_*.py modules found — scan may be broken"
+    assert structure, "No '## Project Structure' section found in README-technical.md"
+
+    for module in modules:
+        with subtests.test(module=module):
+            assert module in structure, (
+                f"evals/{module} is not listed in README-technical.md's "
+                f"'## Project Structure' section"
+            )
+
+
+def test_newsletter_eval_tests_documented(subtests):
+    readme_text = README_PATH.read_text()
+    coverage = _section(readme_text, "Test Coverage by Module")
+    modules = _newsletter_eval_modules()
+
+    assert modules, "No evals/newsletter_*.py modules found — scan may be broken"
+    assert coverage, "No '## Test Coverage by Module' section found in README-technical.md"
+
+    for module in modules:
+        stem = module[: -len(".py")]  # e.g. 'newsletter_run'
+        test_name = f"test_eval_{stem}.py"
+        with subtests.test(test=test_name):
+            assert (TESTS_DIR / test_name).exists(), (
+                f"evals/{module} has no matching {test_name}"
+            )
+            assert test_name in coverage, (
+                f"{test_name} is not documented in README-technical.md's "
+                f"'## Test Coverage by Module' section"
+            )


### PR DESCRIPTION
Adds an evaluation harness for the newsletter grading pipeline so its prompts can be iterated against hand-labeled ground truth, mirroring the email eval's 4-stage shape:

```
newsletter_harvest → newsletter_label → newsletter_run → newsletter_report
```

Design doc: `docs/plans/2026-07-01-newsletter-eval-plan.md`.

## What's included

**Pipeline** (`evals/newsletter_*.py` + `newsletter_schemas.py`):
- **harvest** — pulls candidate newsletters from Gmail (`is_newsletter` guard, body built exactly like production input) into `evals/newsletter_golden_set.jsonl` with no inferred ground truth.
- **label** — a curses TUI to build ground truth by hand. Phase A curates the story list: seed candidates from the production extractor (`Space`, with replace-confirmation), then mark body segments with cursor + `s`/`e`/`Enter` (covered lines are dimmed so omitted paragraphs stand out), plus add/edit/delete, multi-level undo, skip (`k`), and story- and newsletter-level exclusion (`u`/`X`, with `--include-excluded` to restore). Phase B assigns 4 dimension scores + themes per story; the tier is auto-derived.
- **run** — replays the golden set through the real `NewsletterClassifier` behind the shared `CachedLLMClient`. Extraction is scored at the newsletter-body level while quality/tier and themes are scored on **fixed golden stories**, decoupling scoring from extraction variability. Each run records a `prompt_hash`; `--prompts` deep-merges variant prompt TOMLs before hashing, so A/Bs are cheap (cache separates variants by content) and self-identifying.
- **report** — tier accuracy/confusion/P-R-F1, per-dimension MAE + exact/within-1 agreement, multi-label theme micro/macro F1 + exact-set match, and extraction precision/recall via fuzzy one-to-one story matching (`--match-threshold`); two-run comparison and a trend view. Reuses the email eval's metric helpers.

**UX hardening** — the whole pipeline was driven end-to-end against simulated Gmail/LLM servers with synthetic data covering both a well-behaved model and a badly-behaved one (mangled segmentation, malformed scores, invalid themes). 70 findings; the defects and clear gaps are fixed in this branch — highlights: re-seeding no longer silently destroys manual curation; quality parse failures, clamped scores, and dropped invalid themes are counted and named instead of silent; `--verbose` extraction diffs show matched/unmatched story titles with ratios instead of bare counts; dead-end and error messages explain themselves (env vars, next steps, resolved endpoints); a shared `llm_cache` bug that re-billed every no-thinking response on cache hits is fixed. Deliberately deferred design items are tracked in #41.

**Docs & guards** — `evals/README.md` (workflows), `evals/README-technical.md` (every CLI flag + env-var table + cache/`prompt_hash` internals), `CLAUDE.md`; two sync tests keep them honest (`test_eval_newsletter_cli_docs.py` asserts every argparse flag is documented; `test_newsletter_eval_docs.py` asserts modules/tests appear in the technical README).

## Testing

Built strict red/green TDD throughout. Full suite: **872 passed, 107 subtests** (from 608 on main); ruff clean. Beyond unit tests, the TUI and CLIs were smoke-verified by driving the real curses app in a pty (tmux) across the documented journey — including the manual-correction path for mangled model output — with persisted golden-set state asserted via the app's own loader.

## Related issues

- #41 — deferred UX design items from the audit (item 3, newsletter-level exclude, landed here)
- #40 — TUI framework evaluation (Textual/urwid) motivated by this branch's curses work
- #39 — documentation completeness (scoped guard tests landed here; repo-wide generalization deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9eQcTXZNh3oVtEXuR4cUW

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9eQcTXZNh3oVtEXuR4cUW)_