### PR TITLE
Roadmap + Phase 1: 3-value newsletter scoring, corpus-protection fix & curation TUI improvements

### DIFF
--- a/.claude/skills/tui-regression/SKILL.md
+++ b/.claude/skills/tui-regression/SKILL.md
@@ -117,16 +117,22 @@ so a schema break shows up here too.
 
 ## Coverage today
 
-62 scenarios across the four drivers (newsletter_label 16, review 18, edit_tui
-13, newsletter_review 15) exercise every binding/action in each module — browse
+69 scenarios across the four drivers (newsletter_label 16, review 18, edit_tui
+13, newsletter_review 22) exercise every binding/action in each module — browse
 + span sub-mode (with **exact committed-slice** assertions), blind + stage
-variants, the full filter matrix, every modal, Esc/cancel/decline/guard branches,
-undo (incl. empty-stack and undo-after-skip/exclude), scroll (asserting the
-offset, not just liveness), quit paths, and the auto-repeat/last-item guards —
-and each diverse data state is actually **opened and its rendered content
+variants, the full filter matrix (incl. the newsletter_review **date filter** —
+past-N-days window, since-prompt boundary, CANCEL-vs-clear, and the
+`--since`/`init_since` pre-filter), every modal, Esc/cancel/decline/guard
+branches, undo (incl. empty-stack and undo-after-skip/exclude), scroll (asserting
+the offset, not just liveness), quit paths, and the auto-repeat/last-item guards
+— and each diverse data state is actually **opened and its rendered content
 asserted** (emoji/CJK, CRLF, no-stories, multi-message, notes, reviewed, multi-
-story). When you add a binding or a workflow branch, add a scenario here in the
-same change and re-run `run_all.py`.
+story), including the send-date column's **LOCAL-timezone rendering** (an
+evening-UTC send shown on its prior local day) with newest-first sort/no-date-last
+ordering, and the `load_assessments` **old-scheme guard** (a list-valued
+`themes` rejected with a located `path:lineno` error). When you add a binding or
+a workflow branch, add a scenario here in the same change and re-run
+`run_all.py`.
 
 The harness was itself built adversarially: an automated coverage critic flagged
 every unopened data state and every liveness-only (`is_running`) assertion, and

--- a/.claude/skills/tui-regression/drive_edit_tui.py
+++ b/.claude/skills/tui-regression/drive_edit_tui.py
@@ -103,13 +103,20 @@ async def s_unexclude(chk):
         chk.that(path.exists(), "unexclude saved")
 
 
-async def s_unexclude_noop_on_included(chk):
+async def s_exclude_toggle_on_included(chk):
+    # Issue #52: `e` is now a symmetric toggle — on an INCLUDED thread it excludes.
     ths = [t for t in _threads() if t.thread_id == "th-person-fyi"]
     app, path = _app(ths)
     async with app.run_test(size=SIZE) as pilot:
-        await pilot.press("enter", "e")     # e on a non-excluded thread: no-op
+        await pilot.press("enter")
+        chk.that(not ths[0].excluded, "starts included")
+        await pilot.press("e")
         await pilot.pause()
-        chk.that(not path.exists(), "e is a no-op (no save) when not excluded")
+        chk.that(ths[0].excluded, "e excludes an included thread")
+        chk.that(path.exists(), "exclude saved")
+        await pilot.press("e")              # toggle back
+        await pilot.pause()
+        chk.that(not ths[0].excluded, "second e un-excludes")
 
 
 async def s_scroll_detail(chk):
@@ -218,7 +225,7 @@ def scenarios():
         ("edit_label_and_collision", s_edit_label_and_collision),
         ("sender_cancel_no_save", s_sender_cancel_no_save),
         ("unexclude", s_unexclude),
-        ("unexclude_noop_on_included", s_unexclude_noop_on_included),
+        ("exclude_toggle_on_included", s_exclude_toggle_on_included),
         ("scroll_detail", s_scroll_detail),
         ("detail_renders_multimsg_and_notes", s_detail_renders_multimsg_and_notes),
         ("edit_to_person_and_fyi", s_edit_to_person_and_fyi),

--- a/.claude/skills/tui-regression/drive_newsletter_label.py
+++ b/.claude/skills/tui-regression/drive_newsletter_label.py
@@ -60,15 +60,15 @@ async def s_auto_seed_and_label(chk):
         await drain(app, pilot)
         chk.eq(len(nl.stories), 1, "auto-seed produced one story")
         chk.that(nl.stories and "Sarah" in nl.stories[0].text, "seeded text is the body")
-        # Phase B: score 4/4/4/4 + scripture theme.
+        # Phase B: score all-Good (1/2/3 = Poor/OK/Good) + scripture theme emphasized.
         await pilot.press("1", "l")
-        await pilot.press("4", "4", "4", "4")
-        await pilot.press("s", "enter")
+        await pilot.press("3", "3", "3", "3")
+        await pilot.press("s", "s", "enter")   # scripture: present -> emphasized
         await drain(app, pilot)
-        chk.eq(nl.stories[0].expected_scores, {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
+        chk.eq(nl.stories[0].expected_scores, {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
                "scores assigned")
-        chk.eq(nl.stories[0].expected_tier, "excellent", "tier derived from avg 4.0")
-        chk.eq(nl.stories[0].expected_themes, ["scripture"], "theme assigned")
+        chk.eq(nl.stories[0].expected_tier, "excellent", "tier derived from avg 3.0")
+        chk.eq(nl.stories[0].expected_themes, {"scripture": "emphasized"}, "theme assigned")
         chk.that(nl.stories[0].reviewed, "story marked reviewed")
         await pilot.press("c")              # accept (all labeled -> silent) -> back to list
         await drain(app, pilot)
@@ -309,7 +309,7 @@ async def s_relabel_and_score_cancel(chk):
         await drain(app, pilot)
         chk.that("Reviewed: True" in _e2e.screen_text(app), "reviewed=True header rendered")
         orig = dict(nl.stories[0].expected_scores)
-        # Cancel score entry with a non-1-5 key -> labels untouched.
+        # Cancel score entry with a non-1-3 key -> labels untouched.
         await pilot.press("1", "l")
         await pilot.press("9")
         await drain(app, pilot)

--- a/.claude/skills/tui-regression/drive_newsletter_review.py
+++ b/.claude/skills/tui-regression/drive_newsletter_review.py
@@ -46,6 +46,11 @@ def _row_date(row: str) -> str:
     return row.split()[0]
 
 
+def _row_tier(row: str) -> str:
+    """The Tier column (second whitespace-delimited token) of a rendered row."""
+    return row.split()[1]
+
+
 def _title(app) -> str:
     from textual.widgets import Static
     return str(app.query_one("#title", Static).render())
@@ -265,7 +270,7 @@ async def s_detail_no_stories(chk):
     async with app.run_test(size=SIZE) as pilot:
         row = str(app.query_one(ListView).children[0].query_one(Label).render())
         chk.that("0 stories" in row, "list row shows '0 stories' for a no-story record")
-        chk.that(row.strip().startswith("—"), "list row shows '—' tier for None")
+        chk.eq(_row_tier(row), "—", "list row shows '—' tier for None")
         await pilot.press("enter")
         c = _detail_content(app)
         chk.that("No stories extracted" in c, "no-stories detail branch rendered")

--- a/.claude/skills/tui-regression/drive_newsletter_review.py
+++ b/.claude/skills/tui-regression/drive_newsletter_review.py
@@ -7,7 +7,10 @@ an empty filtered result.
 """
 
 import asyncio
+import os
 import sys
+import time
+from contextlib import contextmanager
 
 import synth_data
 from _e2e import report, run_scenarios
@@ -21,14 +24,50 @@ def _recs():
     return synth_data.assessment_records()
 
 
+def _by_id(*ids):
+    """Fresh subset of assessment records selected (and ordered) by message_id."""
+    by = {r["message_id"]: r for r in _recs()}
+    return [by[i] for i in ids]
+
+
 def _lv(app):
     from textual.widgets import ListView
     return app.query_one(ListView)
 
 
+def _rows(app) -> list[str]:
+    """Rendered text of each visible list row, top to bottom."""
+    from textual.widgets import Label, ListView
+    return [str(item.query_one(Label).render()) for item in app.query_one(ListView).children]
+
+
+def _row_date(row: str) -> str:
+    """The Date column (first whitespace-delimited token) of a rendered row."""
+    return row.split()[0]
+
+
 def _title(app) -> str:
     from textual.widgets import Static
     return str(app.query_one("#title", Static).render())
+
+
+@contextmanager
+def _tz(name: str):
+    """Temporarily set the process timezone (Linux ``TZ`` + ``time.tzset()``),
+    restoring the prior value on exit. ``_local_date`` / ``_days_ago_cutoff``
+    read the process-local zone, so date-column and since-filter scenarios must
+    pin it to a west-of-UTC zone to exercise the local-date conversion."""
+    prev = os.environ.get("TZ")
+    os.environ["TZ"] = name
+    time.tzset()
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = prev
+        time.tzset()
 
 
 async def s_list_nav(chk):
@@ -266,6 +305,168 @@ async def s_detail_wide_and_multistory(chk):
         chk.that("東京" in _detail_content(app), "wide-char story text rendered in detail")
 
 
+async def s_date_column_local_rendering(chk):
+    # The evening-UTC send (01:00 on 07-05 UTC) is 20:00 on 07-04 in Chicago, so
+    # the Date column must show the LOCAL date 2026-07-04, never the UTC 07-05.
+    # The no-send_date record renders "—".
+    with _tz("America/Chicago"):
+        app = ReviewApp(_by_id("nd-evening", "a5"))
+        async with app.run_test(size=SIZE):
+            rows = _rows(app)
+            chk.eq(len(rows), 2, "both records listed")
+            chk.eq(_row_date(rows[0]), "2026-07-04",
+                   "evening-UTC send renders the PREVIOUS local calendar date")
+            chk.that("2026-07-05" not in rows[0],
+                     "the raw UTC date never leaks into the row")
+            chk.eq(_row_date(rows[1]), "—", "the no-send_date record renders '—'")
+
+
+async def s_list_sorted_by_send_date_desc(chk):
+    # Fixed-date records (+ the no-date one) prove newest-first ordering with the
+    # dateless record pinned last. Pinned to UTC so midday dates map to exact
+    # local calendar dates for the column assertion.
+    with _tz("UTC"):
+        app = ReviewApp(_by_id("a8", "a5", "a6", "a7"))  # deliberately shuffled input
+        async with app.run_test(size=SIZE):
+            chk.eq([r["message_id"] for r in app.filtered], ["a6", "a7", "a8", "a5"],
+                   "records sorted by send-date descending, no-date last")
+            chk.eq([_row_date(r) for r in _rows(app)],
+                   ["2026-08-01", "2026-07-15", "2026-06-01", "—"],
+                   "visible Date column is newest-first with '—' last")
+
+
+async def s_filter_date_past_window(chk):
+    # a1 (now-2d) and a2 (now-10d) are inside a past-30d window; a3 (now-45d),
+    # a4 (now-200d) and a5 (no date) are outside it.
+    sub = _by_id("a1", "a2", "a3", "a4", "a5")
+    app = ReviewApp(sub)
+    async with app.run_test(size=SIZE) as pilot:
+        full = len(_lv(app))
+        await pilot.press("f")
+        await pilot.pause()
+        await pilot.press("d")          # date submenu
+        await pilot.pause()
+        await pilot.press("3")          # past 30 days
+        await pilot.pause()
+        chk.that("since:" in _title(app), "date filter shows a since cutoff in the title")
+        chk.eq([r["message_id"] for r in app.filtered], ["a1", "a2"],
+               "only the two dynamically-recent records survive past-30d")
+        # Clear via the date submenu's clear key.
+        await pilot.press("f")
+        await pilot.pause()
+        await pilot.press("d")
+        await pilot.pause()
+        await pilot.press("x")          # clear
+        await pilot.pause()
+        chk.that("since:" not in _title(app), "date filter cleared")
+        chk.eq(len(_lv(app)), full, "full list restored after clearing the date filter")
+
+
+async def s_filter_date_since_prompt(chk):
+    from textual.widgets import Input
+    # West-of-UTC so the evening-UTC record's local date (07-04) differs from its
+    # UTC date (07-05); the boundary must be judged on the LOCAL date.
+    with _tz("America/Chicago"):
+        sub = _by_id("nd-evening", "a6", "a8", "a5")  # local: 07-04, 08-01, 06-01, —
+        app = ReviewApp(sub)
+        async with app.run_test(size=SIZE) as pilot:
+            async def _set_since(value: str):
+                await pilot.press("f")
+                await pilot.pause()
+                await pilot.press("d")
+                await pilot.pause()
+                await pilot.press("s")      # "since…" prompt
+                await pilot.pause()
+                app.screen.query_one(Input).value = value
+                await pilot.press("enter")
+                await pilot.pause()
+
+            # since == the UTC date of the evening record: it must be EXCLUDED
+            # (its local date 07-04 is earlier); the 08-01 record still passes.
+            await _set_since("2026-07-05")
+            ids = [r["message_id"] for r in app.filtered]
+            chk.eq(ids, ["a6"], "since=2026-07-05 keeps only the 08-01 record")
+            chk.that("nd-evening" not in ids,
+                     "UTC-date boundary excludes the evening record (local date is earlier)")
+
+            # since == the LOCAL date of the evening record: now INCLUDED.
+            await _set_since("2026-07-04")
+            ids = [r["message_id"] for r in app.filtered]
+            chk.eq(ids, ["a6", "nd-evening"],
+                   "since=2026-07-04 (its local date) now includes the evening record")
+            chk.that("a8" not in ids and "a5" not in ids,
+                     "the 06-01 record and the dateless record stay excluded")
+
+
+async def s_filter_date_cancel(chk):
+    # An unmapped key in the date submenu dismisses with CANCEL -> no change.
+    app = ReviewApp(_recs())
+    async with app.run_test(size=SIZE) as pilot:
+        full = len(_lv(app))
+        await pilot.press("f")
+        await pilot.pause()
+        await pilot.press("d")
+        await pilot.pause()
+        await pilot.press("z")          # unmapped -> CANCEL
+        await pilot.pause()
+        chk.eq(app.f_since, None, "cancel left the since filter unset")
+        chk.that("since:" not in _title(app), "no date filter after cancel")
+        chk.eq(len(_lv(app)), full, "list unchanged after cancel")
+
+
+async def s_init_since_prefilters(chk):
+    # ReviewApp(init_since=...) pre-applies the date filter on launch (mirrors
+    # init_tier). a6 (08-01) passes; a8 (06-01) and a5 (no date) do not.
+    sub = _by_id("a6", "a8", "a5")
+    app = ReviewApp(sub, init_since="2026-07-01")
+    async with app.run_test(size=SIZE):
+        chk.that("since:2026-07-01" in _title(app), "init_since shown in the title")
+        chk.that(0 < len(_lv(app)) < len(sub), "init_since pre-narrowed the list")
+        chk.eq([r["message_id"] for r in app.filtered], ["a6"],
+               "only the record on/after the since date survives launch")
+
+
+async def s_old_scheme_record_rejected_at_load(chk):
+    # load_assessments must fail fast (not mid-render) on a pre-#53 record whose
+    # story themes are a LIST, naming the file + line so the reader can re-migrate.
+    import json
+    import tempfile
+    from pathlib import Path
+
+    from newsletter_review.tui import load_assessments
+
+    new_rec = {
+        "timestamp": "2026-01-05T10:00:00+00:00", "message_id": "ok", "thread_id": "ok",
+        "from": "a@dm.org", "subject": "New scheme", "overall_tier": "good",
+        "stories": [synth_data._story_rec("A fine story.", synth_data._scores(3, 2, 3, 2),
+                                          "good", {"scripture": "present"})],
+    }
+    old_rec = {
+        "timestamp": "2026-01-06T10:00:00+00:00", "message_id": "old", "thread_id": "old",
+        "from": "b@dm.org", "subject": "Old scheme", "overall_tier": "good",
+        "stories": [{
+            "text": "A legacy story.", "scores": synth_data._scores(2, 2, 2, 2),
+            "average_score": 2.0, "tier": "good",
+            "themes": ["scripture", "church"],  # old scheme: a LIST, not a dict
+            "quality_cot": "", "theme_cot": "",
+        }],
+    }
+    tmpdir = tempfile.mkdtemp(prefix="oldscheme_")
+    path = Path(tmpdir) / "assessments.jsonl"
+    path.write_text(json.dumps(new_rec) + "\n" + json.dumps(old_rec) + "\n")
+
+    try:
+        load_assessments(path)
+        chk.that(False, "load_assessments should raise ValueError on an old-scheme record")
+    except ValueError as exc:
+        msg = str(exc)
+        chk.that(str(path) in msg, "error names the offending file path")
+        chk.that(":2:" in msg, "error names the offending line number (2)")
+        chk.that("re-migrated" in msg, "error is actionable (mentions re-migration)")
+    except Exception as exc:  # noqa: BLE001
+        chk.that(False, f"expected ValueError, got {type(exc).__name__}: {exc}")
+
+
 def scenarios():
     return [
         ("list_nav", s_list_nav),
@@ -283,6 +484,13 @@ def scenarios():
         ("detail_no_stories", s_detail_no_stories),
         ("detail_scroll_offset_and_quit", s_detail_scroll_offset_and_quit),
         ("detail_wide_and_multistory", s_detail_wide_and_multistory),
+        ("date_column_local_rendering", s_date_column_local_rendering),
+        ("list_sorted_by_send_date_desc", s_list_sorted_by_send_date_desc),
+        ("filter_date_past_window", s_filter_date_past_window),
+        ("filter_date_since_prompt", s_filter_date_since_prompt),
+        ("filter_date_cancel", s_filter_date_cancel),
+        ("init_since_prefilters", s_init_since_prefilters),
+        ("old_scheme_record_rejected_at_load", s_old_scheme_record_rejected_at_load),
     ]
 
 

--- a/.claude/skills/tui-regression/synth_data.py
+++ b/.claude/skills/tui-regression/synth_data.py
@@ -97,8 +97,8 @@ def newsletters() -> list[GoldenNewsletter]:
         reviewed=True, seeded_from="parse_stories",
     )
     s = GoldenStory(story_id="nl-reviewed:0", text="Dana mentored three interns over the summer.",
-                    expected_scores=_scores(4, 4, 5, 4), expected_tier="excellent",
-                    expected_themes=["disciple_making"], reviewed=True)
+                    expected_scores=_scores(3, 3, 3, 3), expected_tier="excellent",
+                    expected_themes={"disciple_making": "emphasized"}, reviewed=True)
     reviewed.stories = [s]
     nls.append(reviewed)
 
@@ -151,8 +151,8 @@ def newsletters() -> list[GoldenNewsletter]:
         GoldenStory(
             story_id="nl-mixed:0",
             text="Paragraph one of the retreat story.\n\nParagraph two continues the same retreat story.",
-            expected_scores=_scores(3, 3, 3, 3), expected_tier="good",
-            expected_themes=["church"], reviewed=True),
+            expected_scores=_scores(3, 3, 2, 2), expected_tier="good",
+            expected_themes={"church": "present"}, reviewed=True),
         GoldenStory(story_id="nl-mixed:1", text="A separate short story about a baptism."),  # unlabeled
     ]
     nls.append(mixed)
@@ -233,9 +233,10 @@ def threads() -> list[GoldenThread]:
 # ---------------------------------------------------------------------------
 
 def _story_rec(text, scores=None, tier=None, themes=None, qcot="", tcot=""):
+    # Scores are 1/2/3 (Poor/OK/Good); themes are graded dicts (issue #53).
     avg = round(sum(scores.values()) / len(scores), 2) if scores else None
     return {"text": text, "scores": scores, "average_score": avg, "tier": tier,
-            "themes": themes or [], "quality_cot": qcot, "theme_cot": tcot}
+            "themes": {} if themes is None else themes, "quality_cot": qcot, "theme_cot": tcot}
 
 
 def assessment_records() -> list[dict]:
@@ -245,26 +246,28 @@ def assessment_records() -> list[dict]:
         "timestamp": "2026-01-05T10:00:00+00:00", "message_id": "a1", "thread_id": "a1",
         "from": "newsletter@dm.org", "subject": "Excellent edition", "overall_tier": "excellent",
         "stories": [_story_rec("Sarah led 5 students to a scripture retreat this weekend.",
-                               _scores(5, 5, 4, 4), "excellent", ["scripture", "disciple_making"],
+                               _scores(3, 3, 3, 3), "excellent",
+                               {"scripture": "emphasized", "disciple_making": "present"},
                                qcot="Concrete names and numbers throughout.", tcot="Clear scripture focus.")],
     })
     recs.append({
+        # Legacy record: present-only LIST themes — exercises backward-compat rendering.
         "timestamp": "2026-01-06T11:00:00+00:00", "message_id": "a2", "thread_id": "a2",
         "from": "weekly@ministry.org", "subject": "Good update", "overall_tier": "good",
-        "stories": [_story_rec("The church hosted a community dinner.", _scores(3, 3, 3, 3),
+        "stories": [_story_rec("The church hosted a community dinner.", _scores(3, 3, 2, 2),
                                "good", ["church"], qcot="Solid but generic.", tcot="Church theme.")],
     })
     recs.append({
         "timestamp": "2026-01-07T12:00:00+00:00", "message_id": "a3", "thread_id": "a3",
         "from": "digest@dm.org", "subject": "Fair digest", "overall_tier": "fair",
-        "stories": [_story_rec("Some vocation and family news was shared.", _scores(2, 2, 2, 3),
-                               "fair", ["vocation_family"])],
+        "stories": [_story_rec("Some vocation and family news was shared.", _scores(2, 2, 2, 2),
+                               "fair", {"vocation_family": "present"})],
     })
     recs.append({
         "timestamp": "2026-01-08T13:00:00+00:00", "message_id": "a4", "thread_id": "a4",
         "from": "bulletin@church.net", "subject": "Poor bulletin", "overall_tier": "poor",
         "stories": [_story_rec("Announcements and administrative items only.", _scores(1, 1, 1, 2),
-                               "poor", [])],
+                               "poor", {})],
     })
     # No-stories record.
     recs.append({
@@ -276,24 +279,25 @@ def assessment_records() -> list[dict]:
         "timestamp": "2026-01-10T15:00:00+00:00", "message_id": "a6", "thread_id": "a6",
         "from": "multi@partner-org.com", "subject": "Multi-theme edition", "overall_tier": "good",
         "stories": [
-            _story_rec("Christ-like service and scripture memorization combined.", _scores(4, 3, 4, 3),
-                       "good", ["christlikeness", "scripture"], qcot="A" * 400, tcot="B" * 400),
-            _story_rec("Disciple-making across three campuses.", _scores(3, 4, 3, 3),
-                       "good", ["disciple_making"]),
+            _story_rec("Christ-like service and scripture memorization combined.", _scores(3, 2, 3, 2),
+                       "good", {"christlikeness": "emphasized", "scripture": "present"},
+                       qcot="A" * 400, tcot="B" * 400),
+            _story_rec("Disciple-making across three campuses.", _scores(3, 2, 3, 2),
+                       "good", {"disciple_making": "emphasized"}),
         ],
     })
     # Emoji/wide subject.
     recs.append({
         "timestamp": "2026-01-11T16:00:00+00:00", "message_id": "a7", "thread_id": "a7",
         "from": "global@dm.org", "subject": "🌍 東京 global report", "overall_tier": "excellent",
-        "stories": [_story_rec("東京 team baptized 8 new believers 🙏.", _scores(5, 4, 5, 4),
-                               "excellent", ["church", "disciple_making"])],
+        "stories": [_story_rec("東京 team baptized 8 new believers 🙏.", _scores(3, 3, 3, 3),
+                               "excellent", {"church": "present", "disciple_making": "emphasized"})],
     })
     # Long CoT for detail scrolling.
     recs.append({
         "timestamp": "2026-01-12T17:00:00+00:00", "message_id": "a8", "thread_id": "a8",
         "from": "verbose@dm.org", "subject": "Long reasoning", "overall_tier": "fair",
-        "stories": [_story_rec("A modest story.", _scores(2, 3, 2, 2), "fair", ["scripture"],
+        "stories": [_story_rec("A modest story.", _scores(2, 2, 2, 2), "fair", {"scripture": "present"},
                                qcot="\n".join(f"reasoning line {i}" for i in range(30)),
                                tcot="\n".join(f"theme reasoning {i}" for i in range(30)))],
     })

--- a/.claude/skills/tui-regression/synth_data.py
+++ b/.claude/skills/tui-regression/synth_data.py
@@ -15,6 +15,7 @@ JSONL files a real ``load_*`` path can read back:
 import base64
 import json
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Repo modules (run from repo root).
@@ -38,6 +39,20 @@ def _msg(body: str, headers=None) -> dict:
 
 def _scores(simple, concrete, personal, dynamic):
     return {"simple": simple, "concrete": concrete, "personal": personal, "dynamic": dynamic}
+
+
+def _days_before_now_iso(days: int) -> str:
+    """A midday-UTC ``send_date`` *days* before the real current instant, as a
+    UTC ISO string.
+
+    The past-N-days date-filter scenarios compute their cutoff from the real
+    clock (``_days_ago_cutoff``), so the "recent" records must track ``now`` or
+    the harness would rot when the wall clock advances. Midday-UTC keeps the
+    local calendar date within one day of the offset regardless of the reader's
+    timezone, and the large offsets used (2/10 vs 45/200 days) leave a wide
+    margin around the 30-day boundary."""
+    dt = datetime.now(timezone.utc) - timedelta(days=days)
+    return dt.replace(hour=12, minute=0, second=0, microsecond=0).isoformat()
 
 
 # ---------------------------------------------------------------------------
@@ -242,8 +257,12 @@ def _story_rec(text, scores=None, tier=None, themes=None, qcot="", tcot=""):
 def assessment_records() -> list[dict]:
     recs: list[dict] = []
 
+    # a1/a2 are dynamically-RECENT (inside a past-30d window); a3/a4 are
+    # dynamically-OLD (outside it). Dates track the real clock so the past-N-days
+    # filter scenarios don't rot (issue #36).
     recs.append({
         "timestamp": "2026-01-05T10:00:00+00:00", "message_id": "a1", "thread_id": "a1",
+        "send_date": _days_before_now_iso(2),
         "from": "newsletter@dm.org", "subject": "Excellent edition", "overall_tier": "excellent",
         "stories": [_story_rec("Sarah led 5 students to a scripture retreat this weekend.",
                                _scores(3, 3, 3, 3), "excellent",
@@ -252,6 +271,7 @@ def assessment_records() -> list[dict]:
     })
     recs.append({
         "timestamp": "2026-01-06T11:00:00+00:00", "message_id": "a2", "thread_id": "a2",
+        "send_date": _days_before_now_iso(10),
         "from": "weekly@ministry.org", "subject": "Good update", "overall_tier": "good",
         "stories": [_story_rec("The church hosted a community dinner.", _scores(3, 3, 2, 2),
                                "good", {"church": "present"}, qcot="Solid but generic.",
@@ -259,24 +279,30 @@ def assessment_records() -> list[dict]:
     })
     recs.append({
         "timestamp": "2026-01-07T12:00:00+00:00", "message_id": "a3", "thread_id": "a3",
+        "send_date": _days_before_now_iso(45),
         "from": "digest@dm.org", "subject": "Fair digest", "overall_tier": "fair",
         "stories": [_story_rec("Some vocation and family news was shared.", _scores(2, 2, 2, 2),
                                "fair", {"vocation_family": "present"})],
     })
     recs.append({
         "timestamp": "2026-01-08T13:00:00+00:00", "message_id": "a4", "thread_id": "a4",
+        "send_date": _days_before_now_iso(200),
         "from": "bulletin@church.net", "subject": "Poor bulletin", "overall_tier": "poor",
         "stories": [_story_rec("Announcements and administrative items only.", _scores(1, 1, 1, 2),
                                "poor", {})],
     })
-    # No-stories record.
+    # No-stories AND no-send_date record: list column renders "—" and it sorts
+    # last; a positive since-filter always drops it (issue #36).
     recs.append({
         "timestamp": "2026-01-09T14:00:00+00:00", "message_id": "a5", "thread_id": "a5",
         "from": "empty@dm.org", "subject": "No stories here", "overall_tier": None, "stories": [],
     })
+    # a6/a7/a8 carry FIXED midday-UTC send-dates (distinct calendar days) so the
+    # sort-order / init-since scenarios assert exact dates deterministically.
     # Multi-theme, multi-story, distinct sender for the sender filter.
     recs.append({
         "timestamp": "2026-01-10T15:00:00+00:00", "message_id": "a6", "thread_id": "a6",
+        "send_date": "2026-08-01T12:00:00+00:00",
         "from": "multi@partner-org.com", "subject": "Multi-theme edition", "overall_tier": "good",
         "stories": [
             _story_rec("Christ-like service and scripture memorization combined.", _scores(3, 2, 3, 2),
@@ -289,6 +315,7 @@ def assessment_records() -> list[dict]:
     # Emoji/wide subject.
     recs.append({
         "timestamp": "2026-01-11T16:00:00+00:00", "message_id": "a7", "thread_id": "a7",
+        "send_date": "2026-07-15T12:00:00+00:00",
         "from": "global@dm.org", "subject": "🌍 東京 global report", "overall_tier": "excellent",
         "stories": [_story_rec("東京 team baptized 8 new believers 🙏.", _scores(3, 3, 3, 3),
                                "excellent", {"church": "present", "disciple_making": "emphasized"})],
@@ -296,10 +323,23 @@ def assessment_records() -> list[dict]:
     # Long CoT for detail scrolling.
     recs.append({
         "timestamp": "2026-01-12T17:00:00+00:00", "message_id": "a8", "thread_id": "a8",
+        "send_date": "2026-06-01T12:00:00+00:00",
         "from": "verbose@dm.org", "subject": "Long reasoning", "overall_tier": "fair",
         "stories": [_story_rec("A modest story.", _scores(2, 2, 2, 2), "fair", {"scripture": "present"},
                                qcot="\n".join(f"reasoning line {i}" for i in range(30)),
                                tcot="\n".join(f"theme reasoning {i}" for i in range(30)))],
+    })
+    # Evening-UTC send that falls on the PREVIOUS calendar day west of UTC:
+    # 01:00 UTC on 07-05 is 20:00 CDT on 07-04. The list column and since-filter
+    # must show/compare the LOCAL date (2026-07-04), never the UTC slice
+    # (2026-07-05) (issue #36 + local-tz fix).
+    recs.append({
+        "timestamp": "2026-07-05T02:00:00+00:00", "message_id": "nd-evening", "thread_id": "nd-evening",
+        "send_date": "2026-07-05T01:00:00+00:00",
+        "from": "evening@dm.org", "subject": "Evening send lands prior local day",
+        "overall_tier": "good",
+        "stories": [_story_rec("An evening-sent story about outreach.", _scores(3, 2, 2, 3),
+                               "good", {"church": "present"})],
     })
 
     return recs

--- a/.claude/skills/tui-regression/synth_data.py
+++ b/.claude/skills/tui-regression/synth_data.py
@@ -251,11 +251,11 @@ def assessment_records() -> list[dict]:
                                qcot="Concrete names and numbers throughout.", tcot="Clear scripture focus.")],
     })
     recs.append({
-        # Legacy record: present-only LIST themes — exercises backward-compat rendering.
         "timestamp": "2026-01-06T11:00:00+00:00", "message_id": "a2", "thread_id": "a2",
         "from": "weekly@ministry.org", "subject": "Good update", "overall_tier": "good",
         "stories": [_story_rec("The church hosted a community dinner.", _scores(3, 3, 2, 2),
-                               "good", ["church"], qcot="Solid but generic.", tcot="Church theme.")],
+                               "good", {"church": "present"}, qcot="Solid but generic.",
+                               tcot="Church theme.")],
     })
     recs.append({
         "timestamp": "2026-01-07T12:00:00+00:00", "message_id": "a3", "thread_id": "a3",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,9 @@ When `NEWSLETTER_ONLY=1`, the daemon switches to a newsletter-specific pipeline 
 ```
 Poll loop → find unprocessed newsletters (To/Cc matches config recipient)
   → Extract individual stories from newsletter body (Cloud LLM)
-  → Score each story on 4 quality dimensions: simple, concrete, personal, dynamic (Cloud LLM)
-  → Classify each story against Ends Statement themes (Cloud LLM)
-  → Compute overall tier (excellent/good/fair/poor) from averaged scores
+  → Score each story on 4 quality dimensions (simple, concrete, personal, dynamic) as Poor/OK/Good (Cloud LLM)
+  → Grade each story against Ends Statement themes as Absent/Present/Emphasized (Cloud LLM)
+  → Compute overall tier (excellent/good/fair/poor) from the averaged dimension scores (Poor/OK/Good → 1/2/3; excellent ≥ 2.75, good ≥ 2.25, fair ≥ 1.75, else poor)
   → Apply tier + theme labels via api-proxy → Gmail
   → Append assessment record to JSONL file
 ```
@@ -66,7 +66,7 @@ Newsletter uses its own `[newsletter.llm]` config (currently Sonnet 4.6) indepen
 - `agent/newsletter` — Marker (always applied)
 - `agent/newsletter/excellent|good|fair|poor` — Overall quality tier
 - `agent/newsletter/no-stories` — Newsletter contained no extractable stories
-- `agent/newsletter/theme/*` — Per-story theme labels (scripture, christlikeness, church, vocation-family, disciple-making)
+- `agent/newsletter/theme/*` — Per-story theme labels (scripture, christlikeness, church, vocation-family, disciple-making); applied **only when the theme is graded Emphasized** (Present/Absent are recorded in the assessment JSONL but not labeled)
 
 ### Newsletter Review TUI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,10 @@ python -m newsletter_review --sender dm.org          # Filter by sender
 python -m newsletter_review --file path/to/file.jsonl  # Custom JSONL path
 ```
 
-Hotkeys: `f` opens the filter menu (`t` tier → `e/g/f/p/c`, `h` theme → `s/c/h/v/d/x`, `s` sender text input), `Enter` opens detail, `Esc` back, `q` quit.
+The listing shows a send-date column and is sorted by send-date descending (newest
+first; records with no send-date sort last).
+
+Hotkeys: `f` opens the filter menu (`t` tier → `e/g/f/p/c`, `h` theme → `s/c/h/v/d/x`, `s` sender text input, `d` date → `3`=past 30d / `9`=past 90d / `y`=past 365d / `s`=since YYYY-MM-DD / `x`=clear), `Enter` opens detail, `Esc` back, `q` quit.
 
 ### Newsletter evaluation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ python -m newsletter_review                          # Browse all assessments
 python -m newsletter_review --tier poor              # Filter by tier
 python -m newsletter_review --theme scripture        # Filter by theme
 python -m newsletter_review --sender dm.org          # Filter by sender
+python -m newsletter_review --since 2026-01-01       # Filter to sends on/after a local date (YYYY-MM-DD)
 python -m newsletter_review --file path/to/file.jsonl  # Custom JSONL path
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Newsletter uses its own `[newsletter.llm]` config (currently Sonnet 4.6) indepen
 - `agent/newsletter` — Marker (always applied)
 - `agent/newsletter/excellent|good|fair|poor` — Overall quality tier
 - `agent/newsletter/no-stories` — Newsletter contained no extractable stories
-- `agent/newsletter/theme/*` — Per-story theme labels (scripture, christlikeness, church, vocation-family, disciple-making); applied **only when the theme is graded Emphasized** (Present/Absent are recorded in the assessment JSONL but not labeled)
+- `agent/newsletter/theme/*` — Per-story theme labels (scripture, christlikeness, church, vocation-family, disciple-making); applied **only when the theme is graded Emphasized** (merely-Present themes are recorded in the assessment JSONL but not labeled; Absent themes are omitted from the record entirely)
 
 ### Newsletter Review TUI
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Newsletter labels (see [Newsletter Classification](#newsletter-classification)):
 | Label | Purpose |
 |---|---|
 | `agent/newsletter` | Marker applied to all newsletter emails |
-| `agent/newsletter/excellent` | Best story scored >= 4.0 average |
-| `agent/newsletter/good` | Best story scored >= 3.0 average |
-| `agent/newsletter/fair` | Best story scored >= 2.0 average |
-| `agent/newsletter/poor` | Best story scored < 2.0 average |
+| `agent/newsletter/excellent` | Best story averaged >= 2.75 (dimensions scored Poor/OK/Good as 1/2/3) |
+| `agent/newsletter/good` | Best story averaged >= 2.25 |
+| `agent/newsletter/fair` | Best story averaged >= 1.75 |
+| `agent/newsletter/poor` | Best story averaged < 1.75 |
 | `agent/newsletter/no-stories` | No extractable stories found |
-| `agent/newsletter/theme/*` | Theme tags: `scripture`, `christlikeness`, `church`, `vocation-family`, `disciple-making` |
+| `agent/newsletter/theme/*` | Theme tags: `scripture`, `christlikeness`, `church`, `vocation-family`, `disciple-making` — applied only when a story grades the theme Emphasized (merely-Present themes are recorded in the assessment JSONL but not labeled) |
 
 ## Architecture
 

--- a/config.toml
+++ b/config.toml
@@ -165,38 +165,52 @@ user_template = """Newsletter content:
 {body}"""
 
 [newsletter.prompts.quality_assessment]
-system = """You are a writing quality assessor for ministry newsletter stories. Score the following story on four dimensions, each on a 1-5 scale.
+system = """You are a writing quality assessor for ministry newsletter stories. For each of four storytelling dimensions, judge how well this story demonstrates that dimension using a three-value rubric:
 
-Dimensions:
-- SIMPLE (1-5): Does the story focus on one key idea or progression? A 5 means no tangents or extraneous details. A 1 means it tries to cover too many things and feels scattered.
-- CONCRETE (1-5): Does the story narrate particular events involving particular people at particular times and places? A 5 means vivid specifics. A 1 means abstract and generalized.
-- PERSONAL (1-5): Does the story center around one person or a few people, such that what's important to them is what's important to the story? A 5 means deeply personal. A 1 means it's mainly about events, numbers, or ideas disconnected from people.
-- DYNAMIC (1-5): Does the story describe how a person changes over time? A 5 means a clear arc of transformation. A 1 means static — no change, no before-and-after.
+- POOR: The story does not display this dimension of storytelling in any meaningful way.
+- OK: The story displays this dimension, but only partially or inconsistently. There is significant room for improvement.
+- GOOD: The story consistently displays this dimension. While not necessarily perfect, it could serve as an example of what this dimension means.
+
+The dimensions:
+- SIMPLE: Does the story focus on one key idea or progression, with no tangents or extraneous details?
+- CONCRETE: Does the story narrate particular events involving particular people at particular times and places, with vivid specifics rather than abstractions?
+- PERSONAL: Does the story center on one person or a few people, such that what matters to them is what matters to the story — rather than events, numbers, or ideas disconnected from people?
+- DYNAMIC: Does the story describe how a person changes over time — a clear arc of transformation rather than a static account with no before-and-after?
 
 Think step by step about each dimension. Use <think> tags for your reasoning, then respond in this exact format:
 
-SIMPLE: [1-5]
-CONCRETE: [1-5]
-PERSONAL: [1-5]
-DYNAMIC: [1-5]"""
+SIMPLE: [POOR|OK|GOOD]
+CONCRETE: [POOR|OK|GOOD]
+PERSONAL: [POOR|OK|GOOD]
+DYNAMIC: [POOR|OK|GOOD]"""
 
 user_template = """Story text:
 {text}"""
 
 [newsletter.prompts.theme_classification]
-system = """You are a ministry theme classifier. Given a story from a ministry newsletter, identify which themes from the organization's Ends Statement it illustrates.
+system = """You are a ministry theme classifier. Given a story from a ministry newsletter, judge to what degree it illustrates each theme from the organization's Ends Statement, using a three-value rubric:
+
+- ABSENT: The theme is not present in the story at all.
+- PRESENT: The theme is present, but underdeveloped.
+- EMPHASIZED: The theme is well-developed and highlighted in the story.
 
 The Ends Statement themes are:
 
 - SCRIPTURE: Study the Scriptures correctly, apply them to all of life, and teach them to others
-- CHRISTLIKENESS: Exhibit increasing Christlikeness in response to the Gospel. The story must show a specific person growing in character, attitude, or behavior in a way that reflects Christ — not merely mentioning faith or spiritual activity in passing.
-- CHURCH: A college student actively participates in or serves at a local church (not just a campus fellowship). The story must be substantially about their involvement in a local church community while in college. A passing mention of attending church or a church name does not qualify. Example that qualifies: a student joins a local church small group, begins serving on the worship team, or describes how their church community shaped their growth during college.
+- CHRISTLIKENESS: Exhibit increasing Christlikeness in response to the Gospel. Look for a specific person growing in character, attitude, or behavior in a way that reflects Christ — not merely faith or spiritual activity mentioned in passing.
+- CHURCH: A college student actively participates in or serves at a local church (not just a campus fellowship). Look for substantial involvement in a local church community during college; a passing mention of attending church or a church name does not qualify.
 - VOCATION_FAMILY: Honor God in their vocation and family relationships
 - DISCIPLE_MAKING: Continue to make disciples wherever God takes them
 
-A story may match multiple themes, or none at all. Only select themes that the story clearly illustrates — do not force a match. A theme must be a substantial part of what the story is about, not merely referenced in passing.
+Do not force a match. A theme is EMPHASIZED only when it is a substantial part of what the story is about; PRESENT when it appears but is underdeveloped; otherwise ABSENT.
 
-Think step by step. Use <think> tags for your reasoning, then respond with ONLY the matching theme names, one per line. If no themes match, respond with: NONE"""
+Think step by step. Use <think> tags for your reasoning, then respond with one line per theme in this exact format:
+
+SCRIPTURE: [ABSENT|PRESENT|EMPHASIZED]
+CHRISTLIKENESS: [ABSENT|PRESENT|EMPHASIZED]
+CHURCH: [ABSENT|PRESENT|EMPHASIZED]
+VOCATION_FAMILY: [ABSENT|PRESENT|EMPHASIZED]
+DISCIPLE_MAKING: [ABSENT|PRESENT|EMPHASIZED]"""
 
 user_template = """Story text:
 {text}"""

--- a/daemon.py
+++ b/daemon.py
@@ -27,6 +27,7 @@ from newsletter import (
     NewsletterTier,
     aggregate_theme_grades,
     is_newsletter,
+    parse_send_date,
     write_assessment,
 )
 from proxy_client import (
@@ -348,6 +349,9 @@ async def process_single_thread(
                 first_headers = messages[0]["payload"]["headers"]
                 subject = get_header(first_headers, "Subject")
                 sender = get_header(first_headers, "From")
+                send_date = parse_send_date(
+                    get_header(first_headers, "Date"), messages[0].get("internalDate")
+                )
                 transcript = format_thread_transcript(messages, max_thread_chars)
 
                 async with cloud_sem:
@@ -380,6 +384,8 @@ async def process_single_thread(
                             subject=subject,
                             overall_tier=best_tier,
                             stories=story_results,
+                            send_date=send_date,
+                            model=newsletter_classifier.cloud_llm.model,
                         )
                     except Exception:
                         log.exception("Failed to write newsletter assessment for thread %s", thread_id)

--- a/daemon.py
+++ b/daemon.py
@@ -22,7 +22,13 @@ from config_utils import substitute_env_vars
 from gmail_utils import decode_body, get_header
 from labeler import LabelManager, _get_priority
 from llm_client import LLMClient, LLMUnavailableError
-from newsletter import NewsletterClassifier, NewsletterTier, is_newsletter, write_assessment
+from newsletter import (
+    NewsletterClassifier,
+    NewsletterTier,
+    aggregate_theme_grades,
+    is_newsletter,
+    write_assessment,
+)
 from proxy_client import (
     TRANSIENT_TRANSPORT_ERRORS,
     GmailProxyClient,
@@ -349,13 +355,12 @@ async def process_single_thread(
 
                 # Determine overall tier (best story's tier)
                 best_tier = None
-                all_themes = []
                 for sr in story_results:
                     if sr.tier is not None:
                         if best_tier is None or _TIER_RANK.get(sr.tier, 0) > _TIER_RANK.get(best_tier, 0):
                             best_tier = sr.tier
-                    all_themes.extend(sr.themes)
-                all_themes = list(dict.fromkeys(all_themes))  # dedupe, preserve order
+                # Merge graded themes across stories (strongest grade per theme)
+                all_themes = aggregate_theme_grades(story_results)
 
                 async with (write_sem or nullcontext()):
                     await label_manager.apply_newsletter_classification(

--- a/docs/plans/2026-07-08-issue-roadmap.md
+++ b/docs/plans/2026-07-08-issue-roadmap.md
@@ -32,7 +32,7 @@ Directly serves the curation the owner is doing right now.
 |---|---|---|---|---|
 | **#53** | Switch theme scores binary→3-value (Absent/Present/Emphasized) and storytelling dimensions 1–5→3-value (Poor/OK/Good); update prompts, schema, tier derivation, labels | **P0** | M–L | — |
 | **#52** | Add an *exclude* action to `evals.review --edit` (only unexclude exists today); keep parity with the newsletter labeler | **P0** | S | — |
-| **#41** | Deferred newsletter-eval UX items (item 2 already done by the redesign; item 1 sub-line/`$EDITOR` open; items 4–7 open) | **P1** | S–L (triage per sub-item) | — |
+| **#41** | Deferred newsletter-eval UX items. Triaged 2026-07-08: items **2** (cursor-direct selection) and **3** (`X` newsletter exclude) already done by the Textual redesign; item **7** (`is_available` 404 detail) done here; items **1** ($EDITOR/sub-line), **4** (`q` quits), **5** (unreviewed extraction metrics — schema change), **6** (`--verbose` trend) deferred with rationale in `docs/plans/2026-07-08-phase1-decisions.md` | **P1** | S–L (triage per sub-item) | — |
 | **#35** | Newsletter review-TUI header: show sent-date *and* processed-date, separate email-intrinsic vs classification data, show model | **P1** | M | upstream capture |
 | **#36** | Newsletter listing: show send-date column, default sort by date desc, date filters (30/90/365/Since…) | **P1** | M | upstream capture |
 

--- a/docs/plans/2026-07-08-issue-roadmap.md
+++ b/docs/plans/2026-07-08-issue-roadmap.md
@@ -1,0 +1,190 @@
+# Implementation roadmap — all open issues on `brianroberg/email-labeler`
+
+## Context
+
+All 28 open issues were triaged against `HEAD b0b7631` (see each issue's comment for
+current-state verification). This document is the *forward* plan: it groups the issues
+into coherent workstreams, sizes them, maps dependencies, and recommends an order of
+attack. It stays at the epic/sequencing level — no code.
+
+**The organizing insight for prioritization:** the owner has just begun curating the
+first *newsletter* golden set (#53's framing) and is exercising the golden-set editors
+(#52). That is the live frontier, so the plan front-loads the work that de-risks and
+unblocks that curation, then the measurement infrastructure that everything else
+depends on, then correctness, then polish. Two rules of thumb drive the ordering:
+
+1. **Don't tune what you can't measure.** Prompt/accuracy work is gated by a trustworthy
+   golden set. Grow/curate the set *before* investing in prompt changes.
+2. **Change the rubric before you mass-label under it.** Schema/scoring changes that
+   invalidate existing labels (#53) must land before heavy labeling, or the labels get
+   redone.
+
+Priority key: **P0** now / time-sensitive · **P1** next · **P2** later · **P3** opportunistic.
+Effort: **S** (hours) · **M** (a day-ish) · **L** (multi-day / needs a spike).
+
+---
+
+## Epic A — Newsletter scoring model & golden-set curation *(the active frontier)*
+
+Directly serves the curation the owner is doing right now.
+
+| Issue | What | Priority | Effort | Depends on |
+|---|---|---|---|---|
+| **#53** | Switch theme scores binary→3-value (Absent/Present/Emphasized) and storytelling dimensions 1–5→3-value (Poor/OK/Good); update prompts, schema, tier derivation, labels | **P0** | M–L | — |
+| **#52** | Add an *exclude* action to `evals.review --edit` (only unexclude exists today); keep parity with the newsletter labeler | **P0** | S | — |
+| **#41** | Deferred newsletter-eval UX items (item 2 already done by the redesign; item 1 sub-line/`$EDITOR` open; items 4–7 open) | **P1** | S–L (triage per sub-item) | — |
+| **#35** | Newsletter review-TUI header: show sent-date *and* processed-date, separate email-intrinsic vs classification data, show model | **P1** | M | upstream capture |
+| **#36** | Newsletter listing: show send-date column, default sort by date desc, date filters (30/90/365/Since…) | **P1** | M | upstream capture |
+
+**Sequencing within A:**
+- **#53 first** — it changes the scoring schema, so labeling done under the old scheme
+  would need redoing. Land it before the golden set grows large. Expect follow-up
+  prompt-tuning at the rubric boundaries (the owner already flagged this as out of scope
+  for #53 itself — file as a follow-up).
+- **#52 is a quick, high-leverage curation-friction fix** — do it early alongside #53.
+- **#35 + #36 share one prerequisite:** the assessment record (`write_assessment`)
+  doesn't persist the email's send-date or the classifier model. Do that upstream
+  capture *once*, then both TUI issues become straightforward. Treat "persist send-date
+  + model in the assessment JSONL" as the shared enabling step.
+- **#41** is a grab-bag: re-scope it against the current (redesigned) TUI and cherry-pick
+  the still-relevant sub-items; item 1 (character-level spans / `$EDITOR` handoff) is the
+  only large one and is optional.
+
+---
+
+## Epic B — Newsletter classifier quality *(downstream of eval + golden set)*
+
+Improves *what* the newsletter classifier decides. Gated by having the eval harness
+(exists) plus a curated golden set (Epic A, in progress) to measure against.
+
+| Issue | What | Priority | Effort | Notes |
+|---|---|---|---|---|
+| **#8** | Refine SCRIPTURE theme to distinguish "reading the Bible" from "correctly handling Scripture" | **P1–P2** | S–M | Clear precedent: sibling themes were tightened in `7759dea`; apply the same pattern |
+| **#4** | Distinguish personal vs ministry stories (personal recorded but doesn't "count" unless included) | **P2** | M–L | Needs a new schema concept (per-story class + "counts" semantics) + prompt + eval coverage |
+| **#6** | Recognize repeat/similar stories across newsletters | **P3** | L (spike first) | Speculative; likely needs embeddings + storage. Do a feasibility spike before committing |
+
+**Sequencing:** #8 is the cheapest and has a direct precedent — do it first, once the
+rubric change (#53) has settled so you're not tuning a prompt that's about to change
+shape. #4 is a genuine feature (schema + semantics). #6 is research — gate it behind a
+spike that answers cost/feasibility.
+
+---
+
+## Epic C — Email classification accuracy *(gated by the email golden set)*
+
+| Issue | What | Priority | Effort | Depends on |
+|---|---|---|---|---|
+| **#13** | Grow the email golden set to ≥60 reviewed threads, balanced across labels/sender types. **Sub-tasks added:** (1) a read-only `--stats` mode on `evals.review` (composition dashboard — total / excluded / reviewed-unexcluded, plus sender×label crosstab); (2) a `--sender-type person\|service` filter on `evals.review` (it has `--filter-label` but no sender filter today) so the reviewed-pending backlog can be drained toward thin cells. Both are small, reuse `load_golden_set`/`SENDER_TYPES`/`LABELS`, and steer the curation | **P1** | M–L (human review) | — *(enables the rest)* |
+| **#14** | Fix the stable under-classification (needs_response→fyi ×1, fyi→low_priority ×2) via prompt-criteria tuning | **P1** | M | **#13** |
+| **#12** | Reduce local latency: A/B a lean prompt (drop the reasoning scaffold) vs current; adopt if accuracy holds | **P1–P2** | M | **#13** |
+| **#2** | Reconcile golden-set labels with whole-thread state (already-replied → FYI); optionally add an explicit prompt rule | **P2** | S–M | overlaps #13 |
+
+**Sequencing:** **#13 is the keystone** — it unblocks #14 and #12 and makes every
+accuracy number trustworthy. Fold #2's label-consistency pass into the #13 curation
+effort (same activity, same data). Then #14 (correctness of the rare, high-stakes class)
+before #12 (latency, which must not regress accuracy).
+
+**Current status (measured 2026-07-08):** 236 reviewed & usable threads — the ≥60 *count*
+target is already met (~4×). Label balance is fine (needs_response 36 / fyi 95 /
+low_priority 105); the earlier "needs_response barely represented" worry is resolved. The
+remaining lever is **sender balance**: person is only 45/236 (~19%), and that's the
+privacy-critical, locally-served path (#14/#12), so its coverage is the thin side. The
+weakest cell (person/low_priority = 4) likely reflects a true low base rate — don't
+force it. Growth from here is mostly a *reviewing* task: ~164 harvested-but-unreviewed
+threads already sit on disk, so the new `--stats` and `--sender-type` review filters are
+the tools to drain that backlog toward person coverage, then re-baseline accuracy.
+
+---
+
+## Epic D — Daemon resilience & correctness
+
+| Issue | What | Priority | Effort | Notes |
+|---|---|---|---|---|
+| **#30** | *(bug)* Newsletter content-less error swallowed → commits an empty "no-stories" grade; pollutes the assessment corpus | **P1** | M | Intersects Epic A — the corpus the owner is curating/reviewing |
+| **#28** | *(bug/question)* Proxy 403 (human-rejected write) counts toward give-up → can silently abandon a gated thread | **P1 (decision) / P2 (impl)** | S + M | Needs the A/B/C product decision first; fix must also cover the marker-write 403 path |
+| **#29** | *(enh)* Write-phase outage discards a completed classification, re-running the expensive local LLM | **P2** | M | Now bounded to ~max_failures cycles; still wasteful |
+| **#33** | *(enh)* `write_sem` held across a whole per-message write loop (wrong granularity; 5 call sites incl. the new one from PR #38) | **P2** | S–M | Correctness fine; throughput/fairness |
+| **#24** | Local-LLM outage logged as WARNING per-thread; should be INFO + one per-cycle summary (tier-aware) | **P2** | S | `is_available()` already exists, unused in the loop |
+
+**Sequencing:** **#30 first** (it's a correctness bug *and* it corrupts the very corpus
+Epic A is building — treat it as part of protecting the newsletter data). Make the
+**#28 product decision** early (cheap, unblocks a real operational risk) even if the
+implementation waits. **#29 + #33** both live on the write path — bundle them. **#24** is
+an easy quality-of-life win that can slot in anytime.
+
+---
+
+## Epic E — Documentation
+
+| Issue | What | Priority | Effort | Notes |
+|---|---|---|---|---|
+| **#15** | Human READMEs: add the give-up bullet to Resilience, add the new eval flags + thinking-A/B workflow to `evals/README.md`, reference `smoke_concurrency.py`, fix the stale `qwen3-14b` example | **P1** | S | Closes a real, small inconsistency |
+| **#39** | Generalize the doc-completeness guard to the whole repo + backfill missing modules/tests; add a guarded project-structure outline to `README.md` | **P2** | L | Valuable guardrail, but bigger |
+
+**Sequencing:** **#15 now** — it's cheap and the stale model example is actively
+misleading. **#39 after the code churn settles** (Epics A–D add/rename modules; a
+completeness guard is most useful — and least thrash-prone — once the module set is
+stable).
+
+---
+
+## Epic F — TUI shared-infrastructure tech-debt *(from the Textual migration)*
+
+All `tech-debt`, all "not blocking." Value = lower cost/risk of *future* TUI change.
+
+| Issue | What | Priority | Effort | Layer |
+|---|---|---|---|---|
+| **#50** | Extract atomic `save_golden_set` JSONL write into a shared eval helper | **P2** | S | foundation |
+| **#51** | Unify the dismiss-guard + "modal owns the keys" idioms into `tui_common` | **P2** | S | foundation |
+| **#49** | Unify `wrap_text`/`truncate`/`excerpt` into `tui_common` (behavior-sensitive) | **P2** | M | foundation |
+| **#48** | Extract shared `ScrollableDetailScreen` + list-resize helper | **P2** | M | foundation |
+| **#45** | Extract a `mutation_flow` decorator for the `_begin_flow`/`_end_flow` boilerplate (prevents wedge bugs) | **P2–P3** | S | safety |
+| **#46** | Avoid full row rebuilds / re-filtering on non-structural refreshes (perf) | **P3** | M | perf |
+| **#47** | Bound undo memory via copy-on-write snapshots | **P3** | M | memory |
+
+**Sequencing — the key judgment:** these touch the *same* TUI files as Epic A
+(`newsletter_label.py`, `newsletter_review/tui.py`, `edit_tui.py`, `review.py`). To avoid
+editing the same duplication twice, **fold the relevant consolidations into Epic A's TUI
+work** rather than running Epic F as a separate campaign:
+- Doing **#52 / #35 / #36 / #41** already means opening those files — extract the shared
+  helpers (**#50, #51, #49, #48**) *while you're there*.
+- **#45** (mutation_flow) pairs naturally with any `newsletter_label` flow change.
+- **#46 / #47** are pure optimizations that only bite on large newsletters; lowest
+  priority — do only if profiling or memory shows they matter.
+
+---
+
+## Recommended phased roadmap
+
+**Phase 1 — Unblock & protect the active newsletter curation.**
+#53 (rubric change, before mass-labeling) → #52 (exclude editing) → #30 (stop corrupting
+the corpus) → the shared send-date+model capture, then #35 + #36 → triage #41. Opportunistically
+fold in the TUI-consolidation tech-debt (#50/#51/#49/#48/#45) as those files are touched.
+
+**Phase 2 — Measurement & decisions.**
+#13 (grow the email golden set; fold in #2's consistency pass) — can run in parallel with
+newsletter curation. #15 (cheap doc fixes). Make the #28 product decision. #24 (log-noise win).
+
+**Phase 3 — Accuracy & resilience.**
+After #13: #14 then #12 (email accuracy/latency). After the rubric settles: #8 then #4
+(newsletter quality). Implement #28; bundle #29 + #33 (write path).
+
+**Phase 4 — Hardening & long-tail.**
+#39 (doc-completeness guard, once modules are stable). Remaining TUI perf/memory
+debt (#46/#47) if warranted. Spikes for #6 (repeat stories) and the #7 staff-cross-ref
+script — both standalone and lowest urgency.
+
+---
+
+## Notes
+
+- **#52 and #53 are brand-new** (owner-filed today) and were verified but intentionally
+  left un-commented during triage; they are fully incorporated above. #53's own scope is
+  just the scheme switch — boundary-tuning of the new rubric is expected follow-up.
+- **No issue is obsolete.** Two were already Complete and closed during triage (#5, #23);
+  everything remaining is live.
+- **Biggest force multipliers:** #13 (unblocks all email-accuracy work) and #53
+  (prevents re-labeling the newsletter set). Do these early.
+- **Cheapest high-value wins:** #52, #15, #24, #8, #50, #51.
+- This roadmap is deliberately code-free; each epic would get its own implementation
+  plan (with TDD per the repo's red/green rule) when picked up.

--- a/docs/plans/2026-07-08-issue-roadmap.md
+++ b/docs/plans/2026-07-08-issue-roadmap.md
@@ -75,7 +75,7 @@ spike that answers cost/feasibility.
 | Issue | What | Priority | Effort | Depends on |
 |---|---|---|---|---|
 | **#13** | Grow the email golden set to ≥60 reviewed threads, balanced across labels/sender types. **Sub-tasks added:** (1) a read-only `--stats` mode on `evals.review` (composition dashboard — total / excluded / reviewed-unexcluded, plus sender×label crosstab); (2) a `--sender-type person\|service` filter on `evals.review` (it has `--filter-label` but no sender filter today) so the reviewed-pending backlog can be drained toward thin cells. Both are small, reuse `load_golden_set`/`SENDER_TYPES`/`LABELS`, and steer the curation | **P1** | M–L (human review) | — *(enables the rest)* |
-| **#14** | Fix the stable under-classification (needs_response→fyi ×1, fyi→low_priority ×2) via prompt-criteria tuning | **P1** | M | **#13** |
+| **#14** | Fix the stable under-classification (needs_response→fyi ×1, fyi→low_priority ×2) via prompt-criteria tuning. **⚠ These tallies predate the 252-thread expansion** — re-run `evals.run_eval` + `evals.report --verbose` against the current set before acting | **P1** | M | **#13** |
 | **#12** | Reduce local latency: A/B a lean prompt (drop the reasoning scaffold) vs current; adopt if accuracy holds | **P1–P2** | M | **#13** |
 | **#2** | Reconcile golden-set labels with whole-thread state (already-replied → FYI); optionally add an explicit prompt rule | **P2** | S–M | overlaps #13 |
 
@@ -84,15 +84,26 @@ accuracy number trustworthy. Fold #2's label-consistency pass into the #13 curat
 effort (same activity, same data). Then #14 (correctness of the rare, high-stakes class)
 before #12 (latency, which must not regress accuracy).
 
-**Current status (measured 2026-07-08):** 236 reviewed & usable threads — the ≥60 *count*
-target is already met (~4×). Label balance is fine (needs_response 36 / fyi 95 /
-low_priority 105); the earlier "needs_response barely represented" worry is resolved. The
-remaining lever is **sender balance**: person is only 45/236 (~19%), and that's the
-privacy-critical, locally-served path (#14/#12), so its coverage is the thin side. The
-weakest cell (person/low_priority = 4) likely reflects a true low base rate — don't
-force it. Growth from here is mostly a *reviewing* task: ~164 harvested-but-unreviewed
-threads already sit on disk, so the new `--stats` and `--sender-type` review filters are
-the tools to drain that backlog toward person coverage, then re-baseline accuracy.
+**Current status (measured 2026-07-08, after the owner's expansion pass):** 252 reviewed
+& usable threads out of 401 harvested (2 excluded) — the ≥60 *count* target is met (~4×).
+Label balance is fine (needs_response 47 / fyi 99 / low_priority 106); the earlier
+"needs_response barely represented" worry is resolved. Full sender×label crosstab of the
+scored set:
+
+```
+           needs_response   fyi   low_priority   total
+    person             20    32              4      56
+   service             27    67            102     196
+    total              47    99            106     252
+```
+
+The remaining lever is **sender balance**: person is 56/252 (~22%) — up from the earlier
+45, but still the thin side, and it's the privacy-critical, locally-served path
+(#14/#12). The weakest cell (person/low_priority = 4) likely reflects a true low base
+rate — don't force it. Growth from here is mostly a *reviewing* task: ~147
+harvested-but-unreviewed threads (401 − 2 excluded − 252 reviewed) still sit on disk, so
+the new `--stats` and `--sender-type` review filters are the tools to drain that backlog
+toward person coverage, then re-baseline accuracy.
 
 ---
 

--- a/docs/plans/2026-07-08-phase1-decisions.md
+++ b/docs/plans/2026-07-08-phase1-decisions.md
@@ -63,14 +63,19 @@ are already open.
   Daemon cross-story aggregation = max grade per theme (emphasized > present > absent).
 - **Gmail theme label** (owner decision: Emphasized-only) → the daemon applies
   `agent/newsletter/theme/<name>` only for themes whose aggregated grade is `emphasized`.
-- **Report metrics**: LEFT AS-IS for the scheme switch and functions correctly — the
-  report reads the graded dicts as sets of theme *keys*, so its multilabel P/R/F1
-  measures **≥Present detection**, and dimension MAE/exact/within-1 still compute on the
-  1–3 scale. Two refinements are **deferred as follow-up** (not required for the switch;
-  the report is not broken): (a) collapse the theme metric at **positive = Emphasized**
-  to align the headline number with production labeling; (b) **drop within-1** (coarse on
-  a 3-point scale — MAE + exact-match suffice). Both are small, isolated report-only
-  changes.
+- **Report metrics** (post-#53 follow-up):
+  - **(b) within-1: DONE** — dropped from the dimension table + metrics bundle; on a 1–3
+    scale the only non-within-1 pair is a Poor↔Good confusion, so it was ~always 1.0 and
+    added nothing over MAE (now 0–2) + exact-match.
+  - **(a) theme metric: DONE — chose A′ (hybrid).** The **primary** metric
+    (`metrics["themes"]`) is now **Emphasized-positive** (per-theme + micro/macro F1 +
+    exact-set-match) — exactly what earns a Gmail label, so it is production-aligned; a
+    **secondary** `metrics["themes_detection"]` micro-F1 (positive = ≥Present) preserves
+    the "did we detect the theme at all" signal (owner: present detection is
+    secondary-but-not-nothing). Pure A was rejected because it makes Present detection
+    entirely invisible. **Option C** (full 3-class per-theme with the downgrade-vs-miss
+    confusion) is deferred to a filed issue — take it up if A′'s two aggregate F1s stop
+    being enough to explain *how* emphasized detection fails during prompt-tuning.
 
 ## #41 triage outcome (verified against HEAD)
 

--- a/docs/plans/2026-07-08-phase1-decisions.md
+++ b/docs/plans/2026-07-08-phase1-decisions.md
@@ -53,7 +53,9 @@ are already open.
   tokens — preserves `average_score`, the mean-based tier, and eval MAE math with minimal
   churn. Prompt emits `POOR|OK|GOOD` tokens; `parse_quality_scores` maps tokens→ints (a
   digit or unknown token is a parse failure — the old 1–5 clamp / `clamped_dimensions`
-  feature becomes obsolete). TUIs render ints→labels. `_DIMENSIONS` unchanged.
+  feature becomes obsolete). The read-only review **detail** view renders ints→labels
+  (Poor/OK/Good); the labeling TUI's compact story strip keeps the dense `2/3/1/2` int
+  form (space-constrained editor grid). `_DIMENSIONS` unchanged.
 - **Themes** stored as **`dict[str,str]`** mapping theme→`"present"`/`"emphasized"`,
   Absent omitted. `parse_themes`, `StoryResult.themes`, `expected_themes`/
   `predicted_themes`, the assessment JSONL, and the golden set all take this shape.

--- a/docs/plans/2026-07-08-phase1-decisions.md
+++ b/docs/plans/2026-07-08-phase1-decisions.md
@@ -59,8 +59,12 @@ are already open.
 - **Themes** stored as **`dict[str,str]`** mapping theme→`"present"`/`"emphasized"`,
   Absent omitted. `parse_themes`, `StoryResult.themes`, `expected_themes`/
   `predicted_themes`, the assessment JSONL, and the golden set all take this shape.
-  `from_dict` coerces a legacy `list[str]` → `{name: "present"}` so old files still load.
   Daemon cross-story aggregation = max grade per theme (emphasized > present > absent).
+  **No backward-compat to the old scheme** (owner decision): the readers assume the
+  new dict/1–3 shapes (no list→present coercion, no 1–5 fallback) and the golden set /
+  assessment JSONL are regenerated under the new scheme. The parsers still *reject* old-
+  format LLM output (a bare theme name or a digit score → parse failure), which is
+  robustness against a misbehaving model, not data backward-compat.
 - **Gmail theme label** (owner decision: Emphasized-only) → the daemon applies
   `agent/newsletter/theme/<name>` only for themes whose aggregated grade is `emphasized`.
 - **Report metrics** (post-#53 follow-up):

--- a/docs/plans/2026-07-08-phase1-decisions.md
+++ b/docs/plans/2026-07-08-phase1-decisions.md
@@ -1,0 +1,105 @@
+# Phase 1 implementation — confirmed decisions
+
+Companion to `docs/plans/2026-07-08-issue-roadmap.md`. Phase 1 is being implemented
+**autonomously** (owner authorization, 2026-07-08): work through the whole roadmap
+order, stopping only for genuine product decisions. Red/green TDD is mandatory
+(see `CLAUDE.md`). Local commit per sub-project; no push.
+
+Roadmap order: **#53 → #52 → #30 → assessment-capture → #35 → #36 → #41 (triage)**,
+folding in TUI tech-debt (#50/#51/#49/#48/#45) opportunistically where those files
+are already open.
+
+## Confirmed product decisions (owner, 2026-07-08)
+
+### #53 — newsletter scoring schemes
+
+- **Storytelling dimensions**: 1–5 numeric → 3-value **Poor / OK / Good**.
+- **Themes**: boolean → 3-value **Absent / Present / Emphasized**.
+- **Tier derivation** (excellent/good/fair/poor): map Poor/OK/Good → 1/2/3, take the
+  **mean of the four dimensions** (simple, concrete, personal, dynamic), then band:
+
+  | tier | average |
+  |---|---|
+  | excellent | ≥ 2.75 |
+  | good | 2.25 – 2.74 |
+  | fair | 1.75 – 2.24 |
+  | poor | < 1.75 |
+
+  (all-OK = 2.0 → fair; one Poor among three Good ≈ 2.5 → good.)
+
+- **Theme Gmail labels**: apply `agent/newsletter/theme/<name>` **only when the theme
+  is Emphasized**. Present and Absent are still persisted in the assessment record and
+  compared in the eval/report, but do NOT get a Gmail label. (Deliberately changes the
+  existing label's meaning from "present" to "emphasized".)
+- Scope is the scheme switch only. Boundary prompt-tuning of the new rubric is expected
+  follow-up, filed separately — not part of #53.
+
+### #30 — content-less error handling
+
+- Stories-exist-but-every-grade-errored is a **failure**, never a committed outcome.
+  Raise a dedicated content-less exception from the `complete()` guard; re-raise it from
+  `classify_newsletter` alongside `LLMUnavailableError` so it reaches the daemon give-up
+  path (retry, then `agent/attempted`). Per-story parse-level `RuntimeError` stays
+  isolated (`test_non_transient_quality_error_stays_isolated` must stay green).
+- Genuine NO_STORIES (extraction returns zero stories) remains a valid committed
+  `no-stories` outcome — must stay distinct from the failure path.
+- **Sub-problem (b)** of #30 (non-convergence / wasted re-grading on a flaky endpoint):
+  **deferred** — it's a separate enhancement (adjacent to #29), medium/low severity, and
+  the confirmed correctness bug (a) is the P1 target. Noted as follow-up.
+
+## Representation decisions (autonomous; from the understand-phase map)
+
+- **Dimension scores** stored internally as **ints 1/2/3** (Poor/OK/Good), not string
+  tokens — preserves `average_score`, the mean-based tier, and eval MAE math with minimal
+  churn. Prompt emits `POOR|OK|GOOD` tokens; `parse_quality_scores` maps tokens→ints (a
+  digit or unknown token is a parse failure — the old 1–5 clamp / `clamped_dimensions`
+  feature becomes obsolete). TUIs render ints→labels. `_DIMENSIONS` unchanged.
+- **Themes** stored as **`dict[str,str]`** mapping theme→`"present"`/`"emphasized"`,
+  Absent omitted. `parse_themes`, `StoryResult.themes`, `expected_themes`/
+  `predicted_themes`, the assessment JSONL, and the golden set all take this shape.
+  `from_dict` coerces a legacy `list[str]` → `{name: "present"}` so old files still load.
+  Daemon cross-story aggregation = max grade per theme (emphasized > present > absent).
+- **Gmail theme label** (owner decision: Emphasized-only) → the daemon applies
+  `agent/newsletter/theme/<name>` only for themes whose aggregated grade is `emphasized`.
+- **Report metrics**: LEFT AS-IS for the scheme switch and functions correctly — the
+  report reads the graded dicts as sets of theme *keys*, so its multilabel P/R/F1
+  measures **≥Present detection**, and dimension MAE/exact/within-1 still compute on the
+  1–3 scale. Two refinements are **deferred as follow-up** (not required for the switch;
+  the report is not broken): (a) collapse the theme metric at **positive = Emphasized**
+  to align the headline number with production labeling; (b) **drop within-1** (coarse on
+  a 3-point scale — MAE + exact-match suffice). Both are small, isolated report-only
+  changes.
+
+## #41 triage outcome (verified against HEAD)
+
+- **Item 2** (cursor-direct story-row selection) — **DONE**, close.
+- **Item 3** (newsletter-level `X` exclude) — **DONE** (commit c4e3487; roadmap omitted
+  this), close. It is the reference impl to mirror for #52.
+- **Item 7** (`is_available` returns a bare bool) — **PICK UP**, bundled with #30 (same
+  file, `llm_client.py`; both make LLM failures self-describing). Add status detail; gate
+  the preflight 404 hint on an actual 404.
+- **Item 1** ($EDITOR / sub-line spans) — **DEFER** (large; off the active path; prefer a
+  Textual `TextArea` modal if ever taken up).
+- **Item 4** (`q` quits app from detail) — **DEFER** (cross-TUI design opinion; Esc
+  already backs out; auto-save makes it lossless).
+- **Item 5** (unreviewed pollute extraction metrics) — **DEFER** (schema change on
+  `ExtractionPrediction`; mitigated by a stderr warning today; risks double-migration
+  amid the #53 golden-set churn — bundle with dedicated measurement work).
+- **Item 6** (`--verbose` in trend mode) — **DEFER** (lowest value; mitigated).
+
+Roadmap line 35 should be updated to acknowledge item 3 is done.
+
+## TUI tech-debt fold-ins (only while the file is already open)
+
+- **#50** `atomic_write_jsonl(records, path)` → `evals/__init__.py`; `review.save_golden_set`
+  and `newsletter_label.save_golden_set` become thin delegating wrappers (both names kept
+  so `from evals.review import save_golden_set` and test imports don't break). Fold in
+  during #52/#53.
+- **#49 `_truncate`** → `tui_common.truncate()` (edit_tui + newsletter_review copies are
+  byte-identical). Fold in during #52/#35/#36.
+- **#48 scroll base** (`ScrollableDetailScreen`) — only if it drops in cleanly with
+  **per-subclass BINDINGS** (Textual merges BINDINGS across the MRO; a shared base would
+  otherwise leak newsletter_review's `ctrl+b/ctrl+f` aliases into edit_tui). Otherwise skip.
+- **SKIP**: #49 `wrap_text` (divergent whitespace handling), #48 list-resize (divergent
+  bodies), #51 (idiom already unified in `tui_common`), #45 (single-file, `@work`-fragile,
+  concurrency-test-pinned).

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -29,7 +29,7 @@ Harvest always appends to `--output`, deduplicating by thread ID. There is no ov
 | `--filter-label` | Show only threads with this label |
 | `--start-at` | Start at thread index (0-based) |
 
-Review hotkeys: `p`/`s` sender (person/service); `r`/`f`/`l` label (needs_response/fyi/low_priority); `n` notes; `z` undo; `k` skip; `e` exclude; `q` quit. **Skip** (`k`) leaves the thread unreviewed so it reappears later. **Exclude** (`e`) sets `excluded=True` (also marks reviewed): excluded threads are dropped from the review queue here and from `run_eval` entirely. Un-exclude from the `--edit` TUI detail view with `e`. The `excluded` field is persisted in the golden set JSONL; legacy records using the old `skipped` key are still read as excluded.
+Review hotkeys: `p`/`s` sender (person/service); `r`/`f`/`l` label (needs_response/fyi/low_priority); `n` notes; `z` undo; `k` skip; `e` exclude; `q` quit. **Skip** (`k`) leaves the thread unreviewed so it reappears later. **Exclude** (`e`) sets `excluded=True` (also marks reviewed): excluded threads are dropped from the review queue here and from `run_eval` entirely. In the `--edit` TUI detail view, `e` is a symmetric **toggle** (exclude an included thread / un-exclude an excluded one; `reviewed` is left untouched). The `excluded` field is persisted in the golden set JSONL; legacy records using the old `skipped` key are still read as excluded.
 
 ### run_eval
 

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -219,9 +219,10 @@ duplicates — a delete leaves an id gap by design, so cross-run comparisons key
 on `story_id` stay valid.
 
 **Phase B** labels the selected story (`l`): the 4 dimensions (simple, concrete,
-personal, dynamic; `1`–`5`), multi-select themes, notes (`N`), undo (`z`);
-`expected_tier` is auto-derived via `compute_tier` on save and `story.reviewed`
-is set. Saves are atomic (temp-file + rename). `excluded` stories are kept as
+personal, dynamic) each graded Poor/OK/Good (keys `1`/`2`/`3`); themes graded
+Absent/Present/Emphasized (each key `s`/`c`/`h`/`v`/`d` cycles through the three);
+notes (`N`), undo (`z`); `expected_tier` is auto-derived via `compute_tier` (mean
+of the 1/2/3 dimension scores) on save and `story.reviewed` is set. Saves are atomic (temp-file + rename). `excluded` stories are kept as
 extraction truth but skipped from quality/theme scoring.
 
 A **whole newsletter** can be excluded with `X` in the detail view: it is

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -303,12 +303,15 @@ schema.
 Run output: the golden-set load prints a kept/unreviewed/excluded breakdown (with
 actionable hints when nothing is evaluable); `[k/N]` progress lines print during
 evaluation; the end-of-run summary line is
-`Rows: N (X errors, Y quality parse failures, Z theme parse failures)` plus
-optional clamped-score and dropped-theme-token lines; a
+`Rows: N (X errors, Y quality parse failures, Z theme parse failures, W theme
+near-misses)` plus optional `Unrecognized theme labels dropped by the parser:`
+and `Theme lines the parser skipped (near-misses):` detail lines; a
 `Chain-of-thought written to <path>.cot.jsonl` line appears when the sidecar is
 written; httpx request logging is quieted to WARNING. Missing/malformed config,
 `--prompts`, and golden-set files exit 1 with one-line errors, and preflight and
-per-row LLM errors name the resolved endpoint URL and its source env var.
+per-row LLM errors name the resolved endpoint URL and its source env var —
+preflight failures also append `probe()`'s captured detail (HTTP status or
+exception text, plus a model-mismatch hint on 404).
 
 ### newsletter_report
 
@@ -317,7 +320,7 @@ per-row LLM errors name the resolved endpoint URL and its source env var.
 | `--results` | Path to a single results JSONL file |
 | `--compare` | Two result file paths for side-by-side comparison. `.cot.jsonl` sidecars matched by a glob are ignored (with a stderr note), so `*<tag>*.jsonl` globs work |
 | `--results-dir` | Directory of results for trend view (`.cot.jsonl` sidecars skipped) |
-| `--verbose` | Show per-story flips and per-newsletter extraction diffs (no effect with `--results-dir`; a stderr note says so) |
+| `--verbose` | Show per-story disagreements/flips and, in single-run mode only, per-newsletter extraction diffs (no effect with `--results-dir`; a stderr note says so) |
 | `--format` | `table` (default) or `json`. JSON works in all three modes: single run (`{meta, metrics}`), `--compare` (`{"run_a": {meta, metrics}, "run_b": {...}}`), and `--results-dir` (array of summary rows: file, run_id, timestamp, mode, tag, prompt_hash, tier_accuracy, theme_micro_f1, mae_simple, extraction_micro_f1 — `null` for absent sections) |
 | `--match-threshold` | `SequenceMatcher` ratio threshold for the extraction one-to-one match (default: `0.6`). Applies to **text** similarity (see below) |
 
@@ -361,7 +364,8 @@ Metric semantics:
 Single-run report output: the header shows `Golden set:`; the tier section
 pluralizes correctly and lists `Failed stories (quality parse/network): <ids>`;
 the themes section shows a `Parse anomalies: N` line when theme responses
-contained invalid tokens or unparseable output; the extraction section shows
+contained invalid tokens, near-miss lines the parser skipped, or unparseable
+output; the extraction section shows
 `(<N> newsletters, <M> errors, match threshold <t>)` and renders even when every
 extraction call errored (count 0), listing the failed newsletters — extraction
 metrics carry `errors`/`error_threads` alongside the scored counts. Bad
@@ -369,15 +373,17 @@ metrics carry `errors`/`error_threads` alongside the scored counts. Bad
 any `OSError`) exit with a one-line error instead of a traceback.
 
 `--verbose` detail: per-story flips in `--compare` gate the tier diff on both
-runs having quality scores but compare theme sets whenever both rows' theme call
-succeeded — two `--mode themes` runs show their theme flips. Story
+runs having quality scores but compare theme grades (a present -> emphasized
+change counts as a flip) whenever both rows' theme call succeeded — two
+`--mode themes` runs show their theme flips. Story
 Disagreements lines append a story text excerpt (best-effort
 lookup from the run's recorded `golden_set_path`; degrades to bare ids if the
 file moved) and include stories whose quality parse failed but whose themes
 disagree; a `Parse/Network Failures` section prints each failed story with its
 raw quality response (`scores_raw`) or error; a `Theme Parse Anomalies` section
 prints `themes_raw` for stories whose theme output was invalid
-(`invalid tokens dropped: ...`) or unparseable (`parsed to []`); Extraction Diffs
+(`invalid tokens dropped: ...`), contained near-miss lines the parser skipped
+(`near-miss lines skipped: ...`), or was unparseable (`parsed to []`); Extraction Diffs
 honor `--match-threshold` (header says `threshold <t>`) and, for any newsletter
 that isn't a perfect match, list matched pairs with their `SequenceMatcher` ratio
 plus each unmatched predicted / unmatched golden story by a text excerpt.

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -322,9 +322,16 @@ per-row LLM errors name the resolved endpoint URL and its source env var.
 | `--match-threshold` | `SequenceMatcher` ratio threshold for the extraction one-to-one match (default: `0.6`). Applies to **text** similarity (see below) |
 
 Report computes tier accuracy + confusion matrix + P/R/F1 (excellent/good/fair/
-poor), per-dimension MAE and exact/within-1 agreement, per-theme + micro/macro
-multi-label F1 + exact-set-match, and extraction precision/recall/F1 from a greedy
-one-to-one `SequenceMatcher` match.
+poor), per-dimension MAE (0–2) and exact-match agreement (within-1 was dropped in
+the 3-value migration — degenerate on a 1–3 scale), theme multi-label metrics, and
+extraction precision/recall/F1 from a greedy one-to-one `SequenceMatcher` match.
+
+Theme metrics are computed at two thresholds (issue #53): the **primary**
+(`metrics["themes"]`) is **Emphasized-positive** — exactly what the daemon labels
+in Gmail, so it is production-aligned — reported as per-theme + micro/macro F1 +
+exact-set-match; a **secondary** detection metric (`metrics["themes_detection"]`,
+positive = Present-or-Emphasized) reports a single micro-F1 "did we notice the
+theme at all". `theme_micro_f1` in the trend view is the primary (Emphasized) one.
 
 Metric semantics:
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -136,9 +136,10 @@ Navigate to `http://localhost:5000`. Features:
 
 The daemon's newsletter pipeline (active under `NEWSLETTER_ONLY=1`) grades
 ministry-newsletter stories: it **extracts** stories from a body, **scores** each
-on 4 quality dimensions (simple/concrete/personal/dynamic, 1–5) → a **tier**
-(excellent/good/fair/poor), and tags **themes** (scripture/christlikeness/church/
-vocation-family/disciple-making). This harness measures whether that grading is any
+on 4 quality dimensions (simple/concrete/personal/dynamic) as **Poor/OK/Good** → a
+**tier** (excellent/good/fair/poor, from the averaged scores), and grades **themes**
+(scripture/christlikeness/church/vocation-family/disciple-making) as
+**Absent/Present/Emphasized**. This harness measures whether that grading is any
 good, so you can **iterate on the prompts** and see the effect of each change.
 
 It mirrors the email eval's 4 stages, with newsletter-specific modules prefixed

--- a/evals/README.md
+++ b/evals/README.md
@@ -237,8 +237,8 @@ The globs may also match each run's `.cot.jsonl` chain-of-thought sidecar —
 `--compare` ignores sidecars (with a stderr note), so this works as long as each
 glob matches exactly one real results file. The comparison renders
 tier/dimension/theme/extraction deltas and prints each run's `prompt_hash` + tag
-+ mode (warning when the modes differ); `--verbose` lists per-story flips and
-per-newsletter extraction diffs.
++ mode (warning when the modes differ); `--verbose` lists per-story flips
+(per-newsletter extraction diffs appear only in single-run `--results` reports).
 
 ## Typical Workflows
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -54,7 +54,7 @@ Interactive CLI for reviewing and correcting labels in the golden set. Saves ato
 **Setting an email aside.** Some threads aren't useful as test cases. Two options:
 
 - **Skip** (`k`) — render no judgment. The thread is left unreviewed and resurfaces in a later review session.
-- **Exclude** (`e`) — permanently set the thread aside. It is dropped from the review queue and never evaluated. Excluded threads are flagged with an `X` in the `--edit` list view; to bring one back, open `--edit`, select it, and press `e` to un-exclude.
+- **Exclude** (`e`) — permanently set the thread aside. It is dropped from the review queue and never evaluated. Excluded threads are flagged with an `X` in the `--edit` list view. In `--edit`, `e` is a **toggle**: press it on an included thread to exclude it, or on an excluded one to bring it back.
 
 Hotkeys: sender type `p`/`s` (person/service); label `r`/`f`/`l` (needs_response/fyi/low_priority); `n` notes; `z` undo; `k` skip; `e` exclude; `q` quit.
 
@@ -65,7 +65,7 @@ uv run python -m evals.review
 # Show existing labels while reviewing
 uv run python -m evals.review --show-labels
 
-# Textual TUI for editing reviewed threads (also where you un-exclude)
+# Textual TUI for editing reviewed threads (also where you toggle exclude/un-exclude)
 uv run python -m evals.review --edit
 
 # Review only sender classification (stage 1) or label classification (stage 2)

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,8 +1,35 @@
 """Classification evaluation suite for the email labeler."""
 
+import json
+import os
+import tempfile
+from pathlib import Path
+
 import httpx
 
 from proxy_client import ProxyAuthError, ProxyError, ProxyForbiddenError
+
+
+def atomic_write_jsonl(records, path) -> None:
+    """Write *records* to *path* as JSONL atomically (temp file + rename).
+
+    Each record must expose ``.to_dict()``. The temp file lives in the target's
+    directory so the rename is atomic on the same filesystem; on any error the
+    temp file is cleaned up and the original *path* is left untouched. Shared by
+    the golden-set editors (issue #50)."""
+    path = Path(path)
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".jsonl.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            for record in records:
+                f.write(json.dumps(record.to_dict()) + "\n")
+        os.rename(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def plural(n: int, singular: str, plural_form: str | None = None) -> str:

--- a/evals/edit_tui.py
+++ b/evals/edit_tui.py
@@ -20,6 +20,7 @@ from evals.review import _LABEL_KEY_MAP, _SENDER_KEY_MAP, save_golden_set
 from evals.schemas import GoldenThread
 from gmail_utils import decode_body
 from tui_common import CANCEL, HintScreen, KeyMenuScreen, PageListView
+from tui_common import truncate as _truncate
 
 # Abbreviation maps for compact list display
 _SENDER_ABBREV = {"person": "PER", "service": "SVC"}
@@ -36,13 +37,6 @@ _COL_GAP = 2      # space between columns
 # ---------------------------------------------------------------------------
 # Pure helpers
 # ---------------------------------------------------------------------------
-
-def _truncate(text: str, width: int) -> str:
-    """Truncate *text* to *width* chars, adding ``...`` if needed."""
-    if len(text) <= width:
-        return text
-    return text[: width - 3] + "..."
-
 
 def _format_list_row(thread: GoldenThread, max_x: int) -> str:
     """Format a single thread as one list-view line."""

--- a/evals/edit_tui.py
+++ b/evals/edit_tui.py
@@ -116,7 +116,7 @@ class DetailScreen(Screen):
         Binding("q", "quit_app", "Quit", show=False),
         Binding("s", "edit_sender", "Sender", show=False),
         Binding("l", "edit_label", "Label", show=False),
-        Binding("e", "unexclude", "Unexclude", show=False),
+        Binding("e", "toggle_excluded", "Toggle exclude", show=False),
         Binding("up", "scroll_up", "Scroll up", show=False),
         Binding("down", "scroll_down", "Scroll down", show=False),
         Binding("pageup", "page_up", "Page up", show=False),
@@ -156,8 +156,8 @@ class DetailScreen(Screen):
     def _refresh(self) -> None:
         lines = _build_detail_lines(self.thread, self.index, self.total)
         self.query_one("#detail-content", Static).update("\n".join(lines))
-        unexclude = "  [e]unexclude" if self.thread.excluded else ""
-        help_text = f"\u2191/\u2193:Scroll  [s]ender  [l]abel{unexclude}  Esc:Back  q:Quit"
+        excl = "[e]unexclude" if self.thread.excluded else "[e]exclude"
+        help_text = f"\u2191/\u2193:Scroll  [s]ender  [l]abel  {excl}  Esc:Back  q:Quit"
         self.query_one("#detail-help", Static).update(help_text)
         status = f"Sender: {self.thread.expected_sender_type}  Label: {self.thread.expected_label}"
         self.query_one("#detail-status", Static).update(status)
@@ -190,12 +190,13 @@ class DetailScreen(Screen):
 
         self.app.push_screen(KeyMenuScreen(_LABEL_PROMPT, _LABEL_KEY_MAP), apply)
 
-    def action_unexclude(self) -> None:
-        # Un-exclude only; excluding happens in the review loop.
-        if self.thread.excluded:
-            self.thread.excluded = False
-            self._auto_save()
-            self._refresh()
+    def action_toggle_excluded(self) -> None:
+        # Symmetric exclude/unexclude toggle (issue #52). `reviewed` is left
+        # untouched — excluded is orthogonal to reviewed, matching the newsletter
+        # labeler's toggle. Reversible by pressing `e` again.
+        self.thread.excluded = not self.thread.excluded
+        self._auto_save()
+        self._refresh()
 
     # -- navigation ----------------------------------------------------------
 

--- a/evals/llm_cache.py
+++ b/evals/llm_cache.py
@@ -155,6 +155,10 @@ class CachedLLMClient:
         """Delegate to inner client."""
         return await self.inner.is_available(timeout)
 
+    async def probe(self, timeout: float | None = None):
+        """Delegate to inner client (eval preflights probe the wrapped client)."""
+        return await self.inner.probe(timeout)
+
     def flush(self) -> None:
         """Append pending cache entries to disk."""
         if not self._pending:

--- a/evals/llm_cache.py
+++ b/evals/llm_cache.py
@@ -151,10 +151,6 @@ class CachedLLMClient:
         """
         return self._llm_seconds.pop(self._task_key(), 0.0)
 
-    async def is_available(self, timeout: float | None = None) -> bool:
-        """Delegate to inner client."""
-        return await self.inner.is_available(timeout)
-
     async def probe(self, timeout: float | None = None):
         """Delegate to inner client (eval preflights probe the wrapped client)."""
         return await self.inner.probe(timeout)

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -228,16 +228,13 @@ def confirm_story_list(newsletter):
 def assign_scores_and_themes(story, scores, themes):
     """Assign the 4 dimension scores + graded themes to a story and confirm it.
 
-    ``expected_tier`` is auto-derived from *scores* via ``compute_tier``; the
-    story is marked reviewed. *scores*/*themes* are copied so later mutation of
-    the caller's objects does not alias into the golden set. *themes* may be the
-    graded dict (theme -> "present"/"emphasized") produced by ThemeScreen, or a
-    legacy present-only list (coerced to grade "present"); issue #53.
+    *themes* is the graded dict (theme -> "present"/"emphasized") produced by
+    ThemeScreen. ``expected_tier`` is auto-derived from *scores* via
+    ``compute_tier``; the story is marked reviewed. *scores*/*themes* are copied
+    so later mutation of the caller's objects does not alias into the golden set.
     """
     story.expected_scores = dict(scores)
-    story.expected_themes = (
-        dict(themes) if isinstance(themes, dict) else {t: "present" for t in themes}
-    )
+    story.expected_themes = dict(themes)
     story.expected_tier = compute_tier(scores).value
     story.reviewed = True
 

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -37,9 +37,7 @@ import argparse
 import asyncio
 import copy
 import json
-import os
 import sys
-import tempfile
 import unicodedata
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -51,7 +49,7 @@ from textual.binding import Binding
 from textual.screen import Screen
 from textual.widgets import Label, ListItem, ListView, Static
 
-from evals import plural
+from evals import atomic_write_jsonl, plural
 from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
 from newsletter import compute_tier, parse_stories
 from tui_common import BottomModal, HintScreen, PageListView, PromptLineScreen
@@ -90,19 +88,7 @@ def load_golden_set(path: Path) -> list[GoldenNewsletter]:
 
 def save_golden_set(newsletters: list[GoldenNewsletter], path: Path) -> None:
     """Save the golden set atomically (temp file + rename)."""
-    path = Path(path)
-    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".jsonl.tmp")
-    try:
-        with os.fdopen(fd, "w") as f:
-            for nl in newsletters:
-                f.write(json.dumps(nl.to_dict()) + "\n")
-        os.rename(tmp_path, path)
-    except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
+    atomic_write_jsonl(newsletters, path)
 
 
 # ---------------------------------------------------------------------------

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -52,10 +52,17 @@ from textual.widgets import Label, ListItem, ListView, Static
 
 from evals import atomic_write_jsonl, plural
 from evals.newsletter_schemas import GoldenNewsletter, GoldenStory
-from newsletter import compute_tier, parse_stories
+from newsletter import _SCORE_TOKENS, compute_tier, parse_stories
 from tui_common import BottomModal, HintScreen, PageListView, PromptLineScreen
 
 _DIMENSIONS = ("simple", "concrete", "personal", "dynamic")
+
+# The score-entry prompt's rubric options, derived from newsletter._SCORE_TOKENS so
+# the 1/2/3 <-> POOR/OK/GOOD mapping lives in one place; renders "[1]poor [2]ok [3]good".
+_SCORE_OPTIONS = " ".join(
+    f"[{num}]{tok.lower()}"
+    for tok, num in sorted(_SCORE_TOKENS.items(), key=lambda kv: kv[1])
+)
 
 # Theme hotkeys mirror newsletter_review's convention (s/c/h/v/d).
 _THEME_KEYS = {
@@ -908,7 +915,7 @@ class ScoreScreen(BottomModal):
         now = f" (now {self._current[dim]})" if self._current and dim in self._current else ""
         entered = "/".join(str(self._scores[d]) for d in _DIMENSIONS if d in self._scores)
         so_far = f"[{entered}] " if entered else ""
-        return f"{so_far}{dim}{now} [1]poor [2]ok [3]good (other cancels): "
+        return f"{so_far}{dim}{now} {_SCORE_OPTIONS} (other cancels): "
 
     def compose(self) -> ComposeResult:
         yield Static(self._prompt_text(), id="score-prompt", markup=False)

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -25,7 +25,8 @@ Phase A — curate stories / extraction truth.
     A committed story's text is the verbatim inclusive body slice.
 
 Phase B — per-story labels: with a story selected, ``l`` assigns the 4 dimension
-scores (simple/concrete/personal/dynamic, 1-5) and multi-select themes; on save
+scores (simple/concrete/personal/dynamic) each graded Poor/OK/Good (keys 1/2/3)
+and graded themes (each key cycles Absent/Present/Emphasized); on save
 ``expected_tier`` is derived via ``newsletter.compute_tier``.
 
 The state transitions are factored into PURE functions (below) so they can be

--- a/evals/newsletter_label.py
+++ b/evals/newsletter_label.py
@@ -67,6 +67,11 @@ _THEME_KEYS = {
     "d": "disciple_making",
 }
 
+# Themes are graded (issue #53): each key cycles Absent -> Present -> Emphasized
+# -> Absent. Absent is represented by omission from the selected dict.
+_THEME_CYCLE = {None: "present", "present": "emphasized", "emphasized": None}
+_GRADE_ABBR = {"present": "P", "emphasized": "E"}
+
 
 # ---------------------------------------------------------------------------
 # Load / save (atomic temp-file + rename, mirroring evals.review)
@@ -234,14 +239,18 @@ def confirm_story_list(newsletter):
 # ---------------------------------------------------------------------------
 
 def assign_scores_and_themes(story, scores, themes):
-    """Assign the 4 dimension scores + themes to a story and confirm it.
+    """Assign the 4 dimension scores + graded themes to a story and confirm it.
 
     ``expected_tier`` is auto-derived from *scores* via ``compute_tier``; the
     story is marked reviewed. *scores*/*themes* are copied so later mutation of
-    the caller's objects does not alias into the golden set.
+    the caller's objects does not alias into the golden set. *themes* may be the
+    graded dict (theme -> "present"/"emphasized") produced by ThemeScreen, or a
+    legacy present-only list (coerced to grade "present"); issue #53.
     """
     story.expected_scores = dict(scores)
-    story.expected_themes = list(themes)
+    story.expected_themes = (
+        dict(themes) if isinstance(themes, dict) else {t: "present" for t in themes}
+    )
     story.expected_tier = compute_tier(scores).value
     story.reviewed = True
 
@@ -634,13 +643,18 @@ def format_story_strip(newsletter, spans, selected, width: int) -> list[str]:
 
 
 def format_theme_legend(selected, width: int) -> str:
-    """Theme-picker prompt line; falls back to a compact form on narrow screens."""
+    """Theme-picker prompt line; falls back to a compact form on narrow screens.
+
+    *selected* is the graded dict (theme -> "present"/"emphasized"); each theme
+    is shown with its grade abbreviation (P/E), and each key cycles A/P/E.
+    """
+    sel = ", ".join(f"{t}={_GRADE_ABBR[g]}" for t, g in sorted(selected.items())) or "-"
     full_legend = "  ".join(f"[{k}]{v}" for k, v in _THEME_KEYS.items())
-    full = f"Themes {sorted(selected)}: {full_legend}  Enter=done"
+    full = f"Themes {sel}: {full_legend}  (key cycles A/P/E)  Enter=done"
     if len(full) <= width:
         return full
     compact_legend = " ".join(f"[{k}]{v[:3]}" for k, v in _THEME_KEYS.items())
-    compact = f"Themes {','.join(selected) or '-'}: {compact_legend} Enter=done"
+    compact = f"Themes {sel}: {compact_legend} Enter=done"
     if len(compact) <= width:
         return compact
     return f"Themes({len(selected)}): {compact_legend} Enter=done"
@@ -893,10 +907,11 @@ class ConfirmScreen(BottomModal):
 
 
 class ScoreScreen(BottomModal):
-    """The 4 dimension scores, one keypress each; any non-1-5 key cancels all.
+    """The 4 dimension scores, one keypress each (1=Poor, 2=OK, 3=Good); any
+    other key cancels all (issue #53).
 
     When re-labeling, *current* shows the value already assigned per dimension;
-    accepted digits are echoed in the prompt so entry is verifiable.
+    accepted scores are echoed in the prompt so entry is verifiable.
     """
 
     def __init__(self, current=None) -> None:
@@ -909,7 +924,7 @@ class ScoreScreen(BottomModal):
         now = f" (now {self._current[dim]})" if self._current and dim in self._current else ""
         entered = "/".join(str(self._scores[d]) for d in _DIMENSIONS if d in self._scores)
         so_far = f"[{entered}] " if entered else ""
-        return f"{so_far}{dim}{now} [1-5] (other cancels): "
+        return f"{so_far}{dim}{now} [1]poor [2]ok [3]good (other cancels): "
 
     def compose(self) -> ComposeResult:
         yield Static(self._prompt_text(), id="score-prompt", markup=False)
@@ -918,7 +933,7 @@ class ScoreScreen(BottomModal):
         event.stop()
         if self._dismissed:
             return  # key queued behind the dismissal (auto-repeat)
-        if event.key not in ("1", "2", "3", "4", "5"):
+        if event.key not in ("1", "2", "3"):
             self.dismiss_once(None)
             return
         self._scores[_DIMENSIONS[len(self._scores)]] = int(event.key)
@@ -929,15 +944,16 @@ class ScoreScreen(BottomModal):
 
 
 class ThemeScreen(BottomModal):
-    """Multi-select themes by toggling s/c/h/v/d; Enter finishes (no cancel).
+    """Grade themes by cycling s/c/h/v/d through Absent -> Present -> Emphasized
+    -> Absent; Enter finishes (no cancel); issue #53.
 
-    Starts from *initial* (the story's current themes) so re-labeling edits
-    rather than restarts; toggles preserve insertion order.
+    Starts from *initial* (the story's current graded themes) so re-labeling
+    edits rather than restarts.
     """
 
     def __init__(self, initial=None) -> None:
         super().__init__()
-        self._selected: list[str] = list(initial or [])
+        self._selected: dict[str, str] = dict(initial or {})
 
     def _legend(self) -> str:
         return format_theme_legend(self._selected, max(10, self.app.size.width - 1))
@@ -950,14 +966,15 @@ class ThemeScreen(BottomModal):
         if self._dismissed:
             return  # key queued behind the dismissal (auto-repeat)
         if event.key == "enter":
-            self.dismiss_once(list(self._selected))
+            self.dismiss_once(dict(self._selected))
             return
         theme = _THEME_KEYS.get(event.key.lower())
         if theme is not None:
-            if theme in self._selected:
-                self._selected.remove(theme)
+            nxt = _THEME_CYCLE[self._selected.get(theme)]
+            if nxt is None:
+                self._selected.pop(theme, None)
             else:
-                self._selected.append(theme)
+                self._selected[theme] = nxt
             self.query_one("#theme-legend", Static).update(self._legend())
 
 

--- a/evals/newsletter_report.py
+++ b/evals/newsletter_report.py
@@ -236,6 +236,26 @@ def _theme_grade(themes_val, theme: str) -> str | None:
     return (themes_val or {}).get(theme)
 
 
+def _theme_grade_diffs(before, after) -> list[str]:
+    """Grade-aware per-theme diff lines between two theme dicts.
+
+    For each theme in the union of keys, a missing key reads as "absent"; when
+    the grade changed, emit ``"<theme>: <before>-><after>"`` (themes sorted).
+    Unchanged themes are omitted. Verbose disagreement/flip output uses this so a
+    grade-only change (e.g. present -> emphasized) — invisible to a key-set
+    compare but scored as an FP/FN by the Emphasized metric — is still shown.
+    """
+    before = before or {}
+    after = after or {}
+    parts: list[str] = []
+    for theme in sorted(set(before) | set(after)):
+        b = before.get(theme, "absent")
+        a = after.get(theme, "absent")
+        if b != a:
+            parts.append(f"{theme}: {b}->{a}")
+    return parts
+
+
 # What counts as a positive theme label for the multilabel metric (issue #53):
 _POSITIVE_TESTS = {
     "emphasized": lambda g: g == "emphasized",              # what earns a Gmail label
@@ -724,7 +744,7 @@ def _print_verbose_single(
             continue
         tier_diff = r.predicted_scores is not None and r.expected_tier != r.predicted_tier
         theme_diff = _theme_scored(r) and (
-            set(r.expected_themes or {}) != set(r.predicted_themes or {})
+            (r.expected_themes or {}) != (r.predicted_themes or {})
         )
         if tier_diff or theme_diff:
             disagreements.append((r, tier_diff, theme_diff))
@@ -735,8 +755,9 @@ def _print_verbose_single(
         if tier_diff:
             parts.append(f"tier={r.expected_tier}->{r.predicted_tier}")
         if theme_diff:
-            parts.append(f"themes={sorted(set(r.expected_themes or {}))}"
-                         f"->{sorted(set(r.predicted_themes or {}))}")
+            parts.append("themes: " + ", ".join(
+                _theme_grade_diffs(r.expected_themes, r.predicted_themes)
+            ))
         print(" ".join(parts))
 
     # "Never attempted" rows (e.g. --mode themes: no error, no scores_raw) are
@@ -846,11 +867,16 @@ def print_comparison(
         b_s = "N/A" if b is None else f"{b:.2f}"
         print("  " + format_table_row([dim, a_s, b_s, format_mae_delta(a, b)], widths))
 
-    # Themes
+    # Themes — primary Emphasized rows, then the secondary detection (>=Present)
+    # rows so a detection-level regression between runs is visible here too
+    # (print_report shows the detection line for each single run).
     tha, thb = metrics1["themes"], metrics2["themes"]
+    dta, dtb = metrics1["themes_detection"], metrics2["themes_detection"]
     header("Themes")
     pct_row("Micro-F1", tha["micro_f1"], thb["micro_f1"])
     pct_row("Macro-F1", tha["macro_f1"], thb["macro_f1"])
+    pct_row("Detection Micro-F1", dta["micro_f1"], dtb["micro_f1"])
+    pct_row("Detection Macro-F1", dta["macro_f1"], dtb["macro_f1"])
 
     # Extraction
     ea, eb = metrics1["extraction"], metrics2["extraction"]
@@ -891,9 +917,10 @@ def _print_verbose_compare(
                 parts.append(f"tier: {r1.predicted_tier}->{r2.predicted_tier} "
                              f"(expected {r1.expected_tier}){flag}")
         if _theme_scored(r1) and _theme_scored(r2):
-            s1, s2 = set(r1.predicted_themes or {}), set(r2.predicted_themes or {})
-            if s1 != s2:
-                parts.append(f"themes: {sorted(s1)}->{sorted(s2)}")
+            if (r1.predicted_themes or {}) != (r2.predicted_themes or {}):
+                parts.append("themes: " + ", ".join(
+                    _theme_grade_diffs(r1.predicted_themes, r2.predicted_themes)
+                ))
         if parts:
             flips.append((r1.story_id, parts))
     if not flips:

--- a/evals/newsletter_report.py
+++ b/evals/newsletter_report.py
@@ -232,10 +232,8 @@ def _theme_scored(r: StoryPrediction) -> bool:
 
 
 def _theme_grade(themes_val, theme: str) -> str | None:
-    """A theme's stored grade, tolerating the legacy present-only list form."""
-    if isinstance(themes_val, dict):
-        return themes_val.get(theme)
-    return "present" if theme in (themes_val or []) else None
+    """A theme's stored grade (theme -> "present"/"emphasized"), or None if absent."""
+    return (themes_val or {}).get(theme)
 
 
 # What counts as a positive theme label for the multilabel metric (issue #53):
@@ -726,7 +724,7 @@ def _print_verbose_single(
             continue
         tier_diff = r.predicted_scores is not None and r.expected_tier != r.predicted_tier
         theme_diff = _theme_scored(r) and (
-            set(r.expected_themes or []) != set(r.predicted_themes or [])
+            set(r.expected_themes or {}) != set(r.predicted_themes or {})
         )
         if tier_diff or theme_diff:
             disagreements.append((r, tier_diff, theme_diff))
@@ -737,8 +735,8 @@ def _print_verbose_single(
         if tier_diff:
             parts.append(f"tier={r.expected_tier}->{r.predicted_tier}")
         if theme_diff:
-            parts.append(f"themes={sorted(set(r.expected_themes or []))}"
-                         f"->{sorted(set(r.predicted_themes or []))}")
+            parts.append(f"themes={sorted(set(r.expected_themes or {}))}"
+                         f"->{sorted(set(r.predicted_themes or {}))}")
         print(" ".join(parts))
 
     # "Never attempted" rows (e.g. --mode themes: no error, no scores_raw) are
@@ -893,7 +891,7 @@ def _print_verbose_compare(
                 parts.append(f"tier: {r1.predicted_tier}->{r2.predicted_tier} "
                              f"(expected {r1.expected_tier}){flag}")
         if _theme_scored(r1) and _theme_scored(r2):
-            s1, s2 = set(r1.predicted_themes or []), set(r2.predicted_themes or [])
+            s1, s2 = set(r1.predicted_themes or {}), set(r2.predicted_themes or {})
             if s1 != s2:
                 parts.append(f"themes: {sorted(s1)}->{sorted(s2)}")
         if parts:

--- a/evals/newsletter_report.py
+++ b/evals/newsletter_report.py
@@ -29,7 +29,7 @@ from evals.report import (
     format_per_class_table,
     format_table_row,
 )
-from newsletter import _VALID_THEMES
+from newsletter import _VALID_THEMES, classify_theme_line
 
 TIERS = ["excellent", "good", "fair", "poor"]
 DIMENSIONS = ["simple", "concrete", "personal", "dynamic"]
@@ -471,21 +471,24 @@ def match_stories(
     return len(detail["matched"]), len(predicted), len(golden)
 
 
-_THEME_LINE_RE = re.compile(r"^\s*([A-Za-z_]+)\s*:\s*([A-Za-z]+)")
-_THEME_GRADE_TOKENS = {"ABSENT", "PRESENT", "EMPHASIZED"}
-
-
 def theme_parse_anomalies(results: list[StoryPrediction]) -> list[dict]:
-    """Detect theme responses that parse_themes silently normalized.
+    """Detect theme responses that parse_themes silently normalized or skipped.
 
-    Mirrors the current ``NAME: ABSENT|PRESENT|EMPHASIZED`` per-theme format
-    (issue #53) and its run-side twin ``newsletter_run._theme_line_anomalies``.
-    Two kinds:
+    Routes every line through the shared ``newsletter.classify_theme_line`` so
+    this report diagnostic and its run-side twin
+    (``newsletter_run._theme_line_anomalies``) share one source of the response
+    format and cannot drift (Finding 2). At most one anomaly per story; every
+    anomaly dict carries both an ``invalid_tokens`` and a ``near_miss_lines``
+    list. Kinds, by precedence:
 
     - "empty_parse": themes_raw is non-empty and not NONE, yet no line is a
       recognizable theme grading — the model emitted unusable prose.
     - "invalid_tokens": at least one line grades an off-taxonomy theme NAME
       (e.g. FELLOWSHIP) that parse_themes silently drops.
+    - "near_miss": the response otherwise parsed, but a non-blank line is not a
+      recognizable grading (hyphenated/spaced name, misspelled grade) and
+      parse_themes silently skipped it — a parser gap that would otherwise read
+      as a genuine model miss (Finding 3).
 
     An all-ABSENT response is a valid empty result, not an anomaly. Rows without
     themes_raw (legacy files, error rows) are skipped.
@@ -499,30 +502,32 @@ def theme_parse_anomalies(results: list[StoryPrediction]) -> list[dict]:
             continue
         graded_any = False
         invalid: list[str] = []
+        near_miss: list[str] = []
         for line in raw.splitlines():
-            match = _THEME_LINE_RE.match(line)
-            if not match:
+            kind, name, _grade = classify_theme_line(line)
+            if kind == "blank":
                 continue
-            name, grade = match.group(1).upper(), match.group(2).upper()
-            if grade not in _THEME_GRADE_TOKENS:
-                continue  # not a theme grading line
+            if kind == "anomalous":
+                near_miss.append(line.strip())
+                continue
             graded_any = True
-            if name not in _VALID_THEMES:
+            if kind == "off_taxonomy":
                 invalid.append(name)
         if not graded_any:
-            anomalies.append({
-                "story_id": r.story_id,
-                "kind": "empty_parse",
-                "invalid_tokens": invalid,
-                "themes_raw": r.themes_raw,
-            })
+            kind = "empty_parse"  # prose subsumes the near-miss lines
         elif invalid:
-            anomalies.append({
-                "story_id": r.story_id,
-                "kind": "invalid_tokens",
-                "invalid_tokens": invalid,
-                "themes_raw": r.themes_raw,
-            })
+            kind = "invalid_tokens"
+        elif near_miss:
+            kind = "near_miss"
+        else:
+            continue  # fully parsed — nothing dropped or skipped
+        anomalies.append({
+            "story_id": r.story_id,
+            "kind": kind,
+            "invalid_tokens": invalid,
+            "near_miss_lines": near_miss if graded_any else [],
+            "themes_raw": r.themes_raw,
+        })
     return anomalies
 
 
@@ -782,8 +787,17 @@ def _print_verbose_single(
     if anomalies:
         print("\n--- Theme Parse Anomalies ---")
         for a in anomalies:
-            what = ("unparseable output (parsed to [])" if a["kind"] == "empty_parse"
-                    else f"invalid tokens dropped: {', '.join(a['invalid_tokens'])}")
+            if a["kind"] == "empty_parse":
+                what = "unparseable output (parsed to [])"
+            else:
+                parts = []
+                if a["invalid_tokens"]:
+                    parts.append(f"invalid tokens dropped: {', '.join(a['invalid_tokens'])}")
+                if a.get("near_miss_lines"):
+                    parts.append(
+                        f"near-miss lines skipped: {', '.join(a['near_miss_lines'])}"
+                    )
+                what = "; ".join(parts)
             print(f"  {label(a['story_id'])}: {what}")
             raw = "\n".join(f"    | {ln}" for ln in a["themes_raw"].splitlines())
             print(raw)

--- a/evals/newsletter_report.py
+++ b/evals/newsletter_report.py
@@ -424,20 +424,25 @@ def match_stories(
     return len(detail["matched"]), len(predicted), len(golden)
 
 
+_THEME_LINE_RE = re.compile(r"^\s*([A-Za-z_]+)\s*:\s*([A-Za-z]+)")
+_THEME_GRADE_TOKENS = {"ABSENT", "PRESENT", "EMPHASIZED"}
+
+
 def theme_parse_anomalies(results: list[StoryPrediction]) -> list[dict]:
     """Detect theme responses that parse_themes silently normalized.
 
-    Two kinds, mirroring newsletter.parse_themes (one uppercase token per line,
-    unrecognized lines dropped, NONE -> []):
+    Mirrors the current ``NAME: ABSENT|PRESENT|EMPHASIZED`` per-theme format
+    (issue #53) and its run-side twin ``newsletter_run._theme_line_anomalies``.
+    Two kinds:
 
-    - "empty_parse": themes_raw is non-empty and not NONE, yet nothing parsed —
-      the model's output was unusable prose, not a genuine NONE.
-    - "invalid_tokens": some lines were not valid theme names and were silently
-      dropped (e.g. FELLOWSHIP) even though other lines parsed.
+    - "empty_parse": themes_raw is non-empty and not NONE, yet no line is a
+      recognizable theme grading — the model emitted unusable prose.
+    - "invalid_tokens": at least one line grades an off-taxonomy theme NAME
+      (e.g. FELLOWSHIP) that parse_themes silently drops.
 
-    Rows without themes_raw (legacy files, error rows) are skipped.
+    An all-ABSENT response is a valid empty result, not an anomaly. Rows without
+    themes_raw (legacy files, error rows) are skipped.
     """
-    valid_upper = _VALID_THEMES
     anomalies: list[dict] = []
     for r in results:
         if r.error is not None or r.themes_raw is None:
@@ -445,11 +450,19 @@ def theme_parse_anomalies(results: list[StoryPrediction]) -> list[dict]:
         raw = r.themes_raw.strip()
         if not raw or raw.upper() == "NONE":
             continue
-        invalid = [
-            line.strip() for line in raw.splitlines()
-            if line.strip() and line.strip().upper() not in valid_upper
-        ]
-        if not r.predicted_themes:
+        graded_any = False
+        invalid: list[str] = []
+        for line in raw.splitlines():
+            match = _THEME_LINE_RE.match(line)
+            if not match:
+                continue
+            name, grade = match.group(1).upper(), match.group(2).upper()
+            if grade not in _THEME_GRADE_TOKENS:
+                continue  # not a theme grading line
+            graded_any = True
+            if name not in _VALID_THEMES:
+                invalid.append(name)
+        if not graded_any:
             anomalies.append({
                 "story_id": r.story_id,
                 "kind": "empty_parse",

--- a/evals/newsletter_report.py
+++ b/evals/newsletter_report.py
@@ -79,9 +79,9 @@ def compute_dimension_exact_match(results: list[StoryPrediction]) -> dict[str, f
     return _dimension_mean(results, lambda e, p: e == p)
 
 
-def compute_dimension_within1(results: list[StoryPrediction]) -> dict[str, float]:
-    """Fraction of predictions within 1 point of expected per dimension."""
-    return _dimension_mean(results, lambda e, p: abs(e - p) <= 1)
+# NB: a "within-1" dimension metric was dropped in the 3-value migration (#53):
+# on a 1-3 scale the only pair NOT within 1 is a Poor<->Good confusion, so it was
+# ~always 1.0 and added no signal beyond MAE (now 0-2) + exact-match.
 
 
 def format_metric_delta(a: float | None, b: float | None) -> str:
@@ -122,8 +122,10 @@ def compute_all_metrics(
         "tier": compute_tier_metrics(story_results, mode),
         "dimension_mae": compute_dimension_mae(story_results),
         "dimension_exact": compute_dimension_exact_match(story_results),
-        "dimension_within1": compute_dimension_within1(story_results),
-        "themes": compute_multilabel_metrics(story_results, THEMES),
+        # Primary, production-aligned: only Emphasized earns a Gmail label (#53).
+        "themes": compute_multilabel_metrics(story_results, THEMES, positive="emphasized"),
+        # Secondary: whether the theme was detected at all (Present or Emphasized).
+        "themes_detection": compute_multilabel_metrics(story_results, THEMES, positive="detection"),
         "theme_anomalies": theme_parse_anomalies(story_results),
         "extraction": compute_extraction_metrics(
             extraction_results or [], threshold=match_threshold
@@ -229,19 +231,44 @@ def _theme_scored(r: StoryPrediction) -> bool:
     return r.themes_raw is not None or bool(r.predicted_themes)
 
 
+def _theme_grade(themes_val, theme: str) -> str | None:
+    """A theme's stored grade, tolerating the legacy present-only list form."""
+    if isinstance(themes_val, dict):
+        return themes_val.get(theme)
+    return "present" if theme in (themes_val or []) else None
+
+
+# What counts as a positive theme label for the multilabel metric (issue #53):
+_POSITIVE_TESTS = {
+    "emphasized": lambda g: g == "emphasized",              # what earns a Gmail label
+    "detection": lambda g: g in ("present", "emphasized"),  # theme present at all
+}
+
+
+def _positive_theme_set(themes_val, themes: list[str], is_pos) -> set[str]:
+    return {t for t in themes if is_pos(_theme_grade(themes_val, t))}
+
+
 def compute_multilabel_metrics(
     results: list[StoryPrediction],
     themes: list[str],
+    positive: str = "emphasized",
 ) -> dict:
-    """Multi-label theme metrics.
+    """Multi-label theme metrics at a chosen positive threshold (issue #53).
 
-    Each theme is an independent binary label (present/absent) derived from the
-    expected_themes vs predicted_themes sets. Rows whose own theme call failed
-    (see _theme_scored) are excluded; a quality-parse failure alone is not.
-    Returns per-theme P/R/F1, micro-F1, macro-F1, and exact-set-match (fraction
-    where set(expected) == set(predicted)). Aggregates are None when no rows
-    were scored, so empty sections render as N/A rather than a fake 0.0%.
+    *positive* selects what counts as a positive label per theme:
+    - ``"emphasized"`` (default, PRIMARY): only Emphasized — this is exactly what
+      the daemon labels in Gmail, so it is the production-aligned headline metric.
+    - ``"detection"``: Present OR Emphasized — a secondary "did we notice the
+      theme at all" signal.
+
+    Rows whose own theme call failed (see _theme_scored) are excluded; a
+    quality-parse failure alone is not. Returns per-theme P/R/F1, micro-F1,
+    macro-F1, and exact-set-match (fraction where the positive expected set ==
+    the positive predicted set). Aggregates are None when no rows were scored, so
+    empty sections render as N/A rather than a fake 0.0%.
     """
+    is_pos = _POSITIVE_TESTS[positive]
     scored = [r for r in results if _theme_scored(r)]
 
     if not scored:
@@ -262,8 +289,8 @@ def compute_multilabel_metrics(
     for theme in themes:
         tp = fp = fn = 0
         for r in scored:
-            exp = theme in set(r.expected_themes or [])
-            pred = theme in set(r.predicted_themes or [])
+            exp = is_pos(_theme_grade(r.expected_themes, theme))
+            pred = is_pos(_theme_grade(r.predicted_themes, theme))
             if exp and pred:
                 tp += 1
             elif pred and not exp:
@@ -286,7 +313,9 @@ def compute_multilabel_metrics(
     macro_f1 = sum(per_theme[t]["f1"] for t in themes) / len(themes) if themes else 0.0
 
     exact = sum(
-        1 for r in scored if set(r.expected_themes or []) == set(r.predicted_themes or [])
+        1 for r in scored
+        if _positive_theme_set(r.expected_themes, themes, is_pos)
+        == _positive_theme_set(r.predicted_themes, themes, is_pos)
     )
     exact_set_match = exact / len(scored) if scored else None
 
@@ -544,17 +573,16 @@ def load_story_excerpts(golden_set_path: str) -> dict[str, str]:
 def _format_dim_table(
     mae: dict[str, float | None],
     exact: dict[str, float | None],
-    within1: dict[str, float | None],
 ) -> str:
-    widths = [max(len("Dimension"), *(len(d) for d in DIMENSIONS)), 10, 12, 12]
+    widths = [max(len("Dimension"), *(len(d) for d in DIMENSIONS)), 10, 12]
     lines = []
-    lines.append("  " + format_table_row(["Dimension", "MAE", "Exact", "Within-1"], widths))
+    lines.append("  " + format_table_row(["Dimension", "MAE", "Exact"], widths))
     lines.append("  " + "-" * sum(w + 2 for w in widths))
     for dim in DIMENSIONS:
         m = mae.get(dim)
         mae_s = "N/A" if m is None else f"{m:.2f}"
         lines.append("  " + format_table_row(
-            [dim, mae_s, format_pct(exact.get(dim)), format_pct(within1.get(dim))],
+            [dim, mae_s, format_pct(exact.get(dim))],
             widths,
         ))
     return "\n".join(lines)
@@ -625,14 +653,16 @@ def print_report(
         print("\n--- Quality Dimensions ---")
         print(_format_dim_table(
             metrics["dimension_mae"], metrics["dimension_exact"],
-            metrics["dimension_within1"],
         ))
 
         themes = metrics["themes"]
-        print("\n--- Themes (multi-label) ---")
+        print("\n--- Themes (Emphasized — what gets labeled) ---")
         print(f"  Micro-F1: {format_pct(themes['micro_f1'])}   "
               f"Macro-F1: {format_pct(themes['macro_f1'])}   "
               f"Exact-set match: {format_pct(themes['exact_set_match'])}")
+        detection = metrics.get("themes_detection")
+        if detection:
+            print(f"  Detection (≥Present) Micro-F1: {format_pct(detection['micro_f1'])}")
         anomalies = metrics.get("theme_anomalies", [])
         if anomalies:
             print(f"  Parse anomalies: {plural(len(anomalies), 'story', 'stories')} "

--- a/evals/newsletter_run.py
+++ b/evals/newsletter_run.py
@@ -18,7 +18,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import sys
 import time
 import tomllib
@@ -41,7 +40,7 @@ from evals.newsletter_schemas import (
     StoryPrediction,
 )
 from llm_client import LLMClient
-from newsletter import _VALID_THEMES, NewsletterClassifier, compute_tier
+from newsletter import NewsletterClassifier, classify_theme_line, compute_tier
 
 
 def load_golden_set(
@@ -480,38 +479,40 @@ def write_thinking_sidecar(
     return sidecar_path
 
 
-_THEME_LINE_RE = re.compile(r"^\s*([A-Za-z_]+)\s*:\s*([A-Za-z]+)")
-
-
-def _theme_line_anomalies(themes_raw: str) -> tuple[bool, list[str]]:
+def _theme_line_anomalies(themes_raw: str) -> tuple[bool, list[str], list[str]]:
     """Classify a raw theme response for the run summary (issue #53 format).
 
-    Each theme line is ``NAME: ABSENT|PRESENT|EMPHASIZED``. Returns
-    ``(is_garbage, dropped_name_tokens)`` where *is_garbage* is True when the
-    response is neither NONE nor contains any recognizable theme grading (prose
-    masquerading as a confident answer), and *dropped_name_tokens* lists any
-    off-taxonomy theme names the parser silently ignored. An all-ABSENT response
-    is a valid empty result, not garbage.
+    Routes every line through the shared ``newsletter.classify_theme_line`` so
+    this diagnostic and the production parser cannot drift (Finding 2). Returns
+    ``(is_garbage, dropped_name_tokens, near_miss_lines)``:
+
+    - *is_garbage* — the response is neither NONE nor contains any recognizable
+      theme grading (prose masquerading as a confident answer). An all-ABSENT
+      response is a valid empty result, not garbage.
+    - *dropped_name_tokens* — off-taxonomy theme names the parser silently ignored.
+    - *near_miss_lines* — non-blank lines that are not a recognizable grading and
+      parse_themes silently skipped (a hyphenated/spaced name or a misspelled
+      grade that reads as a missed prediction). Surfacing them keeps a systematic
+      parser gap from masquerading as a genuine model miss (Finding 3).
     """
     stripped = themes_raw.strip()
     if not stripped or stripped.upper() == "NONE":
-        return False, []
+        return False, [], []
 
-    valid_grades = {"ABSENT", "PRESENT", "EMPHASIZED"}
     graded_any = False
     dropped: list[str] = []
+    near_miss: list[str] = []
     for line in stripped.splitlines():
-        match = _THEME_LINE_RE.match(line)
-        if not match:
+        kind, name, _grade = classify_theme_line(line)
+        if kind == "blank":
             continue
-        name, grade = match.group(1).upper(), match.group(2).upper()
-        if grade not in valid_grades:
-            continue  # not a theme grading line
-        graded_any = True
-        if name not in _VALID_THEMES:
+        if kind == "anomalous":
+            near_miss.append(line.strip())
+            continue
+        graded_any = True  # "theme" or "off_taxonomy" is a recognizable grading
+        if kind == "off_taxonomy":
             dropped.append(name)
-    is_garbage = not graded_any
-    return is_garbage, dropped
+    return not graded_any, dropped, near_miss
 
 
 def summarize_rows(rows: list) -> dict:
@@ -524,6 +525,9 @@ def summarize_rows(rows: list) -> dict:
       garbage output masquerading as a confident "no themes"
     - dropped_theme_tokens: {token: count} of off-taxonomy theme names parse_themes
       silently dropped from otherwise-parsed responses
+    - theme_near_miss_lines: {line: count} of non-blank lines parse_themes silently
+      skipped (hyphenated/spaced name, misspelled grade) in an otherwise-parsed
+      response — a parser gap that would otherwise read as a model miss (Finding 3)
     """
     counts = {
         "rows": len(rows),
@@ -531,6 +535,7 @@ def summarize_rows(rows: list) -> dict:
         "quality_parse_failures": 0,
         "theme_parse_failures": 0,
         "dropped_theme_tokens": {},
+        "theme_near_miss_lines": {},
     }
     for r in rows:
         if getattr(r, "error", None):
@@ -541,9 +546,17 @@ def summarize_rows(rows: list) -> dict:
             counts["quality_parse_failures"] += 1
         themes_raw = getattr(r, "themes_raw", None)
         if themes_raw is not None:
-            is_garbage, dropped = _theme_line_anomalies(themes_raw)
+            is_garbage, dropped, near_miss = _theme_line_anomalies(themes_raw)
             if is_garbage:
                 counts["theme_parse_failures"] += 1
+            else:
+                # A garbage response is already counted above and its lines are
+                # the prose; only tally near-misses when the response otherwise
+                # parsed, so the near-miss signal isn't double-reported.
+                for line in near_miss:
+                    counts["theme_near_miss_lines"][line] = (
+                        counts["theme_near_miss_lines"].get(line, 0) + 1
+                    )
             for token in dropped:
                 counts["dropped_theme_tokens"][token] = (
                     counts["dropped_theme_tokens"].get(token, 0) + 1
@@ -579,6 +592,7 @@ def format_run_summary(rows: list) -> str:
     --report or grepping the results JSONL.
     """
     counts = summarize_rows(rows)
+    near_miss_total = sum(counts["theme_near_miss_lines"].values())
     problems = []
     if counts["errors"]:
         problems.append(plural(counts["errors"], "error"))
@@ -586,12 +600,20 @@ def format_run_summary(rows: list) -> str:
         problems.append(plural(counts["quality_parse_failures"], "quality parse failure"))
     if counts["theme_parse_failures"]:
         problems.append(plural(counts["theme_parse_failures"], "theme parse failure"))
+    if near_miss_total:
+        problems.append(plural(near_miss_total, "theme near-miss", "theme near-misses"))
     lines = [f"  Rows: {counts['rows']} ({', '.join(problems) if problems else 'no errors'})"]
     if counts["dropped_theme_tokens"]:
         detail = ", ".join(
             f"{tok} x{n}" for tok, n in sorted(counts["dropped_theme_tokens"].items())
         )
         lines.append(f"  Unrecognized theme labels dropped by the parser: {detail}")
+    if counts["theme_near_miss_lines"]:
+        detail = ", ".join(
+            f'"{line}" x{n}'
+            for line, n in sorted(counts["theme_near_miss_lines"].items())
+        )
+        lines.append(f"  Theme lines the parser skipped (near-misses): {detail}")
     return "\n".join(lines)
 
 

--- a/evals/newsletter_run.py
+++ b/evals/newsletter_run.py
@@ -778,15 +778,16 @@ async def main(args: argparse.Namespace) -> None:
         result = await llm.probe()
         if not result.ok:
             base = config["newsletter"]["llm"]
-            # Show the model-mismatch hint only on an actual 404 (issue #41 item 7).
-            hint = (
-                "\nAn HTTP 404 usually means the model name does not match the served model."
-                if result.status_code == 404 else ""
-            )
+            # Surface probe()'s captured diagnosis (HTTP status / exception text /
+            # 404 model-mismatch hint) instead of discarding it (Finding 1). All
+            # wording lives on AvailabilityResult.detail() so this and run_eval's
+            # preflight can't drift (Finding 2).
+            detail = result.detail()
+            detail_part = f"\n{detail}" if detail else ""
             print(
                 f"Error: newsletter LLM '{base['model']}' not reachable at "
                 f"{describe_endpoint()}.\n"
-                "Check that the endpoint is up." + hint,
+                "Check that the endpoint is up." + detail_part,
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/evals/newsletter_run.py
+++ b/evals/newsletter_run.py
@@ -753,13 +753,18 @@ async def main(args: argparse.Namespace) -> None:
     # Preflight: probe the newsletter endpoint once and fail fast on an
     # unreachable / name-mismatched one (skippable via --skip-preflight).
     if not args.skip_preflight:
-        if not await llm.is_available():
+        result = await llm.probe()
+        if not result.ok:
             base = config["newsletter"]["llm"]
+            # Show the model-mismatch hint only on an actual 404 (issue #41 item 7).
+            hint = (
+                "\nAn HTTP 404 usually means the model name does not match the served model."
+                if result.status_code == 404 else ""
+            )
             print(
                 f"Error: newsletter LLM '{base['model']}' not reachable at "
                 f"{describe_endpoint()}.\n"
-                "Check that the endpoint is up; a 404 can also mean the model "
-                "name does not match the served model.",
+                "Check that the endpoint is up." + hint,
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/evals/newsletter_run.py
+++ b/evals/newsletter_run.py
@@ -241,7 +241,7 @@ async def evaluate_story(
         thread_id=thread_id,
         expected_scores=story.expected_scores,
         expected_tier=story.expected_tier,
-        expected_themes=list(story.expected_themes),
+        expected_themes=dict(story.expected_themes),
     )
     thinking = NewsletterThinkingEntry(story_id=story.story_id)
 
@@ -480,19 +480,38 @@ def write_thinking_sidecar(
     return sidecar_path
 
 
-def clamped_dimensions(scores_raw: str) -> list[str]:
-    """Dimensions whose raw model score was outside 1-5 (silently clamped).
+_THEME_LINE_RE = re.compile(r"^\s*([A-Za-z_]+)\s*:\s*([A-Za-z]+)")
 
-    Re-reads the raw quality response with parse_quality_scores' own pattern:
-    an out-of-range score is strong evidence the model misread the rubric, so
-    the run summary must surface it rather than leave it buried in scores_raw.
+
+def _theme_line_anomalies(themes_raw: str) -> tuple[bool, list[str]]:
+    """Classify a raw theme response for the run summary (issue #53 format).
+
+    Each theme line is ``NAME: ABSENT|PRESENT|EMPHASIZED``. Returns
+    ``(is_garbage, dropped_name_tokens)`` where *is_garbage* is True when the
+    response is neither NONE nor contains any recognizable theme grading (prose
+    masquerading as a confident answer), and *dropped_name_tokens* lists any
+    off-taxonomy theme names the parser silently ignored. An all-ABSENT response
+    is a valid empty result, not garbage.
     """
-    clamped = []
-    for dim in ("simple", "concrete", "personal", "dynamic"):
-        match = re.search(rf"{dim.upper()}\s*:\s*(\d+)", scores_raw, flags=re.IGNORECASE)
-        if match and not 1 <= int(match.group(1)) <= 5:
-            clamped.append(dim.upper())
-    return clamped
+    stripped = themes_raw.strip()
+    if not stripped or stripped.upper() == "NONE":
+        return False, []
+
+    valid_grades = {"ABSENT", "PRESENT", "EMPHASIZED"}
+    graded_any = False
+    dropped: list[str] = []
+    for line in stripped.splitlines():
+        match = _THEME_LINE_RE.match(line)
+        if not match:
+            continue
+        name, grade = match.group(1).upper(), match.group(2).upper()
+        if grade not in valid_grades:
+            continue  # not a theme grading line
+        graded_any = True
+        if name not in _VALID_THEMES:
+            dropped.append(name)
+    is_garbage = not graded_any
+    return is_garbage, dropped
 
 
 def summarize_rows(rows: list) -> dict:
@@ -503,8 +522,7 @@ def summarize_rows(rows: list) -> dict:
       parse_quality_scores returned None
     - theme_parse_failures: theme response was neither NONE nor parseable —
       garbage output masquerading as a confident "no themes"
-    - clamped: {story_id: [DIMS]} where raw scores were out of 1-5
-    - dropped_theme_tokens: {token: count} of off-taxonomy labels parse_themes
+    - dropped_theme_tokens: {token: count} of off-taxonomy theme names parse_themes
       silently dropped from otherwise-parsed responses
     """
     counts = {
@@ -512,7 +530,6 @@ def summarize_rows(rows: list) -> dict:
         "errors": 0,
         "quality_parse_failures": 0,
         "theme_parse_failures": 0,
-        "clamped": {},
         "dropped_theme_tokens": {},
     }
     for r in rows:
@@ -520,28 +537,17 @@ def summarize_rows(rows: list) -> dict:
             counts["errors"] += 1
             continue
         scores_raw = getattr(r, "scores_raw", None)
-        if scores_raw is not None:
-            if getattr(r, "predicted_scores", None) is None:
-                counts["quality_parse_failures"] += 1
-            else:
-                dims = clamped_dimensions(scores_raw)
-                if dims:
-                    counts["clamped"][r.story_id] = dims
+        if scores_raw is not None and getattr(r, "predicted_scores", None) is None:
+            counts["quality_parse_failures"] += 1
         themes_raw = getattr(r, "themes_raw", None)
         if themes_raw is not None:
-            stripped = themes_raw.strip()
-            if stripped and stripped.upper() != "NONE":
-                invalid = [
-                    line.strip() for line in stripped.splitlines()
-                    if line.strip() and line.strip().upper() not in _VALID_THEMES
-                ]
-                if not r.predicted_themes:
-                    counts["theme_parse_failures"] += 1
-                elif invalid:
-                    for token in invalid:
-                        counts["dropped_theme_tokens"][token] = (
-                            counts["dropped_theme_tokens"].get(token, 0) + 1
-                        )
+            is_garbage, dropped = _theme_line_anomalies(themes_raw)
+            if is_garbage:
+                counts["theme_parse_failures"] += 1
+            for token in dropped:
+                counts["dropped_theme_tokens"][token] = (
+                    counts["dropped_theme_tokens"].get(token, 0) + 1
+                )
     return counts
 
 
@@ -581,14 +587,6 @@ def format_run_summary(rows: list) -> str:
     if counts["theme_parse_failures"]:
         problems.append(plural(counts["theme_parse_failures"], "theme parse failure"))
     lines = [f"  Rows: {counts['rows']} ({', '.join(problems) if problems else 'no errors'})"]
-    if counts["clamped"]:
-        detail = "; ".join(
-            f"{sid}: {', '.join(dims)}" for sid, dims in counts["clamped"].items()
-        )
-        lines.append(
-            f"  Out-of-range scores clamped to 1-5 in "
-            f"{plural(len(counts['clamped']), 'story', 'stories')} ({detail})"
-        )
     if counts["dropped_theme_tokens"]:
         detail = ", ".join(
             f"{tok} x{n}" for tok, n in sorted(counts["dropped_theme_tokens"].items())

--- a/evals/newsletter_schemas.py
+++ b/evals/newsletter_schemas.py
@@ -8,15 +8,28 @@ older golden sets and result files keep loading as the schema grows.
 from dataclasses import dataclass, field
 
 
+def _coerce_themes(value) -> dict[str, str]:
+    """Normalize a stored themes value to a grade dict (issue #53).
+
+    Accepts the current dict form (theme -> "present"/"emphasized"), a legacy
+    present-only ``list[str]`` (each coerced to grade "present"), or None/empty.
+    """
+    if not value:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    return {name: "present" for name in value}
+
+
 @dataclass
 class GoldenStory:
     """One story within a golden newsletter (ground truth)."""
 
     story_id: str  # stable, f"{thread_id}:{index}"
     text: str
-    expected_scores: dict[str, int] | None = None  # simple/concrete/personal/dynamic, 1-5
+    expected_scores: dict[str, int] | None = None  # simple/concrete/personal/dynamic, 1-3 (Poor/OK/Good)
     expected_tier: str | None = None  # "excellent" / "good" / "fair" / "poor"
-    expected_themes: list[str] = field(default_factory=list)  # lowercase theme names
+    expected_themes: dict[str, str] = field(default_factory=dict)  # theme -> "present"/"emphasized"
     reviewed: bool = False
     notes: str = ""
     excluded: bool = False  # drop from quality/theme scoring, keep as extraction truth
@@ -42,7 +55,7 @@ class GoldenStory:
             text=d["text"],
             expected_scores=d.get("expected_scores"),
             expected_tier=d.get("expected_tier"),
-            expected_themes=d.get("expected_themes", []),
+            expected_themes=_coerce_themes(d.get("expected_themes")),
             reviewed=d.get("reviewed", False),
             notes=d.get("notes", ""),
             excluded=d.get("excluded", False),
@@ -109,10 +122,10 @@ class StoryPrediction:
     thread_id: str
     expected_scores: dict[str, int] | None = None
     expected_tier: str | None = None
-    expected_themes: list[str] = field(default_factory=list)
+    expected_themes: dict[str, str] = field(default_factory=dict)
     predicted_scores: dict[str, int] | None = None
     predicted_tier: str | None = None
-    predicted_themes: list[str] = field(default_factory=list)
+    predicted_themes: dict[str, str] = field(default_factory=dict)
     scores_raw: str | None = None
     themes_raw: str | None = None
     duration_seconds: float = 0.0
@@ -142,10 +155,10 @@ class StoryPrediction:
             thread_id=d["thread_id"],
             expected_scores=d.get("expected_scores"),
             expected_tier=d.get("expected_tier"),
-            expected_themes=d.get("expected_themes", []),
+            expected_themes=_coerce_themes(d.get("expected_themes")),
             predicted_scores=d.get("predicted_scores"),
             predicted_tier=d.get("predicted_tier"),
-            predicted_themes=d.get("predicted_themes", []),
+            predicted_themes=_coerce_themes(d.get("predicted_themes")),
             scores_raw=d.get("scores_raw"),
             themes_raw=d.get("themes_raw"),
             duration_seconds=d.get("duration_seconds", 0.0),

--- a/evals/newsletter_schemas.py
+++ b/evals/newsletter_schemas.py
@@ -9,16 +9,9 @@ from dataclasses import dataclass, field
 
 
 def _coerce_themes(value) -> dict[str, str]:
-    """Normalize a stored themes value to a grade dict (issue #53).
-
-    Accepts the current dict form (theme -> "present"/"emphasized"), a legacy
-    present-only ``list[str]`` (each coerced to grade "present"), or None/empty.
-    """
-    if not value:
-        return {}
-    if isinstance(value, dict):
-        return dict(value)
-    return {name: "present" for name in value}
+    """Normalize a stored themes value to a grade dict (theme -> "present"/
+    "emphasized"), defaulting a missing/empty value to ``{}`` (issue #53)."""
+    return dict(value) if value else {}
 
 
 @dataclass

--- a/evals/newsletter_schemas.py
+++ b/evals/newsletter_schemas.py
@@ -7,11 +7,75 @@ older golden sets and result files keep loading as the schema grows.
 
 from dataclasses import dataclass, field
 
+# Grades that ever appear in a stored theme dict. Kept in lockstep with
+# newsletter.parse_themes (which only stores present/emphasized; absent is
+# omitted) and evals.newsletter_label._THEME_CYCLE / _GRADE_ABBR (which only
+# cycle through / abbreviate exactly these). "absent" and case variants are
+# NOT valid stored grades.
+_VALID_THEME_GRADES = frozenset({"present", "emphasized"})
 
-def _coerce_themes(value) -> dict[str, str]:
+# Valid dimension scores after the 1-3 (Poor/OK/Good) migration; legacy 1-5
+# exports are out of range and must be re-migrated (issue #53).
+_VALID_SCORES = frozenset({1, 2, 3})
+
+
+def _coerce_themes(value, *, story_id: str = "", field_name: str = "themes") -> dict[str, str]:
     """Normalize a stored themes value to a grade dict (theme -> "present"/
-    "emphasized"), defaulting a missing/empty value to ``{}`` (issue #53)."""
-    return dict(value) if value else {}
+    "emphasized"), defaulting a missing/empty value to ``{}`` (issue #53).
+
+    Backward compatibility with the pre-#53 schema was deliberately removed, so
+    this raises a clear, actionable ValueError (rather than silently coercing or
+    dying with an opaque dict-update error) when it meets old-scheme data:
+
+    * ``value`` is a list — the pre-migration theme scheme stored themes as a
+      list of names; the file must be re-migrated to the theme->grade dict
+      scheme (Finding 1).
+    * a grade is anything other than exactly "present"/"emphasized" — a case
+      variant, "absent", or junk would later KeyError the labeling TUI mid
+      session (Finding 2).
+
+    ``story_id``/``field_name`` are woven into the message so the offending
+    record and field are locatable.
+    """
+    where = f"{field_name} for story {story_id!r}" if story_id else field_name
+    if isinstance(value, list):
+        raise ValueError(
+            f"{where} is an old-scheme list {value!r}; this file predates the "
+            "theme-dict migration (issue #53) and must be re-migrated to the new "
+            "theme->grade dict scheme (theme -> 'present'/'emphasized')."
+        )
+    if not value:
+        return {}
+    coerced = dict(value)
+    for theme, grade in coerced.items():
+        if grade not in _VALID_THEME_GRADES:
+            raise ValueError(
+                f"{where}: theme {theme!r} has invalid grade {grade!r}; expected "
+                "exactly 'present' or 'emphasized' ('absent' is represented by "
+                "omitting the theme). Re-migrate this file to the new theme-grade "
+                "scheme (issue #53)."
+            )
+    return coerced
+
+
+def _coerce_scores(value, *, story_id: str = "", field_name: str = "scores"):
+    """Validate a stored dimension-score dict: every value must be an int in
+    1..3 (Poor/OK/Good) after the #53 migration. A missing/None value is passed
+    through unchanged (unlabeled). Legacy 1-5 scores are rejected loudly at load
+    rather than silently corrupting report metrics / the labeling TUI (Finding
+    3). ``story_id``/``field_name`` locate the offending record and field."""
+    if value is None:
+        return None
+    where = f"{field_name} for story {story_id!r}" if story_id else field_name
+    for dimension, score in value.items():
+        if isinstance(score, bool) or not isinstance(score, int) or score not in _VALID_SCORES:
+            raise ValueError(
+                f"{where}: dimension {dimension!r} has invalid value {score!r}; "
+                "expected an int in 1..3 (Poor/OK/Good). This file may be an "
+                "old-scheme (1-5) export needing re-migration to the 1-3 scale "
+                "(issue #53)."
+            )
+    return value
 
 
 @dataclass
@@ -43,12 +107,17 @@ class GoldenStory:
     def from_dict(cls, d: dict) -> "GoldenStory":
         # ``title`` was dropped from the schema; older golden sets that still
         # carry it load fine because the extra key is simply ignored here.
+        sid = d.get("story_id", "")
         return cls(
             story_id=d["story_id"],
             text=d["text"],
-            expected_scores=d.get("expected_scores"),
+            expected_scores=_coerce_scores(
+                d.get("expected_scores"), story_id=sid, field_name="expected_scores"
+            ),
             expected_tier=d.get("expected_tier"),
-            expected_themes=_coerce_themes(d.get("expected_themes")),
+            expected_themes=_coerce_themes(
+                d.get("expected_themes"), story_id=sid, field_name="expected_themes"
+            ),
             reviewed=d.get("reviewed", False),
             notes=d.get("notes", ""),
             excluded=d.get("excluded", False),
@@ -143,15 +212,24 @@ class StoryPrediction:
 
     @classmethod
     def from_dict(cls, d: dict) -> "StoryPrediction":
+        sid = d.get("story_id", "")
         return cls(
             story_id=d["story_id"],
             thread_id=d["thread_id"],
-            expected_scores=d.get("expected_scores"),
+            expected_scores=_coerce_scores(
+                d.get("expected_scores"), story_id=sid, field_name="expected_scores"
+            ),
             expected_tier=d.get("expected_tier"),
-            expected_themes=_coerce_themes(d.get("expected_themes")),
-            predicted_scores=d.get("predicted_scores"),
+            expected_themes=_coerce_themes(
+                d.get("expected_themes"), story_id=sid, field_name="expected_themes"
+            ),
+            predicted_scores=_coerce_scores(
+                d.get("predicted_scores"), story_id=sid, field_name="predicted_scores"
+            ),
             predicted_tier=d.get("predicted_tier"),
-            predicted_themes=_coerce_themes(d.get("predicted_themes")),
+            predicted_themes=_coerce_themes(
+                d.get("predicted_themes"), story_id=sid, field_name="predicted_themes"
+            ),
             scores_raw=d.get("scores_raw"),
             themes_raw=d.get("themes_raw"),
             duration_seconds=d.get("duration_seconds", 0.0),

--- a/evals/review.py
+++ b/evals/review.py
@@ -13,15 +13,14 @@ Usage:
 
 import argparse
 import json
-import os
 import sys
-import tempfile
 from pathlib import Path
 
 from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll
 from textual.widgets import Static
 
+from evals import atomic_write_jsonl
 from evals.schemas import GoldenThread
 from gmail_utils import decode_body
 from tui_common import CANCEL, KeyMenuScreen, PromptLineScreen
@@ -62,18 +61,7 @@ def load_golden_set(path: Path) -> list[GoldenThread]:
 
 def save_golden_set(threads: list[GoldenThread], path: Path) -> None:
     """Save golden set atomically (temp file + rename)."""
-    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".jsonl.tmp")
-    try:
-        with os.fdopen(fd, "w") as f:
-            for thread in threads:
-                f.write(json.dumps(thread.to_dict()) + "\n")
-        os.rename(tmp_path, path)
-    except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
+    atomic_write_jsonl(threads, path)
 
 
 # ---------------------------------------------------------------------------

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -129,7 +129,7 @@ async def preflight_check(
             errors.append(
                 f"cloud LLM '{cloud_base.model}' not reachable at "
                 f"{cloud_base.base_url or '<unset CLOUD_LLM_URL>'}"
-                + _model_mismatch_hint(result.status_code)
+                + _detail_suffix(result)
             )
     if need_local:
         result = await local_base.probe(local_timeout)
@@ -137,18 +137,20 @@ async def preflight_check(
             errors.append(
                 f"local LLM '{local_base.model}' not reachable at "
                 f"{local_base.base_url or '<unset MLX_URL>'}"
-                + _model_mismatch_hint(result.status_code)
+                + _detail_suffix(result)
             )
     return errors
 
 
-def _model_mismatch_hint(status_code: int | None) -> str:
-    """The 404-only hint (issue #41 item 7): a 404 usually means the requested
-    model name doesn't match the served model, distinct from an endpoint that is
-    simply down."""
-    if status_code == 404:
-        return " (HTTP 404 — the model name likely doesn't match the served model)"
-    return ""
+def _detail_suffix(result) -> str:
+    """Parenthesized probe-failure detail for a preflight message, or "" if none.
+
+    Finding 1: surfaces probe()'s captured diagnosis (HTTP status / exception
+    text / 404 model-mismatch hint) instead of discarding it. All wording lives on
+    AvailabilityResult.detail() so this and newsletter_run's preflight can't drift
+    (Finding 2)."""
+    detail = result.detail()
+    return f" ({detail})" if detail else ""
 
 
 def resolve_parallelism(cli_value: int | None, config: dict) -> int:

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -123,18 +123,32 @@ async def preflight_check(
     that loads the requested model on demand, so a cold load is not read as "down".
     """
     errors = []
-    if need_cloud and not await cloud_base.is_available(cloud_timeout):
-        errors.append(
-            f"cloud LLM '{cloud_base.model}' not reachable at "
-            f"{cloud_base.base_url or '<unset CLOUD_LLM_URL>'}"
-        )
-    if need_local and not await local_base.is_available(local_timeout):
-        errors.append(
-            f"local LLM '{local_base.model}' not reachable at "
-            f"{local_base.base_url or '<unset MLX_URL>'} "
-            "(a model-name mismatch with the served model returns 404)"
-        )
+    if need_cloud:
+        result = await cloud_base.probe(cloud_timeout)
+        if not result.ok:
+            errors.append(
+                f"cloud LLM '{cloud_base.model}' not reachable at "
+                f"{cloud_base.base_url or '<unset CLOUD_LLM_URL>'}"
+                + _model_mismatch_hint(result.status_code)
+            )
+    if need_local:
+        result = await local_base.probe(local_timeout)
+        if not result.ok:
+            errors.append(
+                f"local LLM '{local_base.model}' not reachable at "
+                f"{local_base.base_url or '<unset MLX_URL>'}"
+                + _model_mismatch_hint(result.status_code)
+            )
     return errors
+
+
+def _model_mismatch_hint(status_code: int | None) -> str:
+    """The 404-only hint (issue #41 item 7): a 404 usually means the requested
+    model name doesn't match the served model, distinct from an endpoint that is
+    simply down."""
+    if status_code == 404:
+        return " (HTTP 404 — the model name likely doesn't match the served model)"
+    return ""
 
 
 def resolve_parallelism(cli_value: int | None, config: dict) -> int:

--- a/labeler.py
+++ b/labeler.py
@@ -181,14 +181,16 @@ class LabelManager:
         self,
         message_ids: list[str],
         tier: NewsletterTier | None,
-        themes: list[str],
+        themes: dict[str, str],
     ) -> None:
         """Apply newsletter classification labels to message(s).
 
         Args:
             message_ids: Message IDs to label.
             tier: Quality tier of the best story, or None for no-stories.
-            themes: List of theme keys (e.g. ["scripture", "church"]).
+            themes: Graded themes (theme key -> "present"/"emphasized"). Only
+                *emphasized* themes get a Gmail label (issue #53); merely-present
+                themes are recorded in the assessment JSONL but not labeled.
         """
         nl_labels = self.config["newsletter"]["labels"]
         processed_name = self.labels_config["processed"]
@@ -204,7 +206,9 @@ class LabelManager:
         else:
             add_label_ids.append(self.label_ids[nl_labels["no_stories"]])
 
-        for theme in themes:
+        for theme, grade in themes.items():
+            if grade != "emphasized":
+                continue
             theme_name = nl_labels["themes"].get(theme)
             if theme_name and theme_name in self.label_ids:
                 add_label_ids.append(self.label_ids[theme_name])

--- a/llm_client.py
+++ b/llm_client.py
@@ -11,7 +11,7 @@ import httpx
 
 from retry import retry_with_backoff
 
-# Default timeout (seconds) for the lightweight is_available() ping. Longer than
+# Default timeout (seconds) for the lightweight probe() ping. Longer than
 # a typical liveness probe because a server that loads models on demand only
 # loads the requested model on the first request — a cold load of a large model
 # routinely exceeds 10s, and timing out would wrongly report it unreachable.
@@ -245,10 +245,6 @@ class LLMClient:
             # timeout, but also UnsupportedProtocol (unset/schemeless URL) and
             # read/protocol errors (e.g. a dropped connection mid cold-load).
             return AvailabilityResult(ok=False, error=f"{type(exc).__name__}: {exc}")
-
-    async def is_available(self, timeout: float | None = None) -> bool:
-        """Whether the endpoint is reachable (a thin bool wrapper over probe())."""
-        return (await self.probe(timeout)).ok
 
     # Matches <think>...</think> and <<think>>...</<think>> (DeepSeek variant)
     _THINK_PATTERN = re.compile(r"<<?think>>?.*?</<?think>>?", flags=re.DOTALL)

--- a/llm_client.py
+++ b/llm_client.py
@@ -5,6 +5,7 @@ Handles thinking tag stripping for reasoning models.
 """
 
 import re
+from dataclasses import dataclass
 
 import httpx
 
@@ -15,6 +16,20 @@ from retry import retry_with_backoff
 # loads the requested model on the first request — a cold load of a large model
 # routinely exceeds 10s, and timing out would wrongly report it unreachable.
 DEFAULT_AVAILABILITY_TIMEOUT = 60
+
+
+@dataclass(frozen=True)
+class AvailabilityResult:
+    """Result of an endpoint availability probe (issue #41 item 7).
+
+    ``ok`` is True only on HTTP 200. ``status_code`` is the HTTP status when a
+    response arrived (None if none did); ``error`` is the exception detail when
+    the request failed before a response (connect/timeout/unsupported-protocol).
+    """
+
+    ok: bool
+    status_code: int | None = None
+    error: str | None = None
 
 
 class LLMUnavailableError(Exception):
@@ -191,19 +206,20 @@ class LLMClient:
             return self._strip_thinking(content), thinking
         return self._strip_thinking(content)
 
-    async def is_available(self, timeout: float | None = None) -> bool:
-        """Check if the LLM endpoint is reachable.
+    async def probe(self, timeout: float | None = None) -> "AvailabilityResult":
+        """Probe the endpoint, returning status detail (issue #41 item 7).
 
-        Sends a minimal completion request to verify connectivity.
+        Sends a minimal completion request. ``ok`` is True only on HTTP 200.
+        ``status_code`` carries the HTTP status when a response arrived — so a
+        404 (which usually means the requested model name doesn't match the
+        served one) is distinguishable from an endpoint that is simply down.
+        ``error`` carries the exception detail when no response arrived at all.
 
         Args:
             timeout: Seconds to wait for the ping. Defaults to
                 DEFAULT_AVAILABILITY_TIMEOUT, generous enough to cover a server
                 that loads the requested model on demand (a cold load can take
                 far longer than a normal liveness probe).
-
-        Returns:
-            True if the endpoint responds successfully, False otherwise.
         """
         if timeout is None:
             timeout = DEFAULT_AVAILABILITY_TIMEOUT
@@ -223,12 +239,16 @@ class LLMClient:
             async with httpx.AsyncClient(timeout=timeout) as client:
                 response = await client.post(self.base_url, headers=headers, json=body)
 
-            return response.status_code == 200
-        except httpx.RequestError:
+            return AvailabilityResult(ok=response.status_code == 200, status_code=response.status_code)
+        except httpx.RequestError as exc:
             # Any failure to obtain a response means "not available": connect /
             # timeout, but also UnsupportedProtocol (unset/schemeless URL) and
             # read/protocol errors (e.g. a dropped connection mid cold-load).
-            return False
+            return AvailabilityResult(ok=False, error=f"{type(exc).__name__}: {exc}")
+
+    async def is_available(self, timeout: float | None = None) -> bool:
+        """Whether the endpoint is reachable (a thin bool wrapper over probe())."""
+        return (await self.probe(timeout)).ok
 
     # Matches <think>...</think> and <<think>>...</<think>> (DeepSeek variant)
     _THINK_PATTERN = re.compile(r"<<?think>>?.*?</<?think>>?", flags=re.DOTALL)

--- a/llm_client.py
+++ b/llm_client.py
@@ -27,6 +27,19 @@ class LLMUnavailableError(Exception):
     """
 
 
+class LLMContentError(RuntimeError):
+    """The model returned no usable ``content`` (issue #30).
+
+    A reasoning model that exhausts max_tokens mid-<think>, a GLM reply carrying
+    only ``reasoning_content``, or an empty string all yield an unusable response.
+    Retrying as-is won't help, so it is request-specific/permanent and
+    give-up-eligible. It subclasses ``RuntimeError`` so the email pipeline's
+    ``except RuntimeError`` give-up handler catches it unchanged, while giving the
+    newsletter pipeline a dedicated type to re-raise (a *bare* per-story
+    RuntimeError stays isolated; a content-less one propagates to give-up).
+    """
+
+
 class LLMClient:
     """Client for OpenAI-compatible chat completion endpoints."""
 
@@ -162,7 +175,7 @@ class LLMClient:
             # (An empty string must be caught too: it would otherwise parse to a
             # default SERVICE / LOW_PRIORITY label and silently mislabel the email.)
             has_reasoning = bool(msg.get("reasoning_content") or msg.get("reasoning"))
-            raise RuntimeError(
+            raise LLMContentError(
                 f"LLM {self.model} returned no content "
                 f"(max_tokens={self.max_tokens} likely exhausted before a final answer; "
                 f"reasoning_content {'present' if has_reasoning else 'absent'})"

--- a/llm_client.py
+++ b/llm_client.py
@@ -31,6 +31,26 @@ class AvailabilityResult:
     status_code: int | None = None
     error: str | None = None
 
+    def detail(self) -> str:
+        """One-line failure diagnosis for a preflight message (issue #41 item 7).
+
+        The single place that composes a failed probe's specific reason so every
+        consumer surfaces it rather than discarding it (Findings 1 & 2): the HTTP
+        status when a response arrived — with the 404-means-model-name-mismatch
+        hint, distinct from a merely-down endpoint — or the exception text when no
+        response arrived at all (connect/timeout/UnsupportedProtocol). Returns ""
+        when ``ok`` or when there is nothing specific to report.
+        """
+        if self.ok:
+            return ""
+        if self.status_code is not None:
+            if self.status_code == 404:
+                return "HTTP 404 — likely the model name does not match the served model"
+            return f"HTTP {self.status_code}"
+        if self.error:
+            return self.error
+        return ""
+
 
 class LLMUnavailableError(Exception):
     """The LLM endpoint is unreachable or dropped the connection (transient).

--- a/newsletter.py
+++ b/newsletter.py
@@ -36,6 +36,14 @@ _VALID_THEMES = {
 
 _DIMENSIONS = ("simple", "concrete", "personal", "dynamic")
 
+# Storytelling dimensions are graded on a 3-value rubric (issue #53). The tokens
+# map to integers so the tier average and eval metrics stay simple arithmetic.
+_SCORE_TOKENS = {"POOR": 1, "OK": 2, "GOOD": 3}
+
+# Ends-Statement themes are graded on a 3-value rubric (issue #53). "absent" is
+# represented by omission, so only these two grades ever appear in a stored dict.
+_THEME_GRADES = {"PRESENT": "present", "EMPHASIZED": "emphasized"}
+
 
 @dataclass
 class StoryResult:
@@ -43,7 +51,7 @@ class StoryResult:
     scores: dict[str, int] | None = None
     average_score: float | None = None
     tier: NewsletterTier | None = None
-    themes: list[str] = field(default_factory=list)
+    themes: dict[str, str] = field(default_factory=dict)
     quality_cot: str = ""
     theme_cot: str = ""
 
@@ -88,56 +96,84 @@ def parse_stories(raw: str) -> list[str]:
 def parse_quality_scores(raw: str) -> dict[str, int] | None:
     """Parse LLM quality assessment output into dimension scores.
 
-    Returns None if any dimension is missing or has an unparseable value.
-    Clamps scores to 1-5 range.
+    Each dimension is graded POOR/OK/GOOD (mapped to 1/2/3). Returns None if any
+    dimension is missing or its value is not one of those tokens (a legacy digit
+    or an unknown word is a parse failure, not a clamped score).
     """
     if not raw.strip():
         return None
 
     scores = {}
     for dim in _DIMENSIONS:
-        pattern = rf"{dim.upper()}\s*:\s*(\d+)"
+        pattern = rf"{dim.upper()}\s*:\s*(POOR|OK|GOOD)\b"
         match = re.search(pattern, raw, flags=re.IGNORECASE)
         if not match:
             return None
-        try:
-            value = int(match.group(1))
-        except ValueError:
-            return None
-        scores[dim] = max(1, min(5, value))
+        scores[dim] = _SCORE_TOKENS[match.group(1).upper()]
 
     return scores
 
 
-def parse_themes(raw: str) -> list[str]:
-    """Parse LLM theme classification output into theme labels.
+def parse_themes(raw: str) -> dict[str, str]:
+    """Parse LLM theme classification output into graded theme labels.
 
-    Returns list of lowercase theme names. Ignores unrecognized themes.
-    Returns empty list for NONE response.
+    Each recognized theme line is ``THEME: ABSENT|PRESENT|EMPHASIZED``. Returns a
+    dict mapping lowercase theme name -> "present"/"emphasized"; Absent themes and
+    unrecognized names are omitted. Returns an empty dict for a NONE response.
     """
     stripped = raw.strip()
     if not stripped or stripped.upper() == "NONE":
-        return []
+        return {}
 
-    themes = []
+    themes: dict[str, str] = {}
     for line in stripped.splitlines():
-        token = line.strip().upper()
-        if token in _VALID_THEMES:
-            themes.append(token.lower())
+        match = re.match(
+            r"\s*([A-Za-z_]+)\s*:\s*(ABSENT|PRESENT|EMPHASIZED)\b",
+            line,
+            flags=re.IGNORECASE,
+        )
+        if not match:
+            continue
+        name = match.group(1).upper()
+        grade = match.group(2).upper()
+        if name in _VALID_THEMES and grade in _THEME_GRADES:
+            themes[name.lower()] = _THEME_GRADES[grade]
 
     return themes
 
 
 def compute_tier(scores: dict[str, int]) -> NewsletterTier:
-    """Derive quality tier from dimension scores."""
+    """Derive quality tier from the 3-value dimension scores.
+
+    Dimensions are 1/2/3 (Poor/OK/Good); the tier is banded off their mean:
+    excellent >= 2.75, good >= 2.25, fair >= 1.75, else poor (issue #53).
+    """
     avg = sum(scores.values()) / len(scores)
-    if avg >= 4.0:
+    if avg >= 2.75:
         return NewsletterTier.EXCELLENT
-    if avg >= 3.0:
+    if avg >= 2.25:
         return NewsletterTier.GOOD
-    if avg >= 2.0:
+    if avg >= 1.75:
         return NewsletterTier.FAIR
     return NewsletterTier.POOR
+
+
+# Ordering of theme grades for cross-story aggregation (higher = stronger).
+THEME_GRADE_RANK = {"present": 1, "emphasized": 2}
+
+
+def aggregate_theme_grades(stories: list["StoryResult"]) -> dict[str, str]:
+    """Merge per-story graded themes into one dict for the whole newsletter.
+
+    Each theme takes the strongest grade seen across all stories
+    (emphasized > present); themes absent from every story are omitted.
+    """
+    merged: dict[str, str] = {}
+    for story in stories:
+        for theme, grade in story.themes.items():
+            if THEME_GRADE_RANK.get(grade, 0) > THEME_GRADE_RANK.get(merged.get(theme, ""), 0):
+                merged[theme] = grade
+    return merged
 
 
 def write_assessment(
@@ -223,8 +259,8 @@ class NewsletterClassifier:
         scores = parse_quality_scores(raw)
         return scores, cot
 
-    async def classify_themes(self, text: str) -> tuple[list[str], str]:
-        """Tag a story with Ends Statement themes."""
+    async def classify_themes(self, text: str) -> tuple[dict[str, str], str]:
+        """Tag a story with graded Ends Statement themes (theme -> grade)."""
         user_content = self.theme_config["user_template"].format(text=text)
         raw, cot = await self.cloud_llm.complete(
             self.theme_config["system"],

--- a/newsletter.py
+++ b/newsletter.py
@@ -10,6 +10,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from enum import Enum
 from pathlib import Path
 
@@ -176,6 +177,35 @@ def aggregate_theme_grades(stories: list["StoryResult"]) -> dict[str, str]:
     return merged
 
 
+def parse_send_date(date_header: str, internal_date_ms: str | None = None) -> str | None:
+    """Normalize an email's send date to an ISO-8601 UTC string.
+
+    Prefers the RFC-2822 ``Date`` header (a header with no timezone is assumed
+    UTC); falls back to Gmail's ``internalDate`` (epoch milliseconds) when the
+    header is missing or unparseable. Returns None if neither yields a valid date.
+    ISO-8601 UTC sorts lexicographically = chronologically, which the review TUI
+    relies on for date sorting/filtering (issue #35/#36).
+    """
+    if date_header:
+        try:
+            dt = parsedate_to_datetime(date_header)
+        except (ValueError, TypeError):
+            dt = None
+        if dt is not None:
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc).isoformat()
+
+    if internal_date_ms:
+        try:
+            seconds = int(internal_date_ms) / 1000
+            return datetime.fromtimestamp(seconds, tz=timezone.utc).isoformat()
+        except (ValueError, TypeError, OverflowError, OSError):
+            pass
+
+    return None
+
+
 def write_assessment(
     output_file: str,
     message_id: str,
@@ -184,14 +214,25 @@ def write_assessment(
     subject: str,
     overall_tier: NewsletterTier | None,
     stories: list[StoryResult],
+    *,
+    send_date: str | None = None,
+    model: str | None = None,
 ) -> None:
-    """Append a newsletter assessment record to the JSONL output file."""
+    """Append a newsletter assessment record to the JSONL output file.
+
+    ``timestamp`` is the *processed* time (UTC now). ``send_date`` is the email's
+    own send date (ISO-8601 UTC, email-intrinsic) and ``model`` is the classifier
+    model — both used by the review TUI (issue #35/#36). Old records lacking these
+    keys are read with ``.get()`` fallbacks by consumers.
+    """
     record = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "message_id": message_id,
         "thread_id": thread_id,
         "from": sender,
         "subject": subject,
+        "send_date": send_date,
+        "model": model,
         "overall_tier": overall_tier.value if overall_tier else None,
         "stories": [
             {

--- a/newsletter.py
+++ b/newsletter.py
@@ -189,12 +189,13 @@ def parse_send_date(date_header: str, internal_date_ms: str | None = None) -> st
     if date_header:
         try:
             dt = parsedate_to_datetime(date_header)
-        except (ValueError, TypeError):
-            dt = None
-        if dt is not None:
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt.astimezone(timezone.utc).isoformat()
+            if dt is not None:
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                # astimezone can OverflowError near datetime's min/max year.
+                return dt.astimezone(timezone.utc).isoformat()
+        except (ValueError, TypeError, OverflowError):
+            pass
 
     if internal_date_ms:
         try:

--- a/newsletter.py
+++ b/newsletter.py
@@ -41,9 +41,52 @@ _DIMENSIONS = ("simple", "concrete", "personal", "dynamic")
 # map to integers so the tier average and eval metrics stay simple arithmetic.
 _SCORE_TOKENS = {"POOR": 1, "OK": 2, "GOOD": 3}
 
-# Ends-Statement themes are graded on a 3-value rubric (issue #53). "absent" is
-# represented by omission, so only these two grades ever appear in a stored dict.
-_THEME_GRADES = {"PRESENT": "present", "EMPHASIZED": "emphasized"}
+# Ends-Statement themes are graded on a 3-value rubric (issue #53). All three
+# grades are *recognized*; "absent" is represented by omission, so only present/
+# emphasized ever appear in a stored dict (see classify_theme_line / parse_themes).
+_THEME_GRADE_TOKENS = {"ABSENT": "absent", "PRESENT": "present", "EMPHASIZED": "emphasized"}
+
+# One-per-line theme matcher, single-sourced here so the production parser
+# (parse_themes) and the eval anomaly detectors share identical format knowledge
+# and cannot drift (Finding 2). Unanchored ``search`` tolerates leading list
+# markers/markdown (mirrors parse_quality_scores); ``([A-Za-z]+)`` captures ANY
+# grade word so a misspelled grade is still recognized as a line yet rejected as
+# a grade — surfacing it as a near-miss instead of being silently skipped.
+_THEME_LINE_RE = re.compile(r"([A-Za-z_]+)\s*:\s*([A-Za-z]+)")
+
+
+def classify_theme_line(line: str) -> tuple[str, str | None, str | None]:
+    """Classify one line of an LLM theme-grading reply. Returns ``(kind, name, grade)``.
+
+    The single shared theme-line classifier: ``parse_themes`` and the eval
+    anomaly detectors (``newsletter_run._theme_line_anomalies`` /
+    ``newsletter_report.theme_parse_anomalies``) all route through it, so the
+    response-format knowledge lives in one place (Finding 2).
+
+    Kinds:
+      - ``"blank"`` — whitespace-only line; ignore it.
+      - ``"theme"`` — an in-taxonomy grading. ``name`` is the lowercased theme,
+        ``grade`` one of "absent"/"present"/"emphasized". parse_themes stores it
+        iff the grade is not "absent".
+      - ``"off_taxonomy"`` — a ``NAME: GRADE`` line with a valid grade token but an
+        off-taxonomy ``name`` (returned UPPERCASE); parse_themes drops it.
+      - ``"anomalous"`` — a non-blank line that is not a recognizable grading (no
+        ``NAME: WORD`` pair, or a WORD that is not a grade token); parse_themes
+        skips it. Off-taxonomy and anomalous lines are exactly the non-blank lines
+        parse_themes does NOT accept — the diagnostics surface both (Finding 3).
+    """
+    if not line.strip():
+        return "blank", None, None
+    match = _THEME_LINE_RE.search(line)
+    if not match:
+        return "anomalous", None, None
+    name = match.group(1).upper()
+    grade = _THEME_GRADE_TOKENS.get(match.group(2).upper())
+    if grade is None:
+        return "anomalous", None, None
+    if name in _VALID_THEMES:
+        return "theme", name.lower(), grade
+    return "off_taxonomy", name, grade
 
 
 @dataclass
@@ -128,17 +171,11 @@ def parse_themes(raw: str) -> dict[str, str]:
 
     themes: dict[str, str] = {}
     for line in stripped.splitlines():
-        match = re.match(
-            r"\s*([A-Za-z_]+)\s*:\s*(ABSENT|PRESENT|EMPHASIZED)\b",
-            line,
-            flags=re.IGNORECASE,
-        )
-        if not match:
-            continue
-        name = match.group(1).upper()
-        grade = match.group(2).upper()
-        if name in _VALID_THEMES and grade in _THEME_GRADES:
-            themes[name.lower()] = _THEME_GRADES[grade]
+        kind, name, grade = classify_theme_line(line)
+        # Store only in-taxonomy present/emphasized gradings; absent is omitted,
+        # off-taxonomy/anomalous lines are dropped (surfaced by the eval detectors).
+        if kind == "theme" and grade != "absent":
+            themes[name] = grade
 
     return themes
 

--- a/newsletter.py
+++ b/newsletter.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pathlib import Path
 
 from gmail_utils import get_header
-from llm_client import LLMClient, LLMUnavailableError
+from llm_client import LLMClient, LLMContentError, LLMUnavailableError
 
 log = logging.getLogger(__name__)
 
@@ -296,8 +296,11 @@ class NewsletterClassifier:
                     result.scores = scores
                     result.average_score = sum(scores.values()) / len(scores)
                     result.tier = compute_tier(scores)
-            except LLMUnavailableError:
-                raise  # transient — let the daemon retry the whole newsletter
+            except (LLMUnavailableError, LLMContentError):
+                # transient outage OR a content-less response (issue #30): both
+                # affect every story, so propagate to give-up rather than commit
+                # a permanently mis-graded (empty) newsletter.
+                raise
             except Exception:
                 log.warning("Quality assessment failed for story: %s", text[:60])
 
@@ -305,8 +308,8 @@ class NewsletterClassifier:
                 themes, theme_cot = await self.classify_themes(text)
                 result.themes = themes
                 result.theme_cot = theme_cot
-            except LLMUnavailableError:
-                raise  # transient — let the daemon retry the whole newsletter
+            except (LLMUnavailableError, LLMContentError):
+                raise
             except Exception:
                 log.warning("Theme classification failed for story: %s", text[:60])
 

--- a/newsletter_review/__main__.py
+++ b/newsletter_review/__main__.py
@@ -5,6 +5,7 @@ Usage::
     python -m newsletter_review
     python -m newsletter_review --tier poor
     python -m newsletter_review --theme scripture --sender dm.org
+    python -m newsletter_review --since 2026-06-01
     python -m newsletter_review --file path/to/assessments.jsonl
 """
 

--- a/newsletter_review/__main__.py
+++ b/newsletter_review/__main__.py
@@ -10,9 +10,19 @@ Usage::
 
 import argparse
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from newsletter_review.tui import load_assessments, run_review_tui
+
+
+def _since_date(value: str) -> str:
+    """argparse ``type`` for ``--since``: validate ``YYYY-MM-DD`` and normalize to
+    zero-padded ISO, matching the in-TUI since input."""
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date().isoformat()
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"invalid date '{value}' — use YYYY-MM-DD") from None
 
 
 def cli() -> None:
@@ -38,6 +48,11 @@ def cli() -> None:
         "--sender",
         help="Filter by sender (substring match, case-insensitive)",
     )
+    parser.add_argument(
+        "--since",
+        type=_since_date,
+        help="Filter to records sent on or after this local date (YYYY-MM-DD)",
+    )
     args = parser.parse_args()
 
     if not args.file.exists():
@@ -50,7 +65,13 @@ def cli() -> None:
         print(f"Error loading {args.file}: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    run_review_tui(records, init_tier=args.tier, init_theme=args.theme, init_sender=args.sender)
+    run_review_tui(
+        records,
+        init_tier=args.tier,
+        init_theme=args.theme,
+        init_sender=args.sender,
+        init_since=args.since,
+    )
 
 
 if __name__ == "__main__":

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -85,6 +85,11 @@ def apply_filters(
     return result
 
 
+# Dimension score int (1/2/3) -> display label (issue #53); old out-of-range
+# values (legacy 1-5 records) fall back to their raw int.
+_SCORE_LABELS = {1: "Poor", 2: "OK", 3: "Good"}
+
+
 def _format_themes(themes) -> str:
     """Render a story's themes for the detail view.
 
@@ -217,7 +222,7 @@ def build_detail_lines(record: dict, width: int = 80) -> list[str]:
         # Quality scores
         scores = story.get("scores")
         if scores:
-            parts = [f"{k}={v}" for k, v in scores.items()]
+            parts = [f"{k}={_SCORE_LABELS.get(v, v)}" for k, v in scores.items()]
             lines.append(f"Quality scores: {' '.join(parts)}")
         else:
             lines.append("Quality scores: —")
@@ -464,11 +469,13 @@ class ReviewApp(App):
                 self._refresh_list(reset_cursor=True)
                 return
             try:
-                datetime.strptime(result, "%Y-%m-%d")
+                parsed = datetime.strptime(result, "%Y-%m-%d").date()
             except ValueError:
                 self.push_screen(HintScreen(f"Invalid date '{result}' — use YYYY-MM-DD"))
                 return
-            self.f_since = result
+            # Normalize to zero-padded ISO so the lexicographic send-date compare
+            # is correct even for input like "2024-2-5".
+            self.f_since = parsed.isoformat()
             self._refresh_list(reset_cursor=True)
 
         def on_date(result) -> None:

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -6,6 +6,7 @@ including per-story quality scores, themes, and chain-of-thought reasoning.
 
 import json
 import textwrap
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from textual.app import App, ComposeResult
@@ -14,12 +15,13 @@ from textual.containers import VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Label, ListItem, ListView, Static
 
-from tui_common import CANCEL, KeyMenuScreen, PageListView, PromptLineScreen
+from tui_common import CANCEL, HintScreen, KeyMenuScreen, PageListView, PromptLineScreen
 
 # ---------------------------------------------------------------------------
 # Column widths for list view
 # ---------------------------------------------------------------------------
 
+_COL_DATE = 10  # "YYYY-MM-DD"
 _COL_TIER = 10
 _COL_SENDER = 30
 _COL_STORIES = 9  # "N stories"
@@ -36,12 +38,20 @@ def load_assessments(path: Path) -> list[dict]:
         return [json.loads(line) for line in f if line.strip()]
 
 
+def sort_by_send_date(records: list[dict]) -> list[dict]:
+    """Sort records by send-date descending (newest first); records without a
+    send-date sort last. Stable, so equal-dated records keep their input order
+    (issue #36)."""
+    return sorted(records, key=lambda r: r.get("send_date") or "", reverse=True)
+
+
 def apply_filters(
     records: list[dict],
     *,
     tier: str | None = None,
     theme: str | None = None,
     sender: str | None = None,
+    since: str | None = None,
 ) -> list[dict]:
     """Filter assessment records. All active filters are ANDed."""
     result = records
@@ -59,6 +69,10 @@ def apply_filters(
     if sender is not None:
         sender_lower = sender.lower()
         result = [r for r in result if sender_lower in r.get("from", "").lower()]
+    if since is not None:
+        # Filter on the send-date (date part), inclusive; records with no
+        # send-date can't satisfy a positive date filter, so they drop out (#36).
+        result = [r for r in result if (r.get("send_date") or "")[:10] >= since]
     return result
 
 
@@ -100,6 +114,7 @@ def format_filter_summary(
     tier: str | None = None,
     theme: str | None = None,
     sender: str | None = None,
+    since: str | None = None,
 ) -> str:
     """Build a human-readable summary of active filters."""
     parts = []
@@ -109,22 +124,32 @@ def format_filter_summary(
         parts.append(f"theme:{theme}")
     if sender is not None:
         parts.append(f"sender:{sender}")
+    if since is not None:
+        parts.append(f"since:{since}")
     return "  ".join(parts)
+
+
+def _list_date(record: dict) -> str:
+    """The send-date's date part for the list column, or ``—`` if absent (#36)."""
+    send_date = record.get("send_date")
+    return send_date[:10] if send_date else "—"
 
 
 def format_list_row(record: dict, max_x: int) -> str:
     """Format one assessment record as a list-view line."""
+    date = _list_date(record)
     tier = record.get("overall_tier") or "—"
     sender = _truncate(record.get("from", "?"), _COL_SENDER)
     story_count = len(record.get("stories", []))
     stories_str = f"{story_count} stor{'y' if story_count == 1 else 'ies'}"
 
-    fixed_width = _COL_TIER + _COL_SENDER + _COL_STORIES + _COL_GAP * 3
+    fixed_width = _COL_DATE + _COL_TIER + _COL_SENDER + _COL_STORIES + _COL_GAP * 4
     subject_width = max(10, max_x - fixed_width)
     subject = _truncate(record.get("subject", ""), subject_width)
 
     return (
-        f"{tier:<{_COL_TIER}}"
+        f"{date:<{_COL_DATE}}"
+        f"  {tier:<{_COL_TIER}}"
         f"  {sender:<{_COL_SENDER}}"
         f"  {stories_str:<{_COL_STORIES}}"
         f"  {subject}"
@@ -217,7 +242,16 @@ def build_detail_lines(record: dict, width: int = 80) -> list[str]:
 # Filter key maps
 # ---------------------------------------------------------------------------
 
-_FILTER_TYPE_KEYS = {"t": "tier", "h": "theme", "s": "sender"}
+_FILTER_TYPE_KEYS = {"t": "tier", "h": "theme", "s": "sender", "d": "date"}
+
+# Date-filter submenu: "Past N days" values plus a free-form "since" date (#36).
+_DATE_KEYS = {
+    "3": "30",
+    "9": "90",
+    "y": "365",
+    "s": "since",
+    "x": None,  # clear
+}
 
 _TIER_KEYS = {
     "e": "excellent",
@@ -241,9 +275,10 @@ _THEME_KEYS = {
 # Filter prompts (match the curses prompt text)
 # ---------------------------------------------------------------------------
 
-_FILTER_TYPE_PROMPT = "Filter: [t]ier  [h]eme  [s]ender  (other key cancels)"
+_FILTER_TYPE_PROMPT = "Filter: [t]ier  [h]eme  [s]ender  [d]ate  (other key cancels)"
 _TIER_PROMPT = "[e]xcellent  [g]ood  [f]air  [p]oor  [c]lear  (other cancels)"
 _THEME_PROMPT = "[s]cripture [c]hristlikeness [h]urch [v]ocation_family [d]isciple_making [x]clear"
+_DATE_PROMPT = "Past [3]0 days  [9]0 days  [y]ear  [s]ince…  [x]clear  (other cancels)"
 
 
 class DetailScreen(Screen):
@@ -331,18 +366,22 @@ class ReviewApp(App):
         init_tier: str | None = None,
         init_theme: str | None = None,
         init_sender: str | None = None,
+        init_since: str | None = None,
     ) -> None:
         super().__init__()
-        self.all_records = records
-        self.filtered = records
+        # Default ordering is send-date descending, newest first (issue #36).
+        self.all_records = sort_by_send_date(records)
+        self.filtered = self.all_records
         self.f_tier = init_tier
         self.f_theme = init_theme
         self.f_sender = init_sender
+        self.f_since = init_since
 
     def compose(self) -> ComposeResult:
         yield Static(id="title", markup=False)
         hdr = (
-            f"{'Tier':<{_COL_TIER}}"
+            f"{'Date':<{_COL_DATE}}"
+            f"  {'Tier':<{_COL_TIER}}"
             f"  {'Sender':<{_COL_SENDER}}"
             f"  {'Stories':<{_COL_STORIES}}"
             f"  Subject"
@@ -363,7 +402,7 @@ class ReviewApp(App):
     def _refresh_list(self, *, reset_cursor: bool = False, width: int | None = None) -> None:
         self.filtered = apply_filters(
             self.all_records,
-            tier=self.f_tier, theme=self.f_theme, sender=self.f_sender,
+            tier=self.f_tier, theme=self.f_theme, sender=self.f_sender, since=self.f_since,
         )
         width = max(40, width if width is not None else self.size.width)
         listview = self.query_one(ListView)
@@ -377,7 +416,7 @@ class ReviewApp(App):
             listview.index = min(cursor, len(self.filtered) - 1)
 
         filter_str = format_filter_summary(
-            tier=self.f_tier, theme=self.f_theme, sender=self.f_sender,
+            tier=self.f_tier, theme=self.f_theme, sender=self.f_sender, since=self.f_since,
         )
         if filter_str:
             count = f"{len(self.filtered)}/{len(self.all_records)} records"
@@ -415,6 +454,37 @@ class ReviewApp(App):
             self.f_sender = result or None  # empty string clears the filter
             self._refresh_list(reset_cursor=True)
 
+        def on_since(result) -> None:
+            if result is None:
+                return  # Esc = cancel
+            if not result:
+                self.f_since = None  # empty clears
+                self._refresh_list(reset_cursor=True)
+                return
+            try:
+                datetime.strptime(result, "%Y-%m-%d")
+            except ValueError:
+                self.push_screen(HintScreen(f"Invalid date '{result}' — use YYYY-MM-DD"))
+                return
+            self.f_since = result
+            self._refresh_list(reset_cursor=True)
+
+        def on_date(result) -> None:
+            if result == CANCEL:
+                return
+            if result is None:
+                self.f_since = None  # clear
+                self._refresh_list(reset_cursor=True)
+            elif result == "since":
+                self.push_screen(
+                    PromptLineScreen("Since date  (YYYY-MM-DD, empty=clear, Esc=cancel)"),
+                    on_since,
+                )
+            else:
+                cutoff = datetime.now(timezone.utc).date() - timedelta(days=int(result))
+                self.f_since = cutoff.isoformat()
+                self._refresh_list(reset_cursor=True)
+
         def on_type(result) -> None:
             if result == "tier":
                 self.push_screen(KeyMenuScreen(_TIER_PROMPT, _TIER_KEYS), on_tier)
@@ -425,6 +495,8 @@ class ReviewApp(App):
                     PromptLineScreen("Sender filter  (Enter=confirm, empty=clear, Esc=cancel)"),
                     on_sender,
                 )
+            elif result == "date":
+                self.push_screen(KeyMenuScreen(_DATE_PROMPT, _DATE_KEYS), on_date)
 
         self.push_screen(KeyMenuScreen(_FILTER_TYPE_PROMPT, _FILTER_TYPE_KEYS), on_type)
 
@@ -442,11 +514,12 @@ def run_review_tui(
     init_tier: str | None = None,
     init_theme: str | None = None,
     init_sender: str | None = None,
+    init_since: str | None = None,
 ) -> None:
     """Launch the newsletter review TUI.
 
     *records* is the full (unfiltered) set. Initial filter values from CLI
-    args are passed via init_tier/init_theme/init_sender.
+    args are passed via init_tier/init_theme/init_sender/init_since.
     """
     if not records:
         print("No assessment records to display.")
@@ -454,4 +527,5 @@ def run_review_tui(
     ReviewApp(
         records,
         init_tier=init_tier, init_theme=init_theme, init_sender=init_sender,
+        init_since=init_since,
     ).run()

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -15,7 +15,16 @@ from textual.containers import VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Label, ListItem, ListView, Static
 
-from tui_common import CANCEL, HintScreen, KeyMenuScreen, PageListView, PromptLineScreen
+from tui_common import (
+    CANCEL,
+    HintScreen,
+    KeyMenuScreen,
+    PageListView,
+    PromptLineScreen,
+)
+from tui_common import (
+    truncate as _truncate,
+)
 
 # ---------------------------------------------------------------------------
 # Column widths for list view
@@ -74,13 +83,6 @@ def apply_filters(
         # send-date can't satisfy a positive date filter, so they drop out (#36).
         result = [r for r in result if (r.get("send_date") or "")[:10] >= since]
     return result
-
-
-def _truncate(text: str, width: int) -> str:
-    """Truncate text to width chars, adding ``...`` if needed."""
-    if len(text) <= width:
-        return text
-    return text[: width - 3] + "..."
 
 
 def _format_themes(themes) -> str:

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -15,6 +15,7 @@ from textual.containers import VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Label, ListItem, ListView, Static
 
+from newsletter import _SCORE_TOKENS
 from tui_common import (
     CANCEL,
     HintScreen,
@@ -54,6 +55,34 @@ def sort_by_send_date(records: list[dict]) -> list[dict]:
     return sorted(records, key=lambda r: r.get("send_date") or "", reverse=True)
 
 
+def _local_date(send_date: str | None) -> str | None:
+    """Convert a stored UTC ISO send-date to the reader's LOCAL calendar date
+    (``YYYY-MM-DD``).
+
+    Records store ``send_date`` as a UTC-normalized ISO string, so a US-evening
+    send lands on the *next* UTC day; slicing the UTC string would display and
+    filter it a day ahead of the Date header. Parse and re-localize to the
+    machine's timezone before taking the date. Returns ``None`` for a missing or
+    unparseable send-date (callers render ``—`` / drop it from the since-filter)."""
+    if not send_date:
+        return None
+    try:
+        dt = datetime.fromisoformat(send_date)
+    except ValueError:
+        return None
+    return dt.astimezone().date().isoformat()
+
+
+def _days_ago_cutoff(days: int, *, now: datetime | None = None) -> str:
+    """The "past N days" since-cutoff as a LOCAL calendar date (``YYYY-MM-DD``).
+
+    *now* defaults to the current instant; it is converted to the reader's local
+    timezone before the date arithmetic so the cutoff lines up with the
+    local-date column (same off-by-one concern as :func:`_local_date`)."""
+    base = (now or datetime.now(timezone.utc)).astimezone().date()
+    return (base - timedelta(days=days)).isoformat()
+
+
 def apply_filters(
     records: list[dict],
     *,
@@ -79,15 +108,22 @@ def apply_filters(
         sender_lower = sender.lower()
         result = [r for r in result if sender_lower in r.get("from", "").lower()]
     if since is not None:
-        # Filter on the send-date (date part), inclusive; records with no
-        # send-date can't satisfy a positive date filter, so they drop out (#36).
-        result = [r for r in result if (r.get("send_date") or "")[:10] >= since]
+        # Filter on the send-date's LOCAL calendar date, inclusive; records with
+        # no/unparseable send-date can't satisfy a positive date filter, so they
+        # drop out (#36).
+        result = [r for r in result if (_local_date(r.get("send_date")) or "") >= since]
     return result
 
 
 # Dimension score int (1/2/3) -> display label (issue #53); ``.get(v, v)`` is a
-# defensive fallback so an unexpected value shows raw instead of crashing.
-_SCORE_LABELS = {1: "Poor", 2: "OK", 3: "Good"}
+# defensive fallback so an unexpected value shows raw instead of crashing. Derived
+# from newsletter._SCORE_TOKENS (POOR/OK/GOOD) so the 1/2/3 <-> label mapping has a
+# single source of truth; "OK" is an acronym and stays upper-cased while the other
+# rubric words are title-cased.
+_SCORE_LABELS = {
+    num: (tok if tok == "OK" else tok.capitalize())
+    for tok, num in _SCORE_TOKENS.items()
+}
 
 
 def _format_themes(themes: dict) -> str:
@@ -131,9 +167,9 @@ def format_filter_summary(
 
 
 def _list_date(record: dict) -> str:
-    """The send-date's date part for the list column, or ``—`` if absent (#36)."""
-    send_date = record.get("send_date")
-    return send_date[:10] if send_date else "—"
+    """The send-date's LOCAL calendar date for the list column, or ``—`` if
+    absent/unparseable (#36)."""
+    return _local_date(record.get("send_date")) or "—"
 
 
 def format_list_row(record: dict, max_x: int) -> str:
@@ -484,8 +520,7 @@ class ReviewApp(App):
                     on_since,
                 )
             else:
-                cutoff = datetime.now(timezone.utc).date() - timedelta(days=int(result))
-                self.f_since = cutoff.isoformat()
+                self.f_since = _days_ago_cutoff(int(result))
                 self._refresh_list(reset_cursor=True)
 
         def on_type(result) -> None:

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -132,18 +132,30 @@ def format_list_row(record: dict, max_x: int) -> str:
 
 
 def build_detail_lines(record: dict, width: int = 80) -> list[str]:
-    """Build content lines for the detail view. Pure function, no UI."""
+    """Build content lines for the detail view. Pure function, no UI.
+
+    The header separates email-intrinsic data (subject, sender, send-date) from
+    classification data (processed date, model, tier, stories) with a blank line,
+    so the send-date is never confused with the processed date (issue #35).
+    """
     subject = record.get("subject", "")
     sender = record.get("from", "")
-    timestamp = record.get("timestamp", "")
+    send_date = record.get("send_date") or "unknown"
+    processed = record.get("timestamp", "")
+    model = record.get("model") or "—"
     overall_tier = record.get("overall_tier") or "—"
     stories = record.get("stories", [])
 
     lines = [
+        # Email-intrinsic block
         subject,
         "=" * min(60, width),
-        f"From:    {sender}",
-        f"Date:    {timestamp}",
+        f"From: {sender}",
+        f"Sent: {send_date}",
+        "",
+        # Classification block
+        f"Processed: {processed}",
+        f"Model: {model}",
         f"Overall: {overall_tier}",
         f"Stories: {len(stories)}",
         "",

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -85,21 +85,15 @@ def apply_filters(
     return result
 
 
-# Dimension score int (1/2/3) -> display label (issue #53); old out-of-range
-# values (legacy 1-5 records) fall back to their raw int.
+# Dimension score int (1/2/3) -> display label (issue #53); ``.get(v, v)`` is a
+# defensive fallback so an unexpected value shows raw instead of crashing.
 _SCORE_LABELS = {1: "Poor", 2: "OK", 3: "Good"}
 
 
-def _format_themes(themes) -> str:
-    """Render a story's themes for the detail view.
-
-    New records store a graded dict (theme -> "present"/"emphasized"), shown as
-    ``name (grade)``; legacy records store a present-only list, shown as plain
-    names (issue #53).
-    """
-    if isinstance(themes, dict):
-        return ", ".join(f"{name} ({grade})" for name, grade in themes.items())
-    return ", ".join(themes)
+def _format_themes(themes: dict) -> str:
+    """Render a story's graded themes (theme -> "present"/"emphasized") for the
+    detail view as ``name (grade)`` (issue #53)."""
+    return ", ".join(f"{name} ({grade})" for name, grade in themes.items())
 
 
 def wrap_text(text: str, width: int) -> list[str]:

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -69,6 +69,18 @@ def _truncate(text: str, width: int) -> str:
     return text[: width - 3] + "..."
 
 
+def _format_themes(themes) -> str:
+    """Render a story's themes for the detail view.
+
+    New records store a graded dict (theme -> "present"/"emphasized"), shown as
+    ``name (grade)``; legacy records store a present-only list, shown as plain
+    names (issue #53).
+    """
+    if isinstance(themes, dict):
+        return ", ".join(f"{name} ({grade})" for name, grade in themes.items())
+    return ", ".join(themes)
+
+
 def wrap_text(text: str, width: int) -> list[str]:
     """Wrap text to width, preserving existing newlines."""
     if not text:
@@ -152,7 +164,7 @@ def build_detail_lines(record: dict, width: int = 80) -> list[str]:
         lines.append(f"--- Story {i + 1}/{len(stories)}: {excerpt} [{tier}, avg: {avg_str}] ---")
 
         if themes:
-            lines.append(f"Themes: {', '.join(themes)}")
+            lines.append(f"Themes: {_format_themes(themes)}")
 
         lines.append("")
 

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -43,9 +43,30 @@ _COL_GAP = 2
 # ---------------------------------------------------------------------------
 
 def load_assessments(path: Path) -> list[dict]:
-    """Load newsletter assessment records from a JSONL file."""
+    """Load newsletter assessment records from a JSONL file.
+
+    Fails fast on pre-#53 old-scheme records whose story ``themes`` are stored
+    as a LIST instead of a theme->grade dict: they would otherwise crash the
+    detail view mid-render (``build_detail_lines`` calls ``themes.items()``).
+    Backward-compatible tolerant reading was deliberately removed, so raise a
+    clear, located error naming the file + line so the reader knows to
+    re-migrate rather than seeing an opaque ``AttributeError`` (Finding 4)."""
+    records = []
     with open(path) as f:
-        return [json.loads(line) for line in f if line.strip()]
+        for lineno, line in enumerate(f, 1):
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            for story in record.get("stories", []):
+                if isinstance(story.get("themes"), list):
+                    raise ValueError(
+                        f"{path}:{lineno}: old-scheme record — story themes are a "
+                        f"list ({story['themes']!r}), not a theme->grade dict. This "
+                        "file predates the #53 theme-dict migration and must be "
+                        "re-migrated before it can be browsed."
+                    )
+            records.append(record)
+    return records
 
 
 def sort_by_send_date(records: list[dict]) -> list[dict]:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import json
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
@@ -981,6 +982,56 @@ class TestNewsletterRouting:
         mock_classifier.classify.assert_not_called()
         mock_newsletter_classifier.classify_newsletter.assert_called_once()
         mock_label_manager.apply_newsletter_classification.assert_called_once()
+
+    async def test_assessment_records_send_date_and_model(
+        self,
+        mock_proxy,
+        mock_classifier,
+        mock_label_manager,
+        mock_newsletter_classifier,
+        cloud_sem,
+        local_sem,
+        newsletter_thread_response,
+        tmp_path,
+    ):
+        """The assessment record persists the email send-date (from the Date header,
+        ISO-8601 UTC) and the classifier model, distinct from the processed timestamp
+        (shared enabler for #35/#36)."""
+        mock_proxy.get_thread.return_value = newsletter_thread_response
+        mock_newsletter_classifier.classify_newsletter.return_value = [
+            StoryResult(
+                text="Content",
+                scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+                average_score=3.0,
+                tier=NewsletterTier.EXCELLENT,
+                themes={"scripture": "emphasized"},
+            )
+        ]
+        # The classifier's cloud LLM reports the model that actually ran.
+        mock_newsletter_classifier.cloud_llm.model = "claude-sonnet-4-6"
+        out = tmp_path / "assessments.jsonl"
+
+        result = await process_single_thread(
+            "thread_nl",
+            ["msg_nl_001"],
+            mock_proxy,
+            mock_classifier,
+            mock_label_manager,
+            cloud_sem,
+            local_sem,
+            max_thread_chars=50000,
+            newsletter_classifier=mock_newsletter_classifier,
+            newsletter_recipient="newsletters@dm.org",
+            newsletter_output_file=str(out),
+        )
+
+        assert result is True
+        record = json.loads(out.read_text().strip())
+        # newsletter_thread_response's Date header is "Mon, 1 Jan 2024 12:00:00 +0000".
+        assert record["send_date"] == "2024-01-01T12:00:00+00:00"
+        assert record["model"] == "claude-sonnet-4-6"
+        # send-date (email-intrinsic) is distinct from the processed timestamp.
+        assert record["timestamp"] != record["send_date"]
 
     async def test_non_newsletter_uses_priority_pipeline(
         self,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -955,10 +955,10 @@ class TestNewsletterRouting:
         mock_newsletter_classifier.classify_newsletter.return_value = [
             StoryResult(
                 text="Content",
-                scores={"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
-                average_score=4.0,
+                scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+                average_score=3.0,
                 tier=NewsletterTier.EXCELLENT,
-                themes=["scripture"],
+                themes={"scripture": "emphasized"},
             )
         ]
 
@@ -1043,7 +1043,7 @@ class TestNewsletterRouting:
         assert result is True
         call_kwargs = mock_label_manager.apply_newsletter_classification.call_args.kwargs
         assert call_kwargs["tier"] is None
-        assert call_kwargs["themes"] == []
+        assert call_kwargs["themes"] == {}
 
     async def test_newsletter_only_skips_non_newsletter(
         self,
@@ -1091,10 +1091,10 @@ class TestNewsletterRouting:
         mock_newsletter_classifier.classify_newsletter.return_value = [
             StoryResult(
                 text="Content",
-                scores={"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
-                average_score=4.0,
+                scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+                average_score=3.0,
                 tier=NewsletterTier.EXCELLENT,
-                themes=["scripture"],
+                themes={"scripture": "emphasized"},
             )
         ]
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1033,6 +1033,63 @@ class TestNewsletterRouting:
         # send-date (email-intrinsic) is distinct from the processed timestamp.
         assert record["timestamp"] != record["send_date"]
 
+    async def test_content_error_routes_to_give_up_not_empty_commit(
+        self,
+        mock_proxy,
+        mock_classifier,
+        mock_label_manager,
+        cloud_sem,
+        local_sem,
+        newsletter_thread_response,
+        tmp_path,
+    ):
+        """#30 end-to-end: a content-less grade error must route the newsletter to
+        the give-up path — it must NOT commit an empty no-stories label/assessment
+        (which would be indistinguishable from a genuine NO_STORIES newsletter)."""
+        from llm_client import LLMContentError
+        from newsletter import NewsletterClassifier
+
+        mock_proxy.get_thread.return_value = newsletter_thread_response
+        fake_llm = AsyncMock()
+        fake_llm.model = "test-model"
+        fake_llm.complete.side_effect = [
+            ("STORY: A real story about ministry work.", ""),  # extract_stories
+            LLMContentError("model returned no content"),      # assess_quality
+        ]
+        nl_config = {
+            "newsletter": {
+                "prompts": {
+                    "story_extraction": {"system": "s", "user_template": "{body}"},
+                    "quality_assessment": {"system": "s", "user_template": "{text}"},
+                    "theme_classification": {"system": "s", "user_template": "{text}"},
+                }
+            }
+        }
+        classifier = NewsletterClassifier(cloud_llm=fake_llm, config=nl_config)
+        out = tmp_path / "assessments.jsonl"
+        tracker = FailureTracker(max_failures=3)  # below threshold -> retry, not commit
+
+        result = await process_single_thread(
+            "thread_nl",
+            ["msg_nl_001"],
+            mock_proxy,
+            mock_classifier,
+            mock_label_manager,
+            cloud_sem,
+            local_sem,
+            max_thread_chars=50000,
+            newsletter_classifier=classifier,
+            newsletter_recipient="newsletters@dm.org",
+            newsletter_output_file=str(out),
+            failure_tracker=tracker,
+        )
+
+        # Routed to give-up (below threshold -> return False for a later retry),
+        # NOT committed as a (false) no-stories outcome.
+        assert result is False
+        mock_label_manager.apply_newsletter_classification.assert_not_called()
+        assert not out.exists()  # no empty assessment record written
+
     async def test_non_newsletter_uses_priority_pipeline(
         self,
         mock_proxy,

--- a/tests/test_eval_edit_tui.py
+++ b/tests/test_eval_edit_tui.py
@@ -159,15 +159,39 @@ class TestEditActions:
             await pilot.press("escape")
             assert "X" not in str(app.query_one(ListView).children[0].query_one(Label).render())
 
-    async def test_e_is_ignored_when_not_excluded(self, tmp_path):
+    async def test_e_toggles_exclude_on_and_saves(self, tmp_path):
+        # Issue #52: `e` now EXCLUDES an included thread (symmetric toggle), not
+        # just un-excludes. The hint is always shown, state-dependent.
         thread = _golden("t1", excluded=False)
         app = _edit_app([thread], tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")
-            assert "[e]unexclude" not in _screen_text(app)
+            assert "[e]exclude" in _screen_text(app)
+            await pilot.press("e")
+            assert thread.excluded is True
+            assert "[e]unexclude" in _screen_text(app)
+            saved = load_golden_set(tmp_path / "golden.jsonl")
+            assert saved[0].excluded is True
+
+    async def test_e_round_trip_toggle(self, tmp_path):
+        thread = _golden("t1", excluded=False)
+        app = _edit_app([thread], tmp_path)
+        async with app.run_test(size=SIZE) as pilot:
+            await pilot.press("enter")
+            await pilot.press("e")
+            assert thread.excluded is True
             await pilot.press("e")
             assert thread.excluded is False
-            assert not (tmp_path / "golden.jsonl").exists()  # no spurious save
+
+    async def test_e_leaves_reviewed_untouched(self, tmp_path):
+        # Parity with the newsletter toggle: excluding does not flip reviewed.
+        thread = _golden("t1", excluded=False, reviewed=True)
+        app = _edit_app([thread], tmp_path)
+        async with app.run_test(size=SIZE) as pilot:
+            await pilot.press("enter")
+            await pilot.press("e")
+            assert thread.excluded is True
+            assert thread.reviewed is True
 
     async def test_saves_all_threads_not_filtered_view(self, tmp_path):
         hidden = _golden("hidden", expected_label="low_priority")

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -1621,6 +1621,19 @@ class TestDetailLabeling:
             assert nl.stories[0].expected_scores is None
             assert "cancelled" in _status(app).lower()
 
+    async def test_legacy_score_key_4_is_rejected(self, tmp_path):
+        # The score scale narrowed from 1-5 to 1-3 (issue #53): '4' is no longer
+        # a valid score key and cancels entry like any other key.
+        nl = _newsletter("tL", body="b0")
+        seed_stories(nl, ["a"])
+        app = _label_app([nl], tmp_path)
+        async with app.run_test(size=SIZE) as pilot:
+            await pilot.press("enter")
+            await pilot.press("1", "l")
+            await pilot.press("4")  # out of the 1-3 range -> cancels
+            assert nl.stories[0].expected_scores is None
+            assert "cancelled" in _status(app).lower()
+
     async def test_theme_cycle_absent_present_emphasized(self, tmp_path):
         nl = _newsletter("tL", body="b0")
         seed_stories(nl, ["a"])

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -114,21 +114,30 @@ class TestSeedStories:
 class TestAssignScoresAndThemes:
     def test_assigns_scores_themes_reviewed_and_derives_tier(self):
         story = _story()
-        scores = {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}
+        scores = {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}
 
+        # A legacy present-only list is coerced to graded "present" (issue #53).
         assign_scores_and_themes(story, scores, ["scripture", "church"])
 
         assert story.expected_scores == scores
-        assert story.expected_themes == ["scripture", "church"]
+        assert story.expected_themes == {"scripture": "present", "church": "present"}
         assert story.reviewed is True
         assert story.expected_tier == compute_tier(scores).value
         assert story.expected_tier == NewsletterTier.EXCELLENT.value
 
+    def test_assigns_graded_themes_dict(self):
+        story = _story()
+        assign_scores_and_themes(
+            story, _scores(), {"scripture": "emphasized", "church": "present"}
+        )
+        assert story.expected_themes == {"scripture": "emphasized", "church": "present"}
+
     def test_derives_fair_tier_for_midrange_scores(self):
         story = _story()
-        scores = {"simple": 2, "concrete": 3, "personal": 2, "dynamic": 3}
+        # all-OK -> avg 2.0 -> fair (issue #53 bands).
+        scores = {"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2}
 
-        assign_scores_and_themes(story, scores, [])
+        assign_scores_and_themes(story, scores, {})
 
         assert story.expected_tier == "fair"
 
@@ -136,8 +145,8 @@ class TestAssignScoresAndThemes:
         story = _story()
         scores = {"simple": 1, "concrete": 1, "personal": 1, "dynamic": 1}
 
-        assign_scores_and_themes(story, scores, [])
-        scores["simple"] = 5
+        assign_scores_and_themes(story, scores, {})
+        scores["simple"] = 3
 
         assert story.expected_scores["simple"] == 1
 
@@ -222,7 +231,7 @@ class TestUndo:
 
         assign_scores_and_themes(
             nl.stories[0],
-            {"simple": 5, "concrete": 5, "personal": 5, "dynamic": 5},
+            {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
             ["scripture"],
         )
         assert nl.stories[0].reviewed is True
@@ -231,7 +240,7 @@ class TestUndo:
 
         assert nl.stories[0].reviewed is False
         assert nl.stories[0].expected_scores is None
-        assert nl.stories[0].expected_themes == []
+        assert nl.stories[0].expected_themes == {}
 
     def test_snapshot_is_independent_of_later_mutations(self):
         nl = _newsletter("tU")
@@ -467,11 +476,11 @@ class TestFormatStoryStrip:
         nl = _newsletter("t", body="l0")
         nl.stories = [_story("t:0", text="l0")]
         assign_scores_and_themes(
-            nl.stories[0], {"simple": 4, "concrete": 4, "personal": 5, "dynamic": 3}, []
+            nl.stories[0], {"simple": 2, "concrete": 2, "personal": 3, "dynamic": 1}, {}
         )
         nl.stories[0].excluded = True
         lines = format_story_strip(nl, locate_story_spans(nl), selected=None, width=80)
-        assert "4/4/5/3" in lines[0]
+        assert "2/2/3/1" in lines[0]
         assert "EXCL" in lines[0]
 
     def test_no_stories_hint(self):
@@ -531,13 +540,13 @@ class TestCommitSpanEdit:
         nl = _newsletter("t", body="l0\nl1\nl2\nl3")
         nl.stories = [_story("t:5", text="l1")]
         assign_scores_and_themes(
-            nl.stories[0], {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
+            nl.stories[0], {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
             ["church"],
         )
         story = commit_span_edit(nl, SpanEdit(0, 1, 2, "adjust"))
         assert story.text == "l1\nl2"
         assert story.story_id == "t:5"  # id preserved
-        assert story.expected_themes == ["church"]  # labels preserved
+        assert story.expected_themes == {"church": "present"}  # labels preserved
         assert story.expected_scores is not None
 
 
@@ -907,13 +916,17 @@ class TestNewsletterExclusionVisibility:
 
 class TestFormatThemeLegend:
     def test_full_legend_when_it_fits(self):
-        legend = format_theme_legend([], 200)
+        legend = format_theme_legend({}, 200)
         assert "[s]scripture" in legend
         assert "[d]disciple_making" in legend
         assert "Enter=done" in legend
 
+    def test_shows_selected_theme_grade(self):
+        legend = format_theme_legend({"scripture": "emphasized"}, 200)
+        assert "scripture=E" in legend
+
     def test_narrow_terminal_gets_compact_legend_with_all_keys(self):
-        legend = format_theme_legend(["scripture"], 60)
+        legend = format_theme_legend({"scripture": "present"}, 60)
         assert len(legend) <= 60
         for key in "schvd":
             assert f"[{key}]" in legend
@@ -1005,7 +1018,7 @@ class TestBuildExtractorPreflight:
 SIZE = (100, 30)
 
 
-def _scores(n=4):
+def _scores(n=3):
     return {"simple": n, "concrete": n, "personal": n, "dynamic": n}
 
 
@@ -1332,7 +1345,7 @@ class TestDetailSpanEdit:
             await pilot.press("down")       # move end to body 2
             await pilot.press("enter")      # commit
             assert nl.stories[0].text == "l1\nl2"
-            assert nl.stories[0].expected_themes == ["church"]  # labels preserved
+            assert nl.stories[0].expected_themes == {"church": "present"}  # labels preserved
             assert nl.stories[0].expected_scores == _scores()
 
     async def test_in_span_e_sets_end_not_start(self, tmp_path):
@@ -1567,10 +1580,10 @@ class TestDetailLabeling:
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")
             await pilot.press("1", "l")           # select story 1, label
-            await pilot.press("4", "4", "5", "3")  # four dimension scores
+            await pilot.press("1", "2", "3", "2")  # four dimension scores (Poor/OK/Good=1/2/3)
             await pilot.press("enter")             # finish themes
             assert nl.stories[0].expected_scores == {
-                "simple": 4, "concrete": 4, "personal": 5, "dynamic": 3,
+                "simple": 1, "concrete": 2, "personal": 3, "dynamic": 2,
             }
             assert nl.stories[0].reviewed is True
 
@@ -1587,8 +1600,8 @@ class TestDetailLabeling:
         seed_stories(nl, ["a"])
         assign_scores_and_themes(
             nl.stories[0],
-            {"simple": 2, "concrete": 3, "personal": 4, "dynamic": 5},
-            [],
+            {"simple": 2, "concrete": 3, "personal": 3, "dynamic": 1},
+            {},
         )
         app = _label_app([nl], tmp_path)
         async with app.run_test(size=SIZE) as pilot:
@@ -1604,21 +1617,26 @@ class TestDetailLabeling:
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")
             await pilot.press("1", "l")
-            await pilot.press("4", "x")  # any non-digit cancels everything
+            await pilot.press("1", "x")  # any out-of-range/other key cancels everything
             assert nl.stories[0].expected_scores is None
             assert "cancelled" in _status(app).lower()
 
-    async def test_theme_toggle_on_and_off(self, tmp_path):
+    async def test_theme_cycle_absent_present_emphasized(self, tmp_path):
         nl = _newsletter("tL", body="b0")
         seed_stories(nl, ["a"])
         app = _label_app([nl], tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")
             await pilot.press("1", "l")
-            await pilot.press("4", "4", "4", "4")
-            await pilot.press("s", "c", "s")  # scripture on, christlikeness on, scripture off
+            await pilot.press("1", "2", "3", "2")   # dimension scores
+            # scripture cycles present->emphasized (2 presses); christlikeness present;
+            # church present->emphasized->absent (3 presses, removed).
+            await pilot.press("s", "s", "c", "h", "h", "h")
             await pilot.press("enter")
-            assert nl.stories[0].expected_themes == ["christlikeness"]
+            assert nl.stories[0].expected_themes == {
+                "scripture": "emphasized",
+                "christlikeness": "present",
+            }
 
 
 class TestDetailAccept:

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -11,6 +11,7 @@ import sys
 import pytest
 
 from evals.newsletter_label import (
+    ScoreScreen,
     SpanEdit,
     accept_confirmation_message,
     add_story,
@@ -76,6 +77,24 @@ def _story(story_id="t1:0", **kw):
     base = dict(story_id=story_id, text="Text")
     base.update(kw)
     return GoldenStory(**base)
+
+
+class TestScorePrompt:
+    def test_prompt_lists_the_three_rubric_options(self):
+        # The score prompt spells out the 1/2/3 <-> rubric mapping (issue #53).
+        assert "[1]poor [2]ok [3]good" in ScoreScreen()._prompt_text()
+
+    def test_score_options_derived_from_newsletter_tokens(self):
+        # Single source of truth: the option string is derived from
+        # newsletter._SCORE_TOKENS, not a hardcoded duplicate.
+        from evals.newsletter_label import _SCORE_OPTIONS
+        from newsletter import _SCORE_TOKENS
+
+        expected = " ".join(
+            f"[{num}]{tok.lower()}"
+            for tok, num in sorted(_SCORE_TOKENS.items(), key=lambda kv: kv[1])
+        )
+        assert _SCORE_OPTIONS == expected
 
 
 class TestSeedStories:

--- a/tests/test_eval_newsletter_label.py
+++ b/tests/test_eval_newsletter_label.py
@@ -116,11 +116,10 @@ class TestAssignScoresAndThemes:
         story = _story()
         scores = {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}
 
-        # A legacy present-only list is coerced to graded "present" (issue #53).
-        assign_scores_and_themes(story, scores, ["scripture", "church"])
+        assign_scores_and_themes(story, scores, {"scripture": "emphasized", "church": "present"})
 
         assert story.expected_scores == scores
-        assert story.expected_themes == {"scripture": "present", "church": "present"}
+        assert story.expected_themes == {"scripture": "emphasized", "church": "present"}
         assert story.reviewed is True
         assert story.expected_tier == compute_tier(scores).value
         assert story.expected_tier == NewsletterTier.EXCELLENT.value
@@ -232,7 +231,7 @@ class TestUndo:
         assign_scores_and_themes(
             nl.stories[0],
             {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
-            ["scripture"],
+            {"scripture": "emphasized"},
         )
         assert nl.stories[0].reviewed is True
 
@@ -541,7 +540,7 @@ class TestCommitSpanEdit:
         nl.stories = [_story("t:5", text="l1")]
         assign_scores_and_themes(
             nl.stories[0], {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
-            ["church"],
+            {"church": "present"},
         )
         story = commit_span_edit(nl, SpanEdit(0, 1, 2, "adjust"))
         assert story.text == "l1\nl2"
@@ -555,7 +554,7 @@ class TestAcceptConfirmationMessage:
         nl = _newsletter("t")
         seed_stories(nl, ["a"])
         assign_scores_and_themes(
-            nl.stories[0], {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}, []
+            nl.stories[0], {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}, []
         )
         assert accept_confirmation_message(nl) is None
 
@@ -720,8 +719,8 @@ class TestLoadSaveRoundTrip:
         seed_stories(nl, ["a", "b"])
         assign_scores_and_themes(
             nl.stories[0],
-            {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
-            ["scripture"],
+            {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+            {"scripture": "emphasized"},
         )
         confirm_story_list(nl)
 
@@ -786,7 +785,7 @@ class TestSeedConfirmationMessage:
         nl = _newsletter("t")
         seed_stories(nl, ["a", "b"])
         assign_scores_and_themes(
-            nl.stories[0], {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}, []
+            nl.stories[0], {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}, []
         )
         assert "1 labeled" in seed_confirmation_message(nl)
 
@@ -803,7 +802,7 @@ class TestConfirmStatusMessage:
         nl = _newsletter("t")
         seed_stories(nl, ["a"])
         assign_scores_and_themes(
-            nl.stories[0], {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}, []
+            nl.stories[0], {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}, []
         )
         assert confirm_status_message(nl) == "Story list confirmed."
 
@@ -1119,7 +1118,7 @@ class TestDetailReseed:
     async def test_reseed_over_existing_stories_requires_confirmation(self, tmp_path):
         nl = _newsletter("tg", body="b0\nb1")
         seed_stories(nl, ["b0"])
-        assign_scores_and_themes(nl.stories[0], _scores(), ["scripture"])
+        assign_scores_and_themes(nl.stories[0], _scores(), {"scripture": "emphasized"})
         app = _label_app([nl], tmp_path, extract_fn=lambda body: "STORY: b1")
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter", "r")
@@ -1213,7 +1212,7 @@ class TestDetailUndo:
     async def test_cancelled_prompt_does_not_clobber_undo(self, tmp_path):
         nl = _newsletter("tU", body="b0")
         seed_stories(nl, ["a", "b"])
-        assign_scores_and_themes(nl.stories[1], _scores(), [])
+        assign_scores_and_themes(nl.stories[1], _scores(), {})
         app = _label_app([nl], tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")
@@ -1234,7 +1233,7 @@ class TestDetailDelete:
     async def test_deleting_labeled_story_requires_confirmation(self, tmp_path):
         nl = _newsletter("tD", body="b0")
         seed_stories(nl, ["a"])
-        assign_scores_and_themes(nl.stories[0], _scores(), [])
+        assign_scores_and_themes(nl.stories[0], _scores(), {})
         app = _label_app([nl], tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")
@@ -1244,7 +1243,7 @@ class TestDetailDelete:
     async def test_confirmed_delete_of_labeled_story_reports_what_was_deleted(self, tmp_path):
         nl = _newsletter("tD", body="b0")
         seed_stories(nl, ["a"])
-        assign_scores_and_themes(nl.stories[0], _scores(), [])
+        assign_scores_and_themes(nl.stories[0], _scores(), {})
         app = _label_app([nl], tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")
@@ -1336,7 +1335,7 @@ class TestDetailSpanEdit:
     async def test_edit_extends_selected_story_end_preserving_labels(self, tmp_path):
         nl = _newsletter("tE", body="l0\nl1\nl2\nl3")
         seed_stories(nl, ["l1"])  # story spans body line 1 only
-        assign_scores_and_themes(nl.stories[0], _scores(), ["church"])
+        assign_scores_and_themes(nl.stories[0], _scores(), {"church": "emphasized"})
         app = _label_app([nl], tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")
@@ -1345,7 +1344,7 @@ class TestDetailSpanEdit:
             await pilot.press("down")       # move end to body 2
             await pilot.press("enter")      # commit
             assert nl.stories[0].text == "l1\nl2"
-            assert nl.stories[0].expected_themes == {"church": "present"}  # labels preserved
+            assert nl.stories[0].expected_themes == {"church": "emphasized"}  # labels preserved
             assert nl.stories[0].expected_scores == _scores()
 
     async def test_in_span_e_sets_end_not_start(self, tmp_path):
@@ -1656,7 +1655,7 @@ class TestDetailAccept:
     async def test_accept_marks_reviewed_and_advances(self, tmp_path):
         nls = [_newsletter("t0", body="b0"), _newsletter("t1", body="b1")]
         seed_stories(nls[0], ["b0"])
-        assign_scores_and_themes(nls[0].stories[0], _scores(), [])
+        assign_scores_and_themes(nls[0].stories[0], _scores(), {})
         app = _label_app(nls, tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")     # open t0
@@ -1692,7 +1691,7 @@ class TestDetailAccept:
 
         nl = _newsletter("t0", body="b0")
         seed_stories(nl, ["b0"])
-        assign_scores_and_themes(nl.stories[0], _scores(), [])
+        assign_scores_and_themes(nl.stories[0], _scores(), {})
         app = _label_app([nl], tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter", "c")
@@ -1709,7 +1708,7 @@ class TestDetailAccept:
         nls = [_newsletter(f"t{i}", body=f"b{i}") for i in range(3)]
         for nl in nls:
             seed_stories(nl, [f"b{nls.index(nl)}"])
-            assign_scores_and_themes(nl.stories[0], _scores(), [])
+            assign_scores_and_themes(nl.stories[0], _scores(), {})
         app = _label_app(nls, tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")           # open t0
@@ -1738,7 +1737,7 @@ class TestDetailAccept:
         nls = [_newsletter(f"t{i}", body=f"b{i}") for i in range(3)]
         for i, nl in enumerate(nls):
             seed_stories(nl, [f"b{i}"])
-            assign_scores_and_themes(nl.stories[0], _scores(), [])
+            assign_scores_and_themes(nl.stories[0], _scores(), {})
         app = _label_app(nls, tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter")            # open t0 (fully labeled -> no confirm)
@@ -2060,7 +2059,7 @@ class TestModalRobustness:
 
         nl = _newsletter("tR", body="b0")
         seed_stories(nl, ["a", "b"])
-        assign_scores_and_themes(nl.stories[0], _scores(), [])
+        assign_scores_and_themes(nl.stories[0], _scores(), {})
         app = _label_app([nl], tmp_path)
         async with app.run_test(size=SIZE) as pilot:
             await pilot.press("enter", "1")   # select labeled story A

--- a/tests/test_eval_newsletter_report.py
+++ b/tests/test_eval_newsletter_report.py
@@ -74,10 +74,10 @@ def _pred(
         thread_id="t",
         expected_scores=expected_scores,
         expected_tier=expected_tier,
-        expected_themes=expected_themes or [],
+        expected_themes=expected_themes or {},
         predicted_scores=predicted_scores,
         predicted_tier=predicted_tier,
-        predicted_themes=predicted_themes or [],
+        predicted_themes=predicted_themes or {},
         error=error,
     )
 
@@ -148,9 +148,9 @@ class TestMatchStories:
 class TestTierMetrics:
     def test_confusion_and_prf(self):
         results = [
-            _pred(predicted_scores={"simple": 5}, expected_tier="excellent",
+            _pred(predicted_scores={"simple": 3}, expected_tier="excellent",
                   predicted_tier="excellent"),
-            _pred(predicted_scores={"simple": 4}, expected_tier="excellent",
+            _pred(predicted_scores={"simple": 2}, expected_tier="excellent",
                   predicted_tier="good"),  # off-diagonal
             _pred(predicted_scores={"simple": 3}, expected_tier="good",
                   predicted_tier="good"),
@@ -179,7 +179,7 @@ class TestTierMetrics:
         failed = _pred(predicted_scores=None, expected_tier="good", predicted_tier="good")
         failed.scores_raw = "garbage the parser rejected"
         results = [
-            _pred(predicted_scores={"simple": 5}, expected_tier="excellent",
+            _pred(predicted_scores={"simple": 3}, expected_tier="excellent",
                   predicted_tier="excellent"),
             failed,
         ]
@@ -230,8 +230,8 @@ class TestDimensionMetrics:
     def test_only_over_stories_with_both_scores(self):
         results = [
             _pred(
-                expected_scores={"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
-                predicted_scores={"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
+                expected_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
+                predicted_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
             ),
             # parse failure -> excluded entirely
             _pred(expected_scores={"simple": 1}, predicted_scores=None),
@@ -299,18 +299,6 @@ class TestMultilabelThemeMetrics:
         # Detection (secondary): both are >=Present -> a true positive.
         det = compute_multilabel_metrics(results, THEMES, positive="detection")
         assert det["per_theme"]["scripture"]["f1"] == 1.0
-
-    def test_legacy_list_themes_are_present_not_emphasized(self):
-        # Old records store a present-only list; it counts as detected (Present)
-        # but never as Emphasized.
-        results = [
-            _pred(expected_themes=["scripture"], predicted_themes=["scripture"],
-                  predicted_scores={"simple": 3}),
-        ]
-        det = compute_multilabel_metrics(results, THEMES, positive="detection")
-        assert det["per_theme"]["scripture"]["f1"] == 1.0
-        emph = compute_multilabel_metrics(results, THEMES, positive="emphasized")
-        assert emph["per_theme"]["scripture"]["f1"] == 0.0
 
 
 
@@ -460,11 +448,12 @@ class TestThemeMetricsGating:
         # Story with malformed quality response (predicted_scores None) but a
         # perfectly parsed theme prediction must still count in theme metrics.
         results = [
-            _pred(story_id="ok", expected_themes=["church"], predicted_themes=["church"],
+            _pred(story_id="ok", expected_themes={"church": "emphasized"},
+                  predicted_themes={"church": "emphasized"},
                   predicted_scores={"simple": 3}),
         ]
-        failed = _pred(story_id="priya", expected_themes=["christlikeness"],
-                       predicted_themes=[], predicted_scores=None)
+        failed = _pred(story_id="priya", expected_themes={"christlikeness": "emphasized"},
+                       predicted_themes={}, predicted_scores=None)
         failed.themes_raw = "NONE"
         results.append(failed)
         m = compute_multilabel_metrics(results, THEMES)
@@ -473,7 +462,7 @@ class TestThemeMetricsGating:
         assert m["per_theme"]["christlikeness"]["recall"] == 0.0
 
     def test_error_rows_still_excluded(self):
-        errored = _pred(story_id="down", expected_themes=["church"],
+        errored = _pred(story_id="down", expected_themes={"church": "emphasized"},
                         error="connection refused")
         m = compute_multilabel_metrics([errored], THEMES)
         assert m["count"] == 0
@@ -506,7 +495,7 @@ class TestTierQualityNotAttempted:
         # scores_raw=None. Those rows are "quality not attempted", not parse
         # failures — the tier section must not render as "0 stories, N errors".
         row = _pred(story_id="t:0", expected_tier="good",
-                    expected_themes=["church"], predicted_themes=["church"])
+                    expected_themes={"church": "emphasized"}, predicted_themes={"church": "emphasized"})
         row.themes_raw = "CHURCH"
         m = compute_tier_metrics([row])
         assert m["errors"] == 0
@@ -527,7 +516,7 @@ class TestTierQualityNotAttempted:
         # In a --mode themes run the quality call is never in play, so a theme
         # call's network error must not render a misleading tier section
         # ("0 stories, 1 error"). The run's mode comes from RunMeta.
-        errored = _pred(story_id="down", expected_themes=["church"],
+        errored = _pred(story_id="down", expected_themes={"church": "emphasized"},
                         error="connection refused")
         path = tmp_path / "themes_run.jsonl"
         _write_results(path, _meta(mode="themes"), [errored])
@@ -539,8 +528,8 @@ class TestTierQualityNotAttempted:
         assert "Tier Classification" not in out
 
     def test_verbose_failures_section_excludes_not_attempted(self, capsys):
-        row = _pred(story_id="t:0", expected_themes=["church"],
-                    predicted_themes=["church"])
+        row = _pred(story_id="t:0", expected_themes={"church": "emphasized"},
+                    predicted_themes={"church": "emphasized"})
         row.themes_raw = "CHURCH"
         metrics = compute_all_metrics([row])
         print_report(_meta(mode="themes"), metrics, verbose=True, story_results=[row])
@@ -580,7 +569,7 @@ class TestThemeParseAnomalies:
 
     def test_rows_without_raw_are_skipped(self):
         # Legacy rows / error rows carry no themes_raw -> no anomaly.
-        anomalies = theme_parse_anomalies([_pred(story_id="x", predicted_themes=[])])
+        anomalies = theme_parse_anomalies([_pred(story_id="x", predicted_themes={})])
         assert anomalies == []
 
 
@@ -661,7 +650,7 @@ class TestPrintReportSections:
         assert "storys" not in out
 
     def test_theme_anomaly_count_shown(self, capsys):
-        row = _pred(story_id="g:0", predicted_themes=["church"],
+        row = _pred(story_id="g:0", predicted_themes={"church": "emphasized"},
                     predicted_scores={"simple": 3})
         row.themes_raw = "FELLOWSHIP\nCHURCH"
         metrics = compute_all_metrics([row])
@@ -745,7 +734,7 @@ class TestPrintReportVerbose:
         # Quality parse failed but themes parsed fine and disagree -> the story
         # must still appear in Story Disagreements.
         failed = _pred(story_id="g:2", predicted_scores=None,
-                       expected_themes=["christlikeness"], predicted_themes=[])
+                       expected_themes={"christlikeness": "emphasized"}, predicted_themes={})
         failed.themes_raw = "NONE"
         metrics = compute_all_metrics([failed])
         print_report(_meta(), metrics, verbose=True, story_results=[failed])
@@ -755,7 +744,7 @@ class TestPrintReportVerbose:
         assert "christlikeness" in section
 
     def test_verbose_shows_theme_anomaly_raw(self, capsys):
-        row = _pred(story_id="g:1", predicted_themes=[],
+        row = _pred(story_id="g:1", predicted_themes={},
                     predicted_scores={"simple": 3})
         row.themes_raw = "The themes of hope and belonging shine through."
         metrics = compute_all_metrics([row])
@@ -810,7 +799,7 @@ class TestPrintComparisonModes:
         results = [
             _pred(story_id="s", predicted_scores={"simple": 3},
                   expected_tier="good", predicted_tier="good",
-                  expected_themes=["church"], predicted_themes=["church"]),
+                  expected_themes={"church": "emphasized"}, predicted_themes={"church": "emphasized"}),
         ]
         return compute_all_metrics(results)
 
@@ -863,13 +852,14 @@ class TestVerboseCompareThemesMode:
     def test_theme_flip_shown_when_quality_never_ran(self, capsys):
         # --mode themes rows never have predicted_scores; a theme flip between
         # runs must still be listed (not "None!") under Per-story Flips.
-        def row(themes):
-            r = _pred(story_id="s", expected_themes=["church"],
+        def row(themes):  # themes: {name: grade}
+            r = _pred(story_id="s", expected_themes={"church": "emphasized"},
                       predicted_themes=themes)
-            r.themes_raw = "\n".join(t.upper() for t in themes) or "NONE"
+            r.themes_raw = "\n".join(f"{t.upper()}: EMPHASIZED" for t in themes) or "NONE"
             return r
 
-        story1, story2 = [row(["church"])], [row(["scripture"])]
+        story1 = [row({"church": "emphasized"})]
+        story2 = [row({"scripture": "emphasized"})]
         m1 = compute_all_metrics(story1)
         m2 = compute_all_metrics(story2)
         print_comparison(_meta(mode="themes"), m1, _meta(mode="themes"), m2,
@@ -884,7 +874,7 @@ class TestTrendRows:
     def _write_two_runs(self, tmp_path):
         story = _pred(story_id="s", predicted_scores={"simple": 3},
                       expected_tier="good", predicted_tier="good",
-                      predicted_themes=["church"], expected_themes=["church"])
+                      predicted_themes={"church": "emphasized"}, expected_themes={"church": "emphasized"})
         # File names sort in the OPPOSITE order of their timestamps, so
         # chronological ordering must come from run_meta.timestamp.
         _write_results(
@@ -989,7 +979,7 @@ class TestCliJsonAndErrors:
     def _write_run(self, path, **meta_kwargs):
         story = _pred(story_id="s", predicted_scores={"simple": 3},
                       expected_tier="good", predicted_tier="good",
-                      predicted_themes=["church"], expected_themes=["church"])
+                      predicted_themes={"church": "emphasized"}, expected_themes={"church": "emphasized"})
         _write_results(path, _meta(**meta_kwargs), [story])
 
     def test_compare_format_json_emits_json(self, tmp_path, monkeypatch, capsys):

--- a/tests/test_eval_newsletter_report.py
+++ b/tests/test_eval_newsletter_report.py
@@ -15,7 +15,6 @@ from evals.newsletter_report import (
     compute_all_metrics,
     compute_dimension_exact_match,
     compute_dimension_mae,
-    compute_dimension_within1,
     compute_extraction_metrics,
     compute_multilabel_metrics,
     compute_tier_metrics,
@@ -198,24 +197,25 @@ class TestTierMetrics:
 
 
 class TestDimensionMetrics:
-    def test_mae_and_exact_and_within1(self):
+    def test_mae_and_exact(self):
+        # 1-3 (Poor/OK/Good) scores; within-1 was dropped (#53) as degenerate.
         results = [
             _pred(
-                expected_scores={"simple": 5, "concrete": 3, "personal": 4, "dynamic": 2},
-                predicted_scores={"simple": 5, "concrete": 1, "personal": 5, "dynamic": 2},
+                expected_scores={"simple": 3, "concrete": 2, "personal": 3, "dynamic": 1},
+                predicted_scores={"simple": 3, "concrete": 1, "personal": 1, "dynamic": 1},
             ),
             _pred(
-                expected_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
-                predicted_scores={"simple": 4, "concrete": 2, "personal": 2, "dynamic": 2},
+                expected_scores={"simple": 1, "concrete": 2, "personal": 2, "dynamic": 2},
+                predicted_scores={"simple": 3, "concrete": 2, "personal": 2, "dynamic": 2},
             ),
         ]
         mae = compute_dimension_mae(results)
-        # simple: |5-5|=0, |2-4|=2 -> mean 1.0
+        # simple: |3-3|=0, |1-3|=2 -> mean 1.0
         assert abs(mae["simple"] - 1.0) < 1e-9
-        # concrete: |3-1|=2, |2-2|=0 -> mean 1.0
-        assert abs(mae["concrete"] - 1.0) < 1e-9
-        # personal: |4-5|=1, |2-2|=0 -> mean 0.5
-        assert abs(mae["personal"] - 0.5) < 1e-9
+        # concrete: |2-1|=1, |2-2|=0 -> mean 0.5
+        assert abs(mae["concrete"] - 0.5) < 1e-9
+        # personal: |3-1|=2, |2-2|=0 -> mean 1.0
+        assert abs(mae["personal"] - 1.0) < 1e-9
         # dynamic: 0, 0 -> 0.0
         assert abs(mae["dynamic"] - 0.0) < 1e-9
 
@@ -226,12 +226,6 @@ class TestDimensionMetrics:
         assert abs(exact["dynamic"] - 1.0) < 1e-9
         # concrete: row1 wrong, row2 exact -> 1/2
         assert abs(exact["concrete"] - 0.5) < 1e-9
-
-        within1 = compute_dimension_within1(results)
-        # personal: diff 1 and 0 both within 1 -> 1.0
-        assert abs(within1["personal"] - 1.0) < 1e-9
-        # simple: diff 0 (within) and 2 (not) -> 1/2
-        assert abs(within1["simple"] - 0.5) < 1e-9
 
     def test_only_over_stories_with_both_scores(self):
         results = [
@@ -253,49 +247,70 @@ class TestDimensionMetrics:
 
 
 class TestMultilabelThemeMetrics:
+    # The default (PRIMARY) metric is positive=emphasized — what earns a Gmail
+    # label (issue #53 / A′). "detection" (>=Present) is the secondary metric.
     def test_per_theme_micro_macro_and_exact_set(self):
-        # Story 1: expected {scripture, church}, predicted {scripture}
+        # Story 1: expected {scripture, church} emphasized, predicted {scripture}
         #   scripture: TP; church: FN
         # Story 2: expected {christlikeness}, predicted {christlikeness, church}
         #   christlikeness: TP; church: FP
         results = [
-            _pred(expected_themes=["scripture", "church"], predicted_themes=["scripture"],
+            _pred(expected_themes={"scripture": "emphasized", "church": "emphasized"},
+                  predicted_themes={"scripture": "emphasized"},
                   predicted_scores={"simple": 3}),
-            _pred(expected_themes=["christlikeness"],
-                  predicted_themes=["christlikeness", "church"],
+            _pred(expected_themes={"christlikeness": "emphasized"},
+                  predicted_themes={"christlikeness": "emphasized", "church": "emphasized"},
                   predicted_scores={"simple": 3}),
         ]
         m = compute_multilabel_metrics(results, THEMES)
 
-        # scripture: TP=1, FP=0, FN=0 -> P=R=F1=1
         assert m["per_theme"]["scripture"]["f1"] == 1.0
-        # church: TP=0, FP=1, FN=1 -> P=0, R=0, F1=0
         assert m["per_theme"]["church"]["precision"] == 0.0
         assert m["per_theme"]["church"]["recall"] == 0.0
-        # christlikeness: TP=1 -> F1=1
         assert m["per_theme"]["christlikeness"]["f1"] == 1.0
-
-        # Micro: TP=2, FP=1, FN=1 -> P=2/3, R=2/3, F1=2/3
+        # Micro: TP=2, FP=1, FN=1 -> F1=2/3
         assert abs(m["micro_f1"] - (2 / 3)) < 1e-9
-
-        # Macro F1: mean over 5 themes.
-        # scripture=1, christlikeness=1, church=0, vocation_family=0(no support->0),
-        # disciple_making=0 -> (1+1+0+0+0)/5 = 0.4
+        # Macro F1: (1+1+0+0+0)/5 = 0.4
         assert abs(m["macro_f1"] - 0.4) < 1e-9
-
-        # Exact set match: neither story matches exactly -> 0/2
         assert m["exact_set_match"] == 0.0
 
     def test_exact_set_match_positive(self):
         results = [
-            _pred(expected_themes=["scripture"], predicted_themes=["scripture"],
+            _pred(expected_themes={"scripture": "emphasized"},
+                  predicted_themes={"scripture": "emphasized"},
                   predicted_scores={"simple": 3}),
-            _pred(expected_themes=["church", "scripture"],
-                  predicted_themes=["scripture", "church"],  # order-insensitive
+            _pred(expected_themes={"church": "emphasized", "scripture": "emphasized"},
+                  predicted_themes={"scripture": "emphasized", "church": "emphasized"},
                   predicted_scores={"simple": 3}),
         ]
         m = compute_multilabel_metrics(results, THEMES)
         assert m["exact_set_match"] == 1.0
+
+    def test_emphasized_vs_detection_positive(self):
+        # Golden PRESENT, predicted EMPHASIZED: an over-grade.
+        results = [
+            _pred(expected_themes={"scripture": "present"},
+                  predicted_themes={"scripture": "emphasized"},
+                  predicted_scores={"simple": 3}),
+        ]
+        # Emphasized (primary): expected is not emphasized -> a false positive.
+        emph = compute_multilabel_metrics(results, THEMES, positive="emphasized")
+        assert emph["per_theme"]["scripture"]["precision"] == 0.0
+        # Detection (secondary): both are >=Present -> a true positive.
+        det = compute_multilabel_metrics(results, THEMES, positive="detection")
+        assert det["per_theme"]["scripture"]["f1"] == 1.0
+
+    def test_legacy_list_themes_are_present_not_emphasized(self):
+        # Old records store a present-only list; it counts as detected (Present)
+        # but never as Emphasized.
+        results = [
+            _pred(expected_themes=["scripture"], predicted_themes=["scripture"],
+                  predicted_scores={"simple": 3}),
+        ]
+        det = compute_multilabel_metrics(results, THEMES, positive="detection")
+        assert det["per_theme"]["scripture"]["f1"] == 1.0
+        emph = compute_multilabel_metrics(results, THEMES, positive="emphasized")
+        assert emph["per_theme"]["scripture"]["f1"] == 0.0
 
 
 
@@ -783,11 +798,11 @@ class TestDimTableAlignment:
     def test_data_rows_align_with_header(self):
         mae = {d: 0.5 for d in ["simple", "concrete", "personal", "dynamic"]}
         exact = {d: 0.5 for d in mae}
-        within = {d: 1.0 for d in mae}
-        lines = _format_dim_table(mae, exact, within).splitlines()
+        lines = _format_dim_table(mae, exact).splitlines()
         header, first_row = lines[0], lines[2]
         # The MAE column must start at the same offset in header and data rows.
         assert first_row.index("0.50") == header.index("MAE")
+        assert "Within-1" not in header
 
 
 class TestPrintComparisonModes:
@@ -907,7 +922,8 @@ class TestJsonOutput:
     def _story_and_extraction(self):
         story = _pred(story_id="s", predicted_scores={"simple": 3},
                       expected_tier="good", predicted_tier="good",
-                      expected_themes=["church"], predicted_themes=["church"])
+                      expected_themes={"church": "emphasized"},
+                      predicted_themes={"church": "emphasized"})
         extraction = ExtractionPrediction(
             thread_id="A",
             golden_stories=[{"story_id": "A:0", "text": "alpha faith"}],
@@ -923,8 +939,9 @@ class TestJsonOutput:
         assert set(data) == {"meta", "metrics"}
         assert data["meta"]["run_id"] == "abcdef0123456789"
         for key in ("story_count", "tier", "dimension_mae", "dimension_exact",
-                    "dimension_within1", "themes", "theme_anomalies", "extraction"):
+                    "themes", "themes_detection", "theme_anomalies", "extraction"):
             assert key in data["metrics"]
+        assert "dimension_within1" not in data["metrics"]  # dropped (#53)
         assert data["metrics"]["tier"]["accuracy"] == 1.0
         assert data["metrics"]["extraction"]["micro_f1"] == 1.0
 
@@ -1109,10 +1126,11 @@ class TestComparisonDeltaSign:
     def test_compute_all_metrics_bundles_sections(self):
         results = [
             _pred(
-                expected_scores={"simple": 5, "concrete": 5, "personal": 5, "dynamic": 5},
-                predicted_scores={"simple": 5, "concrete": 5, "personal": 5, "dynamic": 5},
+                expected_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+                predicted_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
                 expected_tier="excellent", predicted_tier="excellent",
-                expected_themes=["scripture"], predicted_themes=["scripture"],
+                expected_themes={"scripture": "emphasized"},
+                predicted_themes={"scripture": "emphasized"},
             ),
         ]
         extraction = [

--- a/tests/test_eval_newsletter_report.py
+++ b/tests/test_eval_newsletter_report.py
@@ -535,20 +535,28 @@ class TestTierQualityNotAttempted:
 
 class TestThemeParseAnomalies:
     def test_invalid_token_and_empty_parse_detected(self):
-        marcus = _pred(story_id="g:0", predicted_themes=["church"],
+        # Graded NAME: GRADE format (issue #53).
+        marcus = _pred(story_id="g:0", predicted_themes={"church": "emphasized"},
                        predicted_scores={"simple": 3})
-        marcus.themes_raw = "FELLOWSHIP\nCHURCH"
-        alina = _pred(story_id="g:1", predicted_themes=[],
+        marcus.themes_raw = "FELLOWSHIP: PRESENT\nCHURCH: EMPHASIZED"
+        alina = _pred(story_id="g:1", predicted_themes={},
                       predicted_scores={"simple": 3})
         alina.themes_raw = "The themes of hope and belonging shine through this piece."
-        clean_none = _pred(story_id="g:2", predicted_themes=[],
+        clean_none = _pred(story_id="g:2", predicted_themes={},
                            predicted_scores={"simple": 3})
         clean_none.themes_raw = "NONE"
-        clean = _pred(story_id="g:3", predicted_themes=["scripture"],
+        clean = _pred(story_id="g:3", predicted_themes={"scripture": "present"},
                       predicted_scores={"simple": 3})
-        clean.themes_raw = "SCRIPTURE"
-        anomalies = theme_parse_anomalies([marcus, alina, clean_none, clean])
+        clean.themes_raw = "SCRIPTURE: PRESENT"
+        all_absent = _pred(story_id="g:4", predicted_themes={},
+                           predicted_scores={"simple": 3})
+        all_absent.themes_raw = (
+            "SCRIPTURE: ABSENT\nCHRISTLIKENESS: ABSENT\nCHURCH: ABSENT\n"
+            "VOCATION_FAMILY: ABSENT\nDISCIPLE_MAKING: ABSENT"
+        )
+        anomalies = theme_parse_anomalies([marcus, alina, clean_none, clean, all_absent])
         by_id = {a["story_id"]: a for a in anomalies}
+        # g:2 (NONE), g:3 (valid), g:4 (all-ABSENT = valid empty) are NOT anomalies.
         assert set(by_id) == {"g:0", "g:1"}
         assert by_id["g:0"]["kind"] == "invalid_tokens"
         assert by_id["g:0"]["invalid_tokens"] == ["FELLOWSHIP"]

--- a/tests/test_eval_newsletter_report.py
+++ b/tests/test_eval_newsletter_report.py
@@ -743,6 +743,23 @@ class TestPrintReportVerbose:
         assert "g:2" in section
         assert "christlikeness" in section
 
+    def test_verbose_disagreements_show_grade_only_theme_mismatch(self, capsys):
+        # Same theme KEY, different grade (present vs emphasized): an FP/FN in the
+        # primary Emphasized metric. Key-set equality hides it, so the story must
+        # still be listed under Story Disagreements with grade-aware detail.
+        row = _pred(story_id="g:5", predicted_scores={"simple": 3},
+                    expected_tier="good", predicted_tier="good",
+                    expected_themes={"scripture": "present"},
+                    predicted_themes={"scripture": "emphasized"})
+        metrics = compute_all_metrics([row])
+        print_report(_meta(), metrics, verbose=True, story_results=[row])
+        out = capsys.readouterr().out
+        section = out.split("Story Disagreements")[1]
+        assert "g:5" in section
+        assert "scripture" in section
+        assert "present" in section
+        assert "emphasized" in section
+
     def test_verbose_shows_theme_anomaly_raw(self, capsys):
         row = _pred(story_id="g:1", predicted_themes={},
                     predicted_scores={"simple": 3})
@@ -847,6 +864,23 @@ class TestPrintComparisonModes:
         good_row = next(ln for ln in out.splitlines() if "good F1" in ln)
         assert "N/A" in good_row
 
+    def test_themes_section_shows_detection_f1_rows(self, capsys):
+        # print_report shows a detection (>=Present) line for each single run;
+        # compare mode must too, or a detection-level regression between runs is
+        # invisible. Build a run where detection F1 (100%) differs from the
+        # Emphasized F1 (0%) so the detection rows are distinguishable.
+        row = _pred(story_id="s", predicted_scores={"simple": 3},
+                    expected_themes={"scripture": "present"},
+                    predicted_themes={"scripture": "present"})
+        m = compute_all_metrics([row])
+        print_comparison(_meta(mode="all"), m, _meta(mode="all"), m)
+        out = capsys.readouterr().out
+        themes_section = out.split("--- Themes ---")[1].split("--- Extraction ---")[0]
+        assert "Detection" in themes_section
+        # Detection micro-F1 = 100% (scripture Present in both), while the
+        # Emphasized micro-F1 above it is 0%.
+        assert "100.0%" in themes_section
+
 
 class TestVerboseCompareThemesMode:
     def test_theme_flip_shown_when_quality_never_ran(self, capsys):
@@ -868,6 +902,28 @@ class TestVerboseCompareThemesMode:
         flips = out.split("Per-story Flips")[1]
         assert "None!" not in flips
         assert "church" in flips and "scripture" in flips
+
+    def test_grade_only_theme_flip_shown(self, capsys):
+        # Same theme KEY, grade changed present->emphasized between runs. Key-set
+        # equality hides the flip even though it moves the Emphasized F1 shown in
+        # the table; it must be listed with grade-aware detail (not "None!").
+        def row(grade):
+            r = _pred(story_id="s", expected_themes={"scripture": "present"},
+                      predicted_themes={"scripture": grade})
+            r.themes_raw = f"SCRIPTURE: {grade.upper()}"
+            return r
+
+        story1 = [row("present")]
+        story2 = [row("emphasized")]
+        m1 = compute_all_metrics(story1)
+        m2 = compute_all_metrics(story2)
+        print_comparison(_meta(mode="themes"), m1, _meta(mode="themes"), m2,
+                         verbose=True, story1=story1, story2=story2)
+        out = capsys.readouterr().out
+        flips = out.split("Per-story Flips")[1]
+        assert "None!" not in flips
+        assert "scripture" in flips
+        assert "present" in flips and "emphasized" in flips
 
 
 class TestTrendRows:

--- a/tests/test_eval_newsletter_report.py
+++ b/tests/test_eval_newsletter_report.py
@@ -572,6 +572,28 @@ class TestThemeParseAnomalies:
         anomalies = theme_parse_anomalies([_pred(story_id="x", predicted_themes={})])
         assert anomalies == []
 
+    def test_near_miss_line_flagged(self):
+        # A near-miss line (misspelled grade) parse_themes silently drops must
+        # surface even though the response otherwise parsed — else a systematic
+        # parser gap reads as a genuine model miss (Finding 3).
+        row = _pred(story_id="n:0", predicted_themes={"scripture": "present"},
+                    predicted_scores={"simple": 3})
+        row.themes_raw = "SCRIPTURE: PRESENT\nCHURCH: EMPHASISED"
+        anomalies = theme_parse_anomalies([row])
+        assert len(anomalies) == 1
+        assert anomalies[0]["story_id"] == "n:0"
+        assert anomalies[0]["kind"] == "near_miss"
+        assert "CHURCH: EMPHASISED" in anomalies[0]["near_miss_lines"]
+
+    def test_bulleted_valid_response_is_not_flagged(self):
+        # Coherence with Finding 1: once parse_themes tolerates bullets, a bulleted
+        # VALID response must not be an anomaly.
+        row = _pred(story_id="b:0",
+                    predicted_themes={"scripture": "present", "church": "emphasized"},
+                    predicted_scores={"simple": 3})
+        row.themes_raw = "- SCRIPTURE: PRESENT\n- CHURCH: EMPHASIZED"
+        assert theme_parse_anomalies([row]) == []
+
 
 class TestThemeListSingleSource:
     def test_report_themes_match_newsletter_valid_themes(self):

--- a/tests/test_eval_newsletter_run.py
+++ b/tests/test_eval_newsletter_run.py
@@ -238,8 +238,8 @@ class TestEvaluateExtraction:
 
 class TestEvaluateStory:
     def _story_llm(self):
-        quality_out = "SIMPLE: 4\nCONCRETE: 5\nPERSONAL: 4\nDYNAMIC: 3"
-        theme_out = "SCRIPTURE\nCHURCH"
+        quality_out = "SIMPLE: GOOD\nCONCRETE: GOOD\nPERSONAL: GOOD\nDYNAMIC: OK"
+        theme_out = "SCRIPTURE: EMPHASIZED\nCHURCH: PRESENT"
         return FakeLLM([
             ("QUALITY", quality_out, "quality reasoning"),
             ("THEME", theme_out, "theme reasoning"),
@@ -249,24 +249,24 @@ class TestEvaluateStory:
         llm = self._story_llm()
         story = _story(
             "nl1:0", text="the text",
-            expected_scores={"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4},
-            expected_tier="excellent", expected_themes=["scripture"],
+            expected_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+            expected_tier="excellent", expected_themes={"scripture": "emphasized"},
         )
         pred, thinking = _run(evaluate_story(story, "nl1", _classifier(llm)))
 
         assert pred.story_id == "nl1:0"
         assert pred.thread_id == "nl1"
         # expected_* carried from the golden story
-        assert pred.expected_scores == {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}
+        assert pred.expected_scores == {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}
         assert pred.expected_tier == "excellent"
-        assert pred.expected_themes == ["scripture"]
+        assert pred.expected_themes == {"scripture": "emphasized"}
         # predicted_*
-        assert pred.predicted_scores == {"simple": 4, "concrete": 5, "personal": 4, "dynamic": 3}
-        assert pred.predicted_themes == ["scripture", "church"]
-        # tier derived via compute_tier: avg = (4+5+4+3)/4 = 4.0 -> excellent
+        assert pred.predicted_scores == {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 2}
+        assert pred.predicted_themes == {"scripture": "emphasized", "church": "present"}
+        # tier derived via compute_tier: avg = (3+3+3+2)/4 = 2.75 -> excellent
         assert pred.predicted_tier == "excellent"
         # raw captured
-        assert "SIMPLE: 4" in pred.scores_raw
+        assert "SIMPLE: GOOD" in pred.scores_raw
         assert "SCRIPTURE" in pred.themes_raw
         assert pred.error is None
         # thinking sidecar carries both cots
@@ -283,14 +283,14 @@ class TestEvaluateStory:
         pred, _thinking = _run(evaluate_story(story, "nl2", _classifier(llm)))
         assert pred.predicted_scores is None
         assert pred.predicted_tier is None
-        assert pred.predicted_themes == []
+        assert pred.predicted_themes == {}
 
 
 def _full_llm():
     return FakeLLM([
         ("EXTRACT", "STORY: body", "ecot"),
-        ("QUALITY", "SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3", "qcot"),
-        ("THEME", "SCRIPTURE", "tcot"),
+        ("QUALITY", "SIMPLE: GOOD\nCONCRETE: GOOD\nPERSONAL: OK\nDYNAMIC: OK", "qcot"),
+        ("THEME", "SCRIPTURE: PRESENT", "tcot"),
     ])
 
 
@@ -315,7 +315,7 @@ class TestRunEvaluation:
         # otherwise the test passes even when extraction is broken.
         assert extractions[0].predicted_stories == [{"text": "body"}]
         assert len(stories) == 1
-        assert stories[0].predicted_tier == "good"  # avg 3.0
+        assert stories[0].predicted_tier == "good"  # avg (3+3+2+2)/4 = 2.5
         story_entries = [t for t in thinking if t.story_id]
         assert story_entries[0].quality_cot == "qcot"
         # all-mode also carries a newsletter-level extraction thinking entry
@@ -363,7 +363,7 @@ class TestRunEvaluation:
         ))
         assert not any("THEME" in user for _sys, user in llm.calls)
         assert rows[0].predicted_scores is not None
-        assert rows[0].predicted_themes == []
+        assert rows[0].predicted_themes == {}
         assert rows[0].themes_raw is None
 
     def test_themes_mode_fires_no_quality_llm_calls(self):
@@ -372,7 +372,7 @@ class TestRunEvaluation:
             self._golden(), _classifier(llm), mode="themes", parallelism=1,
         ))
         assert not any("QUALITY" in user for _sys, user in llm.calls)
-        assert rows[0].predicted_themes == ["scripture"]
+        assert rows[0].predicted_themes == {"scripture": "present"}
         assert rows[0].predicted_scores is None
         assert rows[0].predicted_tier is None
         assert rows[0].scores_raw is None
@@ -452,38 +452,43 @@ class TestFormatRunSummary:
     def test_garbage_theme_response_is_a_parse_failure(self):
         from evals.newsletter_run import format_run_summary
         rows = [self._story_row(
-            scores_raw="SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3",
-            predicted_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
-            themes_raw="just some prose, no labels", predicted_themes=[],
+            scores_raw="SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK",
+            predicted_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
+            themes_raw="just some prose, no labels", predicted_themes={},
         )]
         assert "1 theme parse failure" in format_run_summary(rows)
 
     def test_none_theme_response_is_not_a_failure(self):
         from evals.newsletter_run import format_run_summary
         rows = [self._story_row(
-            scores_raw="SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3",
-            predicted_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
-            themes_raw="NONE", predicted_themes=[],
+            scores_raw="SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK",
+            predicted_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
+            themes_raw="NONE", predicted_themes={},
         )]
         assert "theme parse failure" not in format_run_summary(rows)
 
-    def test_clamped_scores_surfaced(self):
+    def test_all_absent_theme_response_is_not_a_failure(self):
+        # A response grading every theme ABSENT is a valid empty result (issue
+        # #53), not garbage — it must not count as a theme parse failure.
         from evals.newsletter_run import format_run_summary
         rows = [self._story_row(
-            scores_raw="SIMPLE: 9\nCONCRETE: 4\nPERSONAL: 3\nDYNAMIC: 2",
-            predicted_scores={"simple": 5, "concrete": 4, "personal": 3, "dynamic": 2},
-            themes_raw="NONE",
+            scores_raw="SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK",
+            predicted_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
+            themes_raw=(
+                "SCRIPTURE: ABSENT\nCHRISTLIKENESS: ABSENT\nCHURCH: ABSENT\n"
+                "VOCATION_FAMILY: ABSENT\nDISCIPLE_MAKING: ABSENT"
+            ),
+            predicted_themes={},
         )]
-        summary = format_run_summary(rows)
-        assert "clamped" in summary
-        assert "SIMPLE" in summary
+        assert "theme parse failure" not in format_run_summary(rows)
 
     def test_dropped_theme_tokens_surfaced(self):
         from evals.newsletter_run import format_run_summary
         rows = [self._story_row(
-            scores_raw="SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3",
-            predicted_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
-            themes_raw="FELLOWSHIP\nCHURCH", predicted_themes=["church"],
+            scores_raw="SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK",
+            predicted_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
+            themes_raw="FELLOWSHIP: PRESENT\nCHURCH: EMPHASIZED",
+            predicted_themes={"church": "emphasized"},
         )]
         assert "FELLOWSHIP" in format_run_summary(rows)
 
@@ -497,9 +502,9 @@ class TestFormatRunSummary:
     def test_clean_run_reports_no_errors(self):
         from evals.newsletter_run import format_run_summary
         rows = [self._story_row(
-            scores_raw="SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3",
-            predicted_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
-            themes_raw="SCRIPTURE", predicted_themes=["scripture"],
+            scores_raw="SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK",
+            predicted_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
+            themes_raw="SCRIPTURE: PRESENT", predicted_themes={"scripture": "present"},
         )]
         summary = format_run_summary(rows)
         assert "Rows: 1" in summary
@@ -1021,7 +1026,7 @@ class TestMainPreflight:
         def fake_build(config, no_cache):
             llm = DeadLLM([
                 ("EXTRACT", "NO_STORIES", ""),
-                ("QUALITY", "SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3", ""),
+                ("QUALITY", "SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK", ""),
                 ("THEME", "NONE", ""),
             ])
             return NewsletterClassifier(cloud_llm=llm, config=config), llm
@@ -1061,7 +1066,7 @@ class TestMainReport:
             stories=[_story(
                 "nl1:0", text="body",
                 expected_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
-                expected_tier="good", expected_themes=["scripture"],
+                expected_tier="good", expected_themes={"scripture": "present"},
             )],
         )])
         out = tmp_path / "r"
@@ -1080,7 +1085,7 @@ class TestMainReport:
             stories=[_story(
                 "nl1:0", text="body",
                 expected_scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
-                expected_tier="good", expected_themes=["scripture"],
+                expected_tier="good", expected_themes={"scripture": "present"},
             )],
         )])
         # First run to produce a prior results file to compare against.

--- a/tests/test_eval_newsletter_run.py
+++ b/tests/test_eval_newsletter_run.py
@@ -932,6 +932,48 @@ class TestEndpointNaming:
             )))
         assert "model name does not match" in capsys.readouterr().err
 
+    def test_preflight_non_404_status_shown(self, tmp_path, monkeypatch, capsys):
+        # Finding 1: a non-404 status (e.g. 401 bad key) must be surfaced so the
+        # user can distinguish a bad key from a down server or a name mismatch.
+        class BadKey(FakeLLM):
+            async def probe(self, timeout=None):
+                from llm_client import AvailabilityResult
+                return AvailabilityResult(ok=False, status_code=401)
+
+        def fake_build(config, no_cache):
+            llm = BadKey([])
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter("nl1", reviewed=True, stories=[_story("nl1:0", text="b")])])
+        with pytest.raises(SystemExit):
+            asyncio.run(newsletter_run.main(_main_args(
+                golden_set=str(golden), output_dir=str(tmp_path / "r"), skip_preflight=False,
+            )))
+        err = capsys.readouterr().err
+        assert "401" in err
+        assert "model name does not match" not in err
+
+    def test_preflight_connection_error_shown(self, tmp_path, monkeypatch, capsys):
+        # Finding 1: probe()'s captured exception text must appear so a down
+        # server / bad URL is distinguishable from a bad key.
+        class Refused(FakeLLM):
+            async def probe(self, timeout=None):
+                from llm_client import AvailabilityResult
+                return AvailabilityResult(ok=False, error="ConnectError: Connection refused")
+
+        def fake_build(config, no_cache):
+            llm = Refused([])
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter("nl1", reviewed=True, stories=[_story("nl1:0", text="b")])])
+        with pytest.raises(SystemExit):
+            asyncio.run(newsletter_run.main(_main_args(
+                golden_set=str(golden), output_dir=str(tmp_path / "r"), skip_preflight=False,
+            )))
+        assert "ConnectError" in capsys.readouterr().err
+
     def test_preflight_down_omits_model_mismatch_hint(self, tmp_path, monkeypatch, capsys):
         # No HTTP response (status None) -> plain unreachable, no model-mismatch hint.
         class Down(FakeLLM):

--- a/tests/test_eval_newsletter_run.py
+++ b/tests/test_eval_newsletter_run.py
@@ -496,6 +496,34 @@ class TestFormatRunSummary:
         )]
         assert "FELLOWSHIP" in format_run_summary(rows)
 
+    def test_theme_near_miss_line_surfaced(self):
+        # A near-miss line (misspelled grade) that parse_themes silently drops
+        # must surface — otherwise a systematic parser gap reads as a model miss
+        # (Finding 3). The response otherwise looks fine (one valid grading), so
+        # it is NOT a garbage/empty parse.
+        from evals.newsletter_run import format_run_summary
+        rows = [self._story_row(
+            scores_raw="SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK",
+            predicted_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
+            themes_raw="SCRIPTURE: PRESENT\nCHURCH: EMPHASISED",
+            predicted_themes={"scripture": "present"},
+        )]
+        summary = format_run_summary(rows)
+        assert "EMPHASISED" in summary
+        assert "theme parse failure" not in summary  # not garbage: it had a grading
+
+    def test_bulleted_valid_themes_are_not_a_near_miss(self):
+        # Coherence with Finding 1: once parse_themes tolerates bullets, a bulleted
+        # VALID response must be clean — no near-miss, no parse failure.
+        from evals.newsletter_run import format_run_summary
+        rows = [self._story_row(
+            scores_raw="SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK",
+            predicted_scores={"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
+            themes_raw="- SCRIPTURE: PRESENT\n- CHURCH: EMPHASIZED",
+            predicted_themes={"scripture": "present", "church": "emphasized"},
+        )]
+        assert "no errors" in format_run_summary(rows)
+
     def test_error_grammar_is_singular(self):
         from evals.newsletter_run import format_run_summary
         rows = [self._story_row(error="boom")]

--- a/tests/test_eval_newsletter_run.py
+++ b/tests/test_eval_newsletter_run.py
@@ -52,6 +52,10 @@ class FakeLLM:
     async def is_available(self, timeout=None):
         return True
 
+    async def probe(self, timeout=None):
+        from llm_client import AvailabilityResult
+        return AvailabilityResult(ok=await self.is_available(timeout))
+
 
 def _classifier(llm):
     config = _prompts_config()
@@ -880,6 +884,43 @@ class TestEndpointNaming:
         err = capsys.readouterr().err
         assert "http://127.0.0.1:8499/v1" in err
         assert "NEWSLETTER_LLM_URL" in err
+
+    def test_preflight_404_shows_model_mismatch_hint(self, tmp_path, monkeypatch, capsys):
+        # Issue #41 item 7: the model-mismatch hint appears only on an actual 404.
+        class Mismatch(FakeLLM):
+            async def probe(self, timeout=None):
+                from llm_client import AvailabilityResult
+                return AvailabilityResult(ok=False, status_code=404)
+
+        def fake_build(config, no_cache):
+            llm = Mismatch([])
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter("nl1", reviewed=True, stories=[_story("nl1:0", text="b")])])
+        with pytest.raises(SystemExit):
+            asyncio.run(newsletter_run.main(_main_args(
+                golden_set=str(golden), output_dir=str(tmp_path / "r"), skip_preflight=False,
+            )))
+        assert "model name does not match" in capsys.readouterr().err
+
+    def test_preflight_down_omits_model_mismatch_hint(self, tmp_path, monkeypatch, capsys):
+        # No HTTP response (status None) -> plain unreachable, no model-mismatch hint.
+        class Down(FakeLLM):
+            async def is_available(self, timeout=None):
+                return False
+
+        def fake_build(config, no_cache):
+            llm = Down([])
+            return NewsletterClassifier(cloud_llm=llm, config=config), llm
+        monkeypatch.setattr(newsletter_run, "build_classifier", fake_build)
+        golden = tmp_path / "g.jsonl"
+        _write_golden(golden, [_newsletter("nl1", reviewed=True, stories=[_story("nl1:0", text="b")])])
+        with pytest.raises(SystemExit):
+            asyncio.run(newsletter_run.main(_main_args(
+                golden_set=str(golden), output_dir=str(tmp_path / "r"), skip_preflight=False,
+            )))
+        assert "model name does not match" not in capsys.readouterr().err
 
 
 class TestReportForwarding:

--- a/tests/test_eval_newsletter_schemas.py
+++ b/tests/test_eval_newsletter_schemas.py
@@ -50,14 +50,6 @@ class TestGoldenStory:
         assert s.notes == ""
         assert s.excluded is False
 
-    def test_legacy_list_themes_coerced_to_present(self):
-        # Golden sets written under the old boolean scheme carry a present-only
-        # list; loading them coerces each to grade "present" (issue #53).
-        s = GoldenStory.from_dict(
-            {"story_id": "x:0", "text": "B", "expected_themes": ["scripture", "church"]}
-        )
-        assert s.expected_themes == {"scripture": "present", "church": "present"}
-
     def test_legacy_title_key_is_tolerated(self):
         # Golden sets written before titles were removed still carry a "title"
         # key; loading them must ignore the extra key, not crash.
@@ -184,18 +176,6 @@ class TestStoryPrediction:
         assert p.themes_raw is None
         assert p.duration_seconds == 0.0
         assert p.error is None
-
-    def test_legacy_list_themes_coerced_to_present(self):
-        p = StoryPrediction.from_dict(
-            {
-                "story_id": "x:0",
-                "thread_id": "x",
-                "expected_themes": ["scripture"],
-                "predicted_themes": ["scripture", "church"],
-            }
-        )
-        assert p.expected_themes == {"scripture": "present"}
-        assert p.predicted_themes == {"scripture": "present", "church": "present"}
 
 
 class TestExtractionPrediction:

--- a/tests/test_eval_newsletter_schemas.py
+++ b/tests/test_eval_newsletter_schemas.py
@@ -17,9 +17,9 @@ class TestGoldenStory:
         s = GoldenStory(
             story_id="t_001:0",
             text="The full story text goes here.",
-            expected_scores={"simple": 4, "concrete": 5, "personal": 3, "dynamic": 2},
+            expected_scores={"simple": 3, "concrete": 3, "personal": 2, "dynamic": 1},
             expected_tier="good",
-            expected_themes=["scripture", "church"],
+            expected_themes={"scripture": "emphasized", "church": "present"},
             reviewed=True,
             notes="clear story",
             excluded=False,
@@ -30,13 +30,13 @@ class TestGoldenStory:
         assert restored.story_id == "t_001:0"
         assert restored.text == "The full story text goes here."
         assert restored.expected_scores == {
-            "simple": 4,
-            "concrete": 5,
-            "personal": 3,
-            "dynamic": 2,
+            "simple": 3,
+            "concrete": 3,
+            "personal": 2,
+            "dynamic": 1,
         }
         assert restored.expected_tier == "good"
-        assert restored.expected_themes == ["scripture", "church"]
+        assert restored.expected_themes == {"scripture": "emphasized", "church": "present"}
         assert restored.reviewed is True
         assert restored.notes == "clear story"
         assert restored.excluded is False
@@ -45,10 +45,18 @@ class TestGoldenStory:
         s = GoldenStory.from_dict({"story_id": "x:0", "text": "B"})
         assert s.expected_scores is None
         assert s.expected_tier is None
-        assert s.expected_themes == []
+        assert s.expected_themes == {}
         assert s.reviewed is False
         assert s.notes == ""
         assert s.excluded is False
+
+    def test_legacy_list_themes_coerced_to_present(self):
+        # Golden sets written under the old boolean scheme carry a present-only
+        # list; loading them coerces each to grade "present" (issue #53).
+        s = GoldenStory.from_dict(
+            {"story_id": "x:0", "text": "B", "expected_themes": ["scripture", "church"]}
+        )
+        assert s.expected_themes == {"scripture": "present", "church": "present"}
 
     def test_legacy_title_key_is_tolerated(self):
         # Golden sets written before titles were removed still carry a "title"
@@ -71,7 +79,7 @@ class TestGoldenNewsletter:
                 GoldenStory(
                     story_id="t_001:1",
                     text="two",
-                    expected_themes=["vocation-family"],
+                    expected_themes={"vocation_family": "present"},
                 ),
             ],
             source="harvested",
@@ -101,7 +109,7 @@ class TestGoldenNewsletter:
         assert restored.stories[0].story_id == "t_001:0"
         assert restored.stories[1].story_id == "t_001:1"
         assert restored.stories[1].text == "two"
-        assert restored.stories[1].expected_themes == ["vocation-family"]
+        assert restored.stories[1].expected_themes == {"vocation_family": "present"}
 
     def test_defaults_when_keys_missing(self):
         nl = GoldenNewsletter.from_dict(
@@ -127,14 +135,14 @@ class TestStoryPrediction:
         p = StoryPrediction(
             story_id="t_001:0",
             thread_id="t_001",
-            expected_scores={"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2},
+            expected_scores={"simple": 3, "concrete": 2, "personal": 3, "dynamic": 1},
             expected_tier="good",
-            expected_themes=["scripture"],
-            predicted_scores={"simple": 3, "concrete": 3, "personal": 4, "dynamic": 2},
+            expected_themes={"scripture": "present"},
+            predicted_scores={"simple": 2, "concrete": 2, "personal": 3, "dynamic": 1},
             predicted_tier="fair",
-            predicted_themes=["scripture", "church"],
-            scores_raw="SIMPLE: 3 ...",
-            themes_raw="scripture, church",
+            predicted_themes={"scripture": "emphasized", "church": "present"},
+            scores_raw="SIMPLE: OK ...",
+            themes_raw="scripture: emphasized",
             duration_seconds=1.5,
             error=None,
         )
@@ -144,23 +152,23 @@ class TestStoryPrediction:
         assert restored.story_id == "t_001:0"
         assert restored.thread_id == "t_001"
         assert restored.expected_scores == {
-            "simple": 4,
-            "concrete": 3,
-            "personal": 5,
-            "dynamic": 2,
+            "simple": 3,
+            "concrete": 2,
+            "personal": 3,
+            "dynamic": 1,
         }
         assert restored.expected_tier == "good"
-        assert restored.expected_themes == ["scripture"]
+        assert restored.expected_themes == {"scripture": "present"}
         assert restored.predicted_scores == {
-            "simple": 3,
-            "concrete": 3,
-            "personal": 4,
-            "dynamic": 2,
+            "simple": 2,
+            "concrete": 2,
+            "personal": 3,
+            "dynamic": 1,
         }
         assert restored.predicted_tier == "fair"
-        assert restored.predicted_themes == ["scripture", "church"]
-        assert restored.scores_raw == "SIMPLE: 3 ..."
-        assert restored.themes_raw == "scripture, church"
+        assert restored.predicted_themes == {"scripture": "emphasized", "church": "present"}
+        assert restored.scores_raw == "SIMPLE: OK ..."
+        assert restored.themes_raw == "scripture: emphasized"
         assert restored.duration_seconds == 1.5
         assert restored.error is None
 
@@ -168,14 +176,26 @@ class TestStoryPrediction:
         p = StoryPrediction.from_dict({"story_id": "x:0", "thread_id": "x"})
         assert p.expected_scores is None
         assert p.expected_tier is None
-        assert p.expected_themes == []
+        assert p.expected_themes == {}
         assert p.predicted_scores is None
         assert p.predicted_tier is None
-        assert p.predicted_themes == []
+        assert p.predicted_themes == {}
         assert p.scores_raw is None
         assert p.themes_raw is None
         assert p.duration_seconds == 0.0
         assert p.error is None
+
+    def test_legacy_list_themes_coerced_to_present(self):
+        p = StoryPrediction.from_dict(
+            {
+                "story_id": "x:0",
+                "thread_id": "x",
+                "expected_themes": ["scripture"],
+                "predicted_themes": ["scripture", "church"],
+            }
+        )
+        assert p.expected_themes == {"scripture": "present"}
+        assert p.predicted_themes == {"scripture": "present", "church": "present"}
 
 
 class TestExtractionPrediction:

--- a/tests/test_eval_newsletter_schemas.py
+++ b/tests/test_eval_newsletter_schemas.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from evals.newsletter_schemas import (
     ExtractionPrediction,
     GoldenNewsletter,
@@ -56,6 +58,114 @@ class TestGoldenStory:
         s = GoldenStory.from_dict({"story_id": "x:0", "title": "Old Title", "text": "B"})
         assert s.text == "B"
         assert not hasattr(s, "title")
+
+
+class TestOldSchemeThemeGuard:
+    """Loading old-scheme (pre-#53) theme LISTS or invalid grades must raise a
+    clear, actionable error naming the record — not an opaque dict-update
+    ValueError (Finding 1) or a silently-accepted junk grade that crashes the
+    labeling TUI mid-session (Finding 2)."""
+
+    def test_golden_list_themes_raise_actionable_error(self):
+        with pytest.raises(ValueError, match="old-scheme") as exc:
+            GoldenStory.from_dict(
+                {"story_id": "t_001:2", "text": "B", "expected_themes": ["church"]}
+            )
+        msg = str(exc.value)
+        assert "t_001:2" in msg  # story_id so the record is locatable
+        assert "church" in msg  # the offending value
+
+    def test_prediction_list_themes_raise_actionable_error(self):
+        with pytest.raises(ValueError, match="old-scheme") as exc:
+            StoryPrediction.from_dict(
+                {
+                    "story_id": "t_001:3",
+                    "thread_id": "t_001",
+                    "predicted_themes": ["scripture"],
+                }
+            )
+        assert "t_001:3" in str(exc.value)
+
+    def test_invalid_theme_grade_rejected(self):
+        # Case variant: _THEME_CYCLE/_GRADE_ABBR/parse_themes only ever produce
+        # exactly "present"/"emphasized"; "Present" would KeyError the TUI.
+        with pytest.raises(ValueError, match="present.*emphasized|grade") as exc:
+            GoldenStory.from_dict(
+                {
+                    "story_id": "t_001:4",
+                    "text": "B",
+                    "expected_themes": {"scripture": "Present"},
+                }
+            )
+        msg = str(exc.value)
+        assert "t_001:4" in msg
+        assert "scripture" in msg
+        assert "Present" in msg
+
+    def test_absent_grade_rejected(self):
+        # "absent" is represented by omission and is never stored as a grade.
+        with pytest.raises(ValueError):
+            GoldenStory.from_dict(
+                {
+                    "story_id": "t_001:5",
+                    "text": "B",
+                    "expected_themes": {"scripture": "absent"},
+                }
+            )
+
+    def test_prediction_invalid_predicted_grade_rejected(self):
+        with pytest.raises(ValueError):
+            StoryPrediction.from_dict(
+                {
+                    "story_id": "t_001:6",
+                    "thread_id": "t_001",
+                    "predicted_themes": {"church": "maybe"},
+                }
+            )
+
+
+class TestOldSchemeScoreGuard:
+    """Legacy 1-5 scores must be rejected loudly at load, not accepted silently
+    (Finding 3) — otherwise the report computes MAE against the wrong scale and
+    the TUI shows out-of-range keys."""
+
+    def test_out_of_range_expected_score_rejected(self):
+        with pytest.raises(ValueError, match="1..3|old-scheme|re-migrat") as exc:
+            GoldenStory.from_dict(
+                {
+                    "story_id": "t_001:7",
+                    "text": "B",
+                    "expected_scores": {"simple": 3, "concrete": 5},
+                }
+            )
+        msg = str(exc.value)
+        assert "t_001:7" in msg
+        assert "concrete" in msg  # the offending dimension
+        assert "5" in msg  # the offending value
+
+    def test_out_of_range_predicted_score_rejected(self):
+        with pytest.raises(ValueError) as exc:
+            StoryPrediction.from_dict(
+                {
+                    "story_id": "t_001:8",
+                    "thread_id": "t_001",
+                    "predicted_scores": {"simple": 4},
+                }
+            )
+        assert "t_001:8" in str(exc.value)
+
+    def test_valid_scores_and_missing_scores_still_load(self):
+        # 1-3 scores pass; None/missing stays None (unchanged behavior).
+        s = GoldenStory.from_dict(
+            {
+                "story_id": "t_001:9",
+                "text": "B",
+                "expected_scores": {"simple": 1, "concrete": 2, "personal": 3},
+            }
+        )
+        assert s.expected_scores == {"simple": 1, "concrete": 2, "personal": 3}
+        s2 = GoldenStory.from_dict({"story_id": "t_001:10", "text": "B"})
+        assert s2.expected_scores is None
 
 
 class TestGoldenNewsletter:

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -304,11 +304,12 @@ class TestRequiredEndpoints:
 
 
 class _FakeClient:
-    def __init__(self, model, base_url, available, status_code=None):
+    def __init__(self, model, base_url, available, status_code=None, error=None):
         self.model = model
         self.base_url = base_url
         self._available = available
         self._status_code = status_code
+        self._error = error
         self.checked = False
         self.last_timeout = "unset"
 
@@ -319,7 +320,9 @@ class _FakeClient:
         from llm_client import AvailabilityResult
         self.checked = True
         self.last_timeout = timeout
-        return AvailabilityResult(ok=self._available, status_code=self._status_code)
+        return AvailabilityResult(
+            ok=self._available, status_code=self._status_code, error=self._error
+        )
 
 
 def _run(coro):
@@ -375,6 +378,27 @@ class TestPreflightCheck:
         local = _FakeClient("qwen3", "http://local", False)
         errors = _run(preflight_check(cloud, local, False, True))
         assert "404" not in errors[0]
+
+    def test_non_404_status_code_is_shown(self):
+        # Finding 1: a non-404 status (e.g. 401 bad key, 500 down) must be
+        # surfaced, not discarded, so the user can tell them apart.
+        cloud = _FakeClient("c", "http://cloud", True)
+        local = _FakeClient("qwen3", "http://local", False, status_code=401)
+        errors = _run(preflight_check(cloud, local, False, True))
+        assert len(errors) == 1
+        assert "401" in errors[0]
+
+    def test_connection_error_text_is_shown(self):
+        # Finding 1: probe()'s captured exception text (connect/timeout/
+        # UnsupportedProtocol) must appear so a down server / bad URL is
+        # distinguishable from a bad key.
+        cloud = _FakeClient("c", "http://cloud", True)
+        local = _FakeClient(
+            "qwen3", "http://local", False, error="ConnectError: Connection refused"
+        )
+        errors = _run(preflight_check(cloud, local, False, True))
+        assert len(errors) == 1
+        assert "ConnectError" in errors[0]
 
     def test_forwards_per_endpoint_timeouts_to_is_available(self):
         # Cloud and local get their own probe timeouts (cloud need not wait out

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -304,17 +304,22 @@ class TestRequiredEndpoints:
 
 
 class _FakeClient:
-    def __init__(self, model, base_url, available):
+    def __init__(self, model, base_url, available, status_code=None):
         self.model = model
         self.base_url = base_url
         self._available = available
+        self._status_code = status_code
         self.checked = False
         self.last_timeout = "unset"
 
     async def is_available(self, timeout=None):
+        return (await self.probe(timeout)).ok
+
+    async def probe(self, timeout=None):
+        from llm_client import AvailabilityResult
         self.checked = True
         self.last_timeout = timeout
-        return self._available
+        return AvailabilityResult(ok=self._available, status_code=self._status_code)
 
 
 def _run(coro):
@@ -347,6 +352,29 @@ class TestPreflightCheck:
         errors = _run(preflight_check(cloud, local, False, True))
         assert errors == []
         assert cloud.checked is False  # never probed
+
+    def test_404_shows_model_mismatch_hint(self):
+        # Issue #41 item 7: the "model-name mismatch returns 404" hint appears
+        # only when the probe actually got a 404.
+        cloud = _FakeClient("c", "http://cloud", True)
+        local = _FakeClient("qwen3", "http://local", False, status_code=404)
+        errors = _run(preflight_check(cloud, local, False, True))
+        assert len(errors) == 1
+        assert "404" in errors[0]
+
+    def test_non_404_omits_model_mismatch_hint(self):
+        cloud = _FakeClient("c", "http://cloud", True)
+        local = _FakeClient("qwen3", "http://local", False, status_code=503)
+        errors = _run(preflight_check(cloud, local, False, True))
+        assert len(errors) == 1
+        assert "404" not in errors[0]
+
+    def test_unreachable_no_response_omits_hint(self):
+        # No HTTP response at all (status_code None) -> no 404 hint.
+        cloud = _FakeClient("c", "http://cloud", True)
+        local = _FakeClient("qwen3", "http://local", False)
+        errors = _run(preflight_check(cloud, local, False, True))
+        assert "404" not in errors[0]
 
     def test_forwards_per_endpoint_timeouts_to_is_available(self):
         # Cloud and local get their own probe timeouts (cloud need not wait out
@@ -477,10 +505,11 @@ class TestMainPreflightWiring:
     def test_unreachable_local_endpoint_exits_1_before_evaluating(
         self, tmp_path, monkeypatch
     ):
-        async def _never_available(self, timeout=None):
-            return False
+        async def _down(self, timeout=None):
+            from llm_client import AvailabilityResult
+            return AvailabilityResult(ok=False)
 
-        monkeypatch.setattr(run_eval.LLMClient, "is_available", _never_available)
+        monkeypatch.setattr(run_eval.LLMClient, "probe", _down)
         path = tmp_path / "golden.jsonl"
         _write_golden_set(path, [
             _golden("person_thread", reviewed=True, expected_sender_type="person"),
@@ -495,13 +524,14 @@ class TestMainPreflightWiring:
     def test_skip_preflight_bypasses_the_check(self, tmp_path, monkeypatch):
         # With the endpoint "down" but --skip-preflight, main must get PAST preflight
         # (and then fail later trying to actually classify — proving preflight was skipped).
-        async def _never_available(self, timeout=None):
-            return False
+        async def _down(self, timeout=None):
+            from llm_client import AvailabilityResult
+            return AvailabilityResult(ok=False)
 
         async def _boom(*a, **k):
             raise RuntimeError("reached evaluation")
 
-        monkeypatch.setattr(run_eval.LLMClient, "is_available", _never_available)
+        monkeypatch.setattr(run_eval.LLMClient, "probe", _down)
         monkeypatch.setattr(run_eval, "run_evaluation", _boom)
         path = tmp_path / "golden.jsonl"
         _write_golden_set(path, [

--- a/tests/test_eval_util.py
+++ b/tests/test_eval_util.py
@@ -1,6 +1,40 @@
 """Tests for shared evals helpers."""
 
-from evals import plural
+import json
+
+from evals import atomic_write_jsonl, plural
+
+
+class _Rec:
+    def __init__(self, value):
+        self.value = value
+
+    def to_dict(self):
+        return {"value": self.value}
+
+
+class TestAtomicWriteJsonl:
+    def test_writes_one_json_line_per_record(self, tmp_path):
+        path = tmp_path / "out.jsonl"
+        atomic_write_jsonl([_Rec(1), _Rec(2)], path)
+        lines = path.read_text().strip().splitlines()
+        assert [json.loads(line) for line in lines] == [{"value": 1}, {"value": 2}]
+
+    def test_accepts_str_path(self, tmp_path):
+        path = tmp_path / "out.jsonl"
+        atomic_write_jsonl([_Rec(1)], str(path))  # str coerced to Path
+        assert path.exists()
+
+    def test_overwrites_existing_file(self, tmp_path):
+        path = tmp_path / "out.jsonl"
+        atomic_write_jsonl([_Rec(1)], path)
+        atomic_write_jsonl([_Rec(2)], path)
+        assert path.read_text().strip() == json.dumps({"value": 2})
+
+    def test_leaves_no_temp_file_on_success(self, tmp_path):
+        path = tmp_path / "out.jsonl"
+        atomic_write_jsonl([_Rec(1)], path)
+        assert [p.name for p in tmp_path.iterdir()] == ["out.jsonl"]
 
 
 class TestPlural:

--- a/tests/test_eval_util.py
+++ b/tests/test_eval_util.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from evals import atomic_write_jsonl, plural
 
 
@@ -35,6 +37,22 @@ class TestAtomicWriteJsonl:
         path = tmp_path / "out.jsonl"
         atomic_write_jsonl([_Rec(1)], path)
         assert [p.name for p in tmp_path.iterdir()] == ["out.jsonl"]
+
+    def test_write_failure_cleans_temp_and_leaves_original(self, tmp_path):
+        # A mid-write failure must unlink the temp file and leave the original
+        # file untouched (the rename never happens).
+        path = tmp_path / "out.jsonl"
+        atomic_write_jsonl([_Rec("original")], path)
+
+        class _Bad:
+            def to_dict(self):
+                raise ValueError("boom")
+
+        with pytest.raises(ValueError):
+            atomic_write_jsonl([_Rec("new"), _Bad()], path)
+
+        assert json.loads(path.read_text().strip()) == {"value": "original"}
+        assert [p.name for p in tmp_path.iterdir()] == ["out.jsonl"]  # no temp left
 
 
 class TestPlural:

--- a/tests/test_labeler.py
+++ b/tests/test_labeler.py
@@ -376,7 +376,7 @@ class TestNewsletterApplyLabels:
         await newsletter_label_manager.apply_newsletter_classification(
             message_ids=["msg_001"],
             tier=NewsletterTier.EXCELLENT,
-            themes=["scripture", "christlikeness"],
+            themes={"scripture": "emphasized", "christlikeness": "present"},
         )
 
         mock_proxy.modify_message.assert_called_once()
@@ -385,9 +385,28 @@ class TestNewsletterApplyLabels:
         assert "Label_4" in add_ids  # processed
         assert "Label_10" in add_ids  # newsletter marker
         assert "Label_11" in add_ids  # excellent
-        assert "Label_20" in add_ids  # theme/scripture
-        assert "Label_21" in add_ids  # theme/christlikeness
+        assert "Label_20" in add_ids  # theme/scripture (emphasized -> labeled)
+        # christlikeness is only "present", not "emphasized" — issue #53 applies the
+        # Gmail theme label ONLY for emphasized themes.
+        assert "Label_21" not in add_ids
         assert "INBOX" in call_kwargs["remove_label_ids"]
+
+    async def test_present_theme_not_labeled(
+        self, newsletter_label_manager, mock_proxy, all_labels_with_newsletter
+    ):
+        mock_proxy.list_labels.return_value = all_labels_with_newsletter
+        await newsletter_label_manager.verify_labels()
+        mock_proxy.modify_message.return_value = {"id": "msg_001"}
+
+        await newsletter_label_manager.apply_newsletter_classification(
+            message_ids=["msg_001"],
+            tier=NewsletterTier.GOOD,
+            themes={"scripture": "present", "church": "present"},
+        )
+
+        add_ids = mock_proxy.modify_message.call_args.kwargs["add_label_ids"]
+        assert "Label_20" not in add_ids  # theme/scripture not emphasized
+        assert "Label_22" not in add_ids  # theme/church not emphasized
 
     async def test_apply_newsletter_no_stories(
         self, newsletter_label_manager, mock_proxy, all_labels_with_newsletter
@@ -399,7 +418,7 @@ class TestNewsletterApplyLabels:
         await newsletter_label_manager.apply_newsletter_classification(
             message_ids=["msg_001"],
             tier=None,
-            themes=[],
+            themes={},
         )
 
         call_kwargs = mock_proxy.modify_message.call_args.kwargs
@@ -419,6 +438,6 @@ class TestNewsletterApplyLabels:
         await newsletter_label_manager.apply_newsletter_classification(
             message_ids=["msg_001", "msg_002"],
             tier=NewsletterTier.GOOD,
-            themes=["church"],
+            themes={"church": "emphasized"},
         )
         assert mock_proxy.modify_message.call_count == 2

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -535,3 +535,17 @@ class TestIsAvailable:
 
         await cached.is_available(timeout=42)
         inner.is_available.assert_awaited_once_with(42)
+
+
+class TestProbe:
+    async def test_delegates_probe_to_inner(self, tmp_path: Path):
+        # The cache wraps the real client that eval preflights probe(); it must
+        # forward probe() or the default (cached) newsletter run crashes.
+        from llm_client import AvailabilityResult
+        inner = _make_inner()
+        inner.probe.return_value = AvailabilityResult(ok=False, status_code=404)
+        cached = CachedLLMClient(inner, tmp_path / "cache.jsonl")
+
+        result = await cached.probe(timeout=7)
+        assert result.status_code == 404
+        inner.probe.assert_awaited_once_with(7)

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -519,24 +519,6 @@ class TestThinking:
         assert thinking == "deep reasoning"
 
 
-class TestIsAvailable:
-    async def test_delegates_to_inner(self, tmp_path: Path):
-        inner = _make_inner()
-        inner.is_available.return_value = True
-        cached = CachedLLMClient(inner, tmp_path / "cache.jsonl")
-
-        assert await cached.is_available() is True
-        inner.is_available.assert_awaited_once()
-
-    async def test_forwards_timeout_to_inner(self, tmp_path: Path):
-        inner = _make_inner()
-        inner.is_available.return_value = True
-        cached = CachedLLMClient(inner, tmp_path / "cache.jsonl")
-
-        await cached.is_available(timeout=42)
-        inner.is_available.assert_awaited_once_with(42)
-
-
 class TestProbe:
     async def test_delegates_probe_to_inner(self, tmp_path: Path):
         # The cache wraps the real client that eval preflights probe(); it must

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -410,6 +410,45 @@ class TestContentlessResponse:
                 await glm_client.complete("sys", "user", include_thinking=True)
 
 
+class TestProbe:
+    """probe() carries status detail so preflight can distinguish a 404
+    (model-name mismatch) from an unreachable endpoint (issue #41 item 7)."""
+
+    async def test_probe_ok_on_200(self, local_client):
+        mock_response = _mock_response(json_data={"choices": [{"message": {"content": "ok"}}]})
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await local_client.probe()
+            assert result.ok is True
+            assert result.status_code == 200
+            assert result.error is None
+
+    async def test_probe_reports_404_status(self, local_client):
+        mock_response = _mock_response(status_code=404, json_data={"error": "not found"})
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await local_client.probe()
+            assert result.ok is False
+            assert result.status_code == 404
+
+    async def test_probe_error_on_connection_failure(self, local_client):
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.ConnectError("Connection refused")
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await local_client.probe()
+            assert result.ok is False
+            assert result.status_code is None
+            assert "ConnectError" in result.error
+
+
 class TestIsAvailable:
     async def test_available_when_server_responds(self, local_client):
         """is_available returns True when server returns 200."""

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -7,6 +7,7 @@ import pytest
 
 from llm_client import (
     DEFAULT_AVAILABILITY_TIMEOUT,
+    AvailabilityResult,
     LLMClient,
     LLMContentError,
     LLMUnavailableError,
@@ -486,6 +487,39 @@ class TestProbe:
             await local_client.probe(timeout=123)
 
             assert mock_client_cls.call_args.kwargs["timeout"] == 123
+
+
+class TestAvailabilityDetail:
+    """AvailabilityResult.detail() is the single place that composes a probe
+    failure's diagnosis (Findings 1 & 2): the HTTP status (with the 404
+    model-mismatch hint) or the exception text, so every preflight can surface it
+    instead of discarding it."""
+
+    def test_detail_empty_when_ok(self):
+        assert AvailabilityResult(ok=True, status_code=200).detail() == ""
+
+    def test_detail_includes_non_404_status_code(self):
+        detail = AvailabilityResult(ok=False, status_code=401).detail()
+        assert "401" in detail
+        # A non-404 status is not a model-mismatch, so no such hint.
+        assert "model name does not match" not in detail
+
+    def test_detail_404_includes_model_mismatch_hint(self):
+        detail = AvailabilityResult(ok=False, status_code=404).detail()
+        assert "404" in detail
+        assert "model name does not match" in detail
+
+    def test_detail_includes_error_text(self):
+        detail = AvailabilityResult(
+            ok=False, error="ConnectError: Connection refused"
+        ).detail()
+        assert "ConnectError" in detail
+        assert "Connection refused" in detail
+
+    def test_detail_empty_when_no_status_or_error(self):
+        # ok=False with neither a status nor an error (e.g. a bare down probe) has
+        # nothing specific to say.
+        assert AvailabilityResult(ok=False).detail() == ""
 
 
 class TestExtraBody:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from llm_client import DEFAULT_AVAILABILITY_TIMEOUT, LLMClient, LLMUnavailableError
+from llm_client import (
+    DEFAULT_AVAILABILITY_TIMEOUT,
+    LLMClient,
+    LLMContentError,
+    LLMUnavailableError,
+)
 
 
 @pytest.fixture
@@ -324,6 +329,22 @@ class TestContentlessResponse:
             msg = str(exc_info.value)
             assert "test-cloud-model" in msg
             assert "max_tokens" in msg  # names the likely cause
+
+    async def test_content_less_raises_llm_content_error(self, cloud_client):
+        """The content-less guard raises the dedicated LLMContentError type so the
+        newsletter pipeline can re-raise it to the give-up path (issue #30). It must
+        subclass RuntimeError to preserve the email pipeline's give-up handler."""
+        assert issubclass(LLMContentError, RuntimeError)
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {"role": "assistant", "content": None}}]
+        })
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(LLMContentError, match="no content"):
+                await cloud_client.complete("sys", "user")
 
     async def test_none_content_raises_runtime_error(self, cloud_client):
         """An explicit `content: null` raises RuntimeError, not a downstream crash."""

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -448,66 +448,19 @@ class TestProbe:
             assert result.status_code is None
             assert "ConnectError" in result.error
 
-
-class TestIsAvailable:
-    async def test_available_when_server_responds(self, local_client):
-        """is_available returns True when server returns 200."""
-        mock_response = _mock_response(json_data={
-            "choices": [{"message": {"content": "ok"}}]
-        })
-
-        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.post.return_value = mock_response
-            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
-            assert await local_client.is_available() is True
-
-    async def test_unavailable_on_connection_error(self, local_client):
-        """is_available returns False when server is unreachable."""
-        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.post.side_effect = httpx.ConnectError("Connection refused")
-            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
-            assert await local_client.is_available() is False
-
-    async def test_unavailable_on_timeout(self, local_client):
-        """is_available returns False on timeout."""
-        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.post.side_effect = httpx.TimeoutException("Timeout")
-            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
-            assert await local_client.is_available() is False
-
-    async def test_unavailable_on_http_error(self, local_client):
-        """is_available returns False on non-200 response."""
-        mock_response = _mock_response(status_code=503, json_data={"error": "Service Unavailable"})
-
-        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.post.return_value = mock_response
-            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
-            assert await local_client.is_available() is False
-
-    async def test_unavailable_on_unsupported_protocol(self, local_client):
-        """An unset/schemeless URL makes httpx raise UnsupportedProtocol; the
-        preflight relies on this being caught (returns False), not propagated."""
+    async def test_probe_error_on_unsupported_protocol(self, local_client):
+        """An unset/schemeless URL makes httpx raise UnsupportedProtocol; probe()
+        relies on this being caught (ok=False), not propagated."""
         with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.post.side_effect = httpx.UnsupportedProtocol("missing scheme")
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            assert await local_client.is_available() is False
+            result = await local_client.probe()
+            assert result.ok is False
 
-    async def test_default_availability_timeout_is_longer_than_10s(self, local_client):
+    async def test_probe_default_timeout_is_longer_than_10s(self, local_client):
         """The ping timeout defaults to DEFAULT_AVAILABILITY_TIMEOUT (>10s) so a
         cold on-demand model load is not mistaken for an unreachable server."""
         assert DEFAULT_AVAILABILITY_TIMEOUT > 10
@@ -518,11 +471,11 @@ class TestIsAvailable:
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            await local_client.is_available()
+            await local_client.probe()
 
             assert mock_client_cls.call_args.kwargs["timeout"] == DEFAULT_AVAILABILITY_TIMEOUT
 
-    async def test_explicit_timeout_is_honored(self, local_client):
+    async def test_probe_explicit_timeout_is_honored(self, local_client):
         mock_response = _mock_response(json_data={"choices": [{"message": {"content": "ok"}}]})
         with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
@@ -530,7 +483,7 @@ class TestIsAvailable:
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            await local_client.is_available(timeout=123)
+            await local_client.probe(timeout=123)
 
             assert mock_client_cls.call_args.kwargs["timeout"] == 123
 
@@ -601,7 +554,7 @@ class TestExtraBody:
             assert set(body.keys()) == {"model", "max_tokens", "temperature", "messages"}
 
     async def test_extra_body_in_availability_check(self):
-        """Extra body fields are included in is_available ping."""
+        """Extra body fields are included in the probe() ping."""
         client = LLMClient(
             base_url="http://localhost:8080/v1/chat/completions",
             api_key="",
@@ -618,7 +571,7 @@ class TestExtraBody:
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            await client.is_available()
+            await client.probe()
 
             body = mock_client.post.call_args.kwargs["json"]
             assert body["enable_thinking"] is False

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -42,6 +42,16 @@ class TestParseSendDate:
         assert parse_send_date("", None) is None
         assert parse_send_date("garbage", None) is None
 
+    def test_extreme_year_offset_does_not_raise(self):
+        # A near-max-year date with a west offset overflows past year 9999 when
+        # shifted to UTC; the tz conversion must be guarded so this degrades to a
+        # fallback, not an uncaught OverflowError.
+        assert parse_send_date("Fri, 31 Dec 9999 23:59:59 -1200", None) is None
+        # ...and falls back to internalDate when available.
+        assert parse_send_date(
+            "Fri, 31 Dec 9999 23:59:59 -1200", "1704067200000"
+        ) == "2024-01-01T00:00:00+00:00"
+
 
 class TestParseStories:
     def test_single_story(self):

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from llm_client import LLMUnavailableError
+from llm_client import LLMContentError, LLMUnavailableError
 from newsletter import (
     NewsletterClassifier,
     NewsletterTier,
@@ -440,6 +440,26 @@ class TestClassifyNewsletterTransientOutage:
             LLMUnavailableError("cloud endpoint down"),                    # classify_themes
         ]
         with pytest.raises(LLMUnavailableError):
+            await nl_classifier.classify_newsletter("body")
+
+    async def test_content_error_during_quality_propagates(self, nl_classifier, mock_cloud_llm):
+        """A content-less LLMContentError during quality propagates (issue #30) so the
+        daemon routes the whole newsletter to give-up rather than committing an empty
+        grade indistinguishable from a genuine NO_STORIES."""
+        mock_cloud_llm.complete.side_effect = [
+            ("STORY: Content", ""),                       # extract_stories
+            LLMContentError("model returned no content"),  # assess_quality
+        ]
+        with pytest.raises(LLMContentError):
+            await nl_classifier.classify_newsletter("body")
+
+    async def test_content_error_during_theme_propagates(self, nl_classifier, mock_cloud_llm):
+        mock_cloud_llm.complete.side_effect = [
+            ("STORY: Content", ""),                                        # extract_stories
+            ("SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK", ""),    # assess_quality
+            LLMContentError("model returned no content"),                  # classify_themes
+        ]
+        with pytest.raises(LLMContentError):
             await nl_classifier.classify_newsletter("body")
 
     async def test_non_transient_quality_error_stays_isolated(self, nl_classifier, mock_cloud_llm):

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -14,10 +14,33 @@ from newsletter import (
     compute_tier,
     is_newsletter,
     parse_quality_scores,
+    parse_send_date,
     parse_stories,
     parse_themes,
     write_assessment,
 )
+
+
+class TestParseSendDate:
+    # Normalize the email send-date to ISO-8601 UTC (issue #35/#36 enabler).
+    def test_rfc2822_header_to_iso_utc(self):
+        assert parse_send_date("Mon, 1 Jan 2024 12:00:00 +0000") == "2024-01-01T12:00:00+00:00"
+
+    def test_offset_converted_to_utc(self):
+        assert parse_send_date("Mon, 1 Jan 2024 12:00:00 +0500") == "2024-01-01T07:00:00+00:00"
+
+    def test_naive_header_assumed_utc(self):
+        assert parse_send_date("1 Jan 2024 12:00:00") == "2024-01-01T12:00:00+00:00"
+
+    def test_falls_back_to_internal_date_ms(self):
+        assert parse_send_date("", "1704067200000") == "2024-01-01T00:00:00+00:00"
+
+    def test_unparseable_header_falls_back_to_internal(self):
+        assert parse_send_date("not a date at all", "1704067200000") == "2024-01-01T00:00:00+00:00"
+
+    def test_none_when_nothing_usable(self):
+        assert parse_send_date("", None) is None
+        assert parse_send_date("garbage", None) is None
 
 
 class TestParseStories:
@@ -518,6 +541,29 @@ class TestWriteAssessment:
         assert record["stories"][0]["themes"] == {"scripture": "present", "church": "emphasized"}
         assert record["stories"][0]["quality_cot"] == "quality reasoning"
         assert "timestamp" in record
+
+    def test_writes_send_date_and_model(self, tmp_path):
+        output_file = tmp_path / "assessments.jsonl"
+        write_assessment(
+            output_file=str(output_file),
+            message_id="m", thread_id="t", sender="a@b.com", subject="Subj",
+            overall_tier=NewsletterTier.GOOD, stories=[StoryResult(text="x")],
+            send_date="2024-01-01T12:00:00+00:00", model="claude-sonnet-4-6",
+        )
+        record = json.loads(output_file.read_text().strip())
+        assert record["send_date"] == "2024-01-01T12:00:00+00:00"
+        assert record["model"] == "claude-sonnet-4-6"
+
+    def test_send_date_and_model_default_to_none(self, tmp_path):
+        output_file = tmp_path / "assessments.jsonl"
+        write_assessment(
+            output_file=str(output_file),
+            message_id="m", thread_id="t", sender="a@b.com", subject="Subj",
+            overall_tier=None, stories=[StoryResult(text="x")],
+        )
+        record = json.loads(output_file.read_text().strip())
+        assert record["send_date"] is None
+        assert record["model"] is None
 
     def test_appends_to_existing_file(self, tmp_path):
         output_file = tmp_path / "assessments.jsonl"

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -11,6 +11,7 @@ from newsletter import (
     NewsletterTier,
     StoryResult,
     aggregate_theme_grades,
+    classify_theme_line,
     compute_tier,
     is_newsletter,
     parse_quality_scores,
@@ -227,6 +228,65 @@ class TestParseThemes:
     def test_with_extra_whitespace(self):
         raw = "  SCRIPTURE : PRESENT \n  CHURCH:EMPHASIZED  "
         assert parse_themes(raw) == {"scripture": "present", "church": "emphasized"}
+
+    def test_tolerates_bulleted_prefixes(self):
+        # A list-marker/markdown prefix must not defeat matching (mirrors
+        # parse_quality_scores' unanchored tolerance). Finding 1.
+        raw = "- SCRIPTURE: EMPHASIZED\n- CHURCH: PRESENT\n- VOCATION_FAMILY: ABSENT"
+        assert parse_themes(raw) == {"scripture": "emphasized", "church": "present"}
+
+
+class TestClassifyThemeLine:
+    # classify_theme_line is the single shared per-line theme classifier that
+    # parse_themes AND the eval anomaly detectors all use, so their format
+    # knowledge cannot drift (Finding 2). A "flagged" line (off_taxonomy /
+    # anomalous) is one parse_themes does NOT store and the diagnostics must
+    # surface (Finding 3).
+    FLAGGED = {"off_taxonomy", "anomalous"}
+
+    def test_bulleted_valid_line_is_not_flagged(self):
+        # Coherence with Finding 1: a bulleted VALID line both parses and is not
+        # an anomaly.
+        kind, name, grade = classify_theme_line("- SCRIPTURE: EMPHASIZED")
+        assert (kind, name, grade) == ("theme", "scripture", "emphasized")
+        assert kind not in self.FLAGGED
+
+    def test_absent_valid_line_is_recognized_not_flagged(self):
+        # An all-ABSENT response is a valid empty result, so a valid-name ABSENT
+        # line must be recognized (kind "theme"), never flagged.
+        kind, name, grade = classify_theme_line("SCRIPTURE: ABSENT")
+        assert (kind, name, grade) == ("theme", "scripture", "absent")
+        assert kind not in self.FLAGGED
+
+    def test_blank_line_is_ignorable(self):
+        assert classify_theme_line("   ")[0] == "blank"
+
+    def test_near_miss_lines_are_flagged(self):
+        # The Finding 3 repro lines: parse_themes drops each, so each must be
+        # flagged (never silently a "theme"/"blank").
+        for line in (
+            "DISCIPLE-MAKING: EMPHASIZED",   # hyphen instead of underscore
+            "SCRIPTURE: EMPHASISED",         # misspelled grade
+            "VOCATION FAMILY: PRESENT",      # space instead of underscore
+        ):
+            assert classify_theme_line(line)[0] in self.FLAGGED, line
+
+    def test_agrees_with_parse_themes(self):
+        # Anti-drift invariant: a line parse_themes STORES classifies as "theme";
+        # a flagged line is never stored by parse_themes.
+        lines = [
+            "SCRIPTURE: PRESENT", "- CHURCH: EMPHASIZED", "SCRIPTURE: ABSENT",
+            "FELLOWSHIP: PRESENT", "SCRIPTURE: EMPHASISED",
+            "VOCATION FAMILY: PRESENT", "DISCIPLE-MAKING: EMPHASIZED",
+            "just some prose", "", "   ",
+        ]
+        for line in lines:
+            kind = classify_theme_line(line)[0]
+            stored = parse_themes(line)
+            if stored:
+                assert kind == "theme", f"{line!r} stored but kind={kind}"
+            if kind in self.FLAGGED:
+                assert stored == {}, f"{line!r} flagged but parse stored {stored}"
 
 
 class TestComputeTier:

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -10,6 +10,7 @@ from newsletter import (
     NewsletterClassifier,
     NewsletterTier,
     StoryResult,
+    aggregate_theme_grades,
     compute_tier,
     is_newsletter,
     parse_quality_scores,
@@ -99,103 +100,160 @@ class TestParseStories:
 
 
 class TestParseQualityScores:
-    def test_valid_scores(self):
-        raw = "SIMPLE: 4\nCONCRETE: 3\nPERSONAL: 5\nDYNAMIC: 2"
+    # Poor/OK/Good tokens map to 1/2/3 (issue #53).
+    def test_valid_tokens(self):
+        raw = "SIMPLE: GOOD\nCONCRETE: OK\nPERSONAL: GOOD\nDYNAMIC: POOR"
         scores = parse_quality_scores(raw)
-        assert scores == {"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2}
+        assert scores == {"simple": 3, "concrete": 2, "personal": 3, "dynamic": 1}
 
-    def test_scores_with_extra_whitespace(self):
-        raw = "  SIMPLE:  4 \n CONCRETE: 3\n  PERSONAL:5\n DYNAMIC :2  "
+    def test_tokens_with_extra_whitespace(self):
+        raw = "  SIMPLE:  GOOD \n CONCRETE: OK\n  PERSONAL:GOOD\n DYNAMIC : POOR  "
         scores = parse_quality_scores(raw)
-        assert scores == {"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2}
+        assert scores == {"simple": 3, "concrete": 2, "personal": 3, "dynamic": 1}
 
-    def test_scores_with_trailing_text(self):
-        raw = "SIMPLE: 4 - very focused\nCONCRETE: 3\nPERSONAL: 5\nDYNAMIC: 2"
+    def test_case_insensitive(self):
+        raw = "simple: good\nconcrete: ok\npersonal: Good\ndynamic: poor"
         scores = parse_quality_scores(raw)
-        assert scores == {"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2}
+        assert scores == {"simple": 3, "concrete": 2, "personal": 3, "dynamic": 1}
+
+    def test_tokens_with_trailing_text(self):
+        raw = "SIMPLE: GOOD - very focused\nCONCRETE: OK\nPERSONAL: GOOD\nDYNAMIC: POOR"
+        scores = parse_quality_scores(raw)
+        assert scores == {"simple": 3, "concrete": 2, "personal": 3, "dynamic": 1}
 
     def test_missing_dimension_returns_none(self):
-        raw = "SIMPLE: 4\nCONCRETE: 3\nPERSONAL: 5"
+        raw = "SIMPLE: GOOD\nCONCRETE: OK\nPERSONAL: GOOD"
         scores = parse_quality_scores(raw)
         assert scores is None
 
-    def test_invalid_score_returns_none(self):
-        raw = "SIMPLE: 4\nCONCRETE: six\nPERSONAL: 5\nDYNAMIC: 2"
+    def test_unknown_token_returns_none(self):
+        raw = "SIMPLE: GREAT\nCONCRETE: OK\nPERSONAL: GOOD\nDYNAMIC: POOR"
         scores = parse_quality_scores(raw)
         assert scores is None
 
-    def test_score_out_of_range_clamped(self):
-        raw = "SIMPLE: 7\nCONCRETE: 0\nPERSONAL: 5\nDYNAMIC: 2"
+    def test_legacy_digit_value_returns_none(self):
+        # The old 1-5 numeric format is no longer accepted.
+        raw = "SIMPLE: 4\nCONCRETE: 3\nPERSONAL: 5\nDYNAMIC: 2"
         scores = parse_quality_scores(raw)
-        assert scores == {"simple": 5, "concrete": 1, "personal": 5, "dynamic": 2}
+        assert scores is None
 
     def test_empty_input_returns_none(self):
         assert parse_quality_scores("") is None
 
-    def test_last_line_fallback(self):
-        raw = "Here are my scores:\n\nSIMPLE: 4\nCONCRETE: 3\nPERSONAL: 5\nDYNAMIC: 2"
+    def test_scores_after_preamble(self):
+        raw = "Here are my scores:\n\nSIMPLE: GOOD\nCONCRETE: OK\nPERSONAL: GOOD\nDYNAMIC: POOR"
         scores = parse_quality_scores(raw)
-        assert scores == {"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2}
+        assert scores == {"simple": 3, "concrete": 2, "personal": 3, "dynamic": 1}
 
 
 class TestParseThemes:
-    def test_single_theme(self):
-        themes = parse_themes("SCRIPTURE")
-        assert themes == ["scripture"]
+    # Themes are graded Absent/Present/Emphasized (issue #53); parse returns a
+    # dict theme->grade with Absent omitted.
+    def test_single_present_theme(self):
+        assert parse_themes("SCRIPTURE: PRESENT") == {"scripture": "present"}
 
-    def test_multiple_themes(self):
-        themes = parse_themes("SCRIPTURE\nCHRISTLIKENESS")
-        assert themes == ["scripture", "christlikeness"]
+    def test_emphasized_theme(self):
+        assert parse_themes("SCRIPTURE: EMPHASIZED") == {"scripture": "emphasized"}
 
-    def test_all_themes(self):
-        raw = "SCRIPTURE\nCHRISTLIKENESS\nCHURCH\nVOCATION_FAMILY\nDISCIPLE_MAKING"
-        themes = parse_themes(raw)
-        assert len(themes) == 5
+    def test_multiple_graded_themes(self):
+        raw = "SCRIPTURE: EMPHASIZED\nCHURCH: PRESENT"
+        assert parse_themes(raw) == {"scripture": "emphasized", "church": "present"}
+
+    def test_absent_is_omitted(self):
+        raw = "SCRIPTURE: ABSENT\nCHURCH: PRESENT"
+        assert parse_themes(raw) == {"church": "present"}
+
+    def test_all_absent_returns_empty(self):
+        raw = (
+            "SCRIPTURE: ABSENT\nCHRISTLIKENESS: ABSENT\nCHURCH: ABSENT\n"
+            "VOCATION_FAMILY: ABSENT\nDISCIPLE_MAKING: ABSENT"
+        )
+        assert parse_themes(raw) == {}
 
     def test_none_response(self):
-        themes = parse_themes("NONE")
-        assert themes == []
+        assert parse_themes("NONE") == {}
 
     def test_none_with_whitespace(self):
-        themes = parse_themes("  NONE  ")
-        assert themes == []
+        assert parse_themes("  NONE  ") == {}
 
-    def test_ignores_invalid_themes(self):
-        themes = parse_themes("SCRIPTURE\nINVALID_THEME\nCHURCH")
-        assert themes == ["scripture", "church"]
+    def test_ignores_invalid_theme_names(self):
+        raw = "SCRIPTURE: PRESENT\nINVALID_THEME: EMPHASIZED\nCHURCH: PRESENT"
+        assert parse_themes(raw) == {"scripture": "present", "church": "present"}
+
+    def test_ignores_unparseable_lines(self):
+        raw = "SCRIPTURE: PRESENT\nsome commentary\nCHURCH: EMPHASIZED"
+        assert parse_themes(raw) == {"scripture": "present", "church": "emphasized"}
+
+    def test_legacy_bare_theme_name_is_ignored(self):
+        # The old bare-name (present-only) format no longer conveys a grade.
+        assert parse_themes("SCRIPTURE\nCHURCH") == {}
 
     def test_empty_input(self):
-        themes = parse_themes("")
-        assert themes == []
+        assert parse_themes("") == {}
 
     def test_with_extra_whitespace(self):
-        themes = parse_themes("  SCRIPTURE \n  CHURCH  ")
-        assert themes == ["scripture", "church"]
+        raw = "  SCRIPTURE : PRESENT \n  CHURCH:EMPHASIZED  "
+        assert parse_themes(raw) == {"scripture": "present", "church": "emphasized"}
 
 
 class TestComputeTier:
-    def test_excellent(self):
-        scores = {"simple": 5, "concrete": 4, "personal": 4, "dynamic": 5}
+    # Poor/OK/Good -> 1/2/3; tier = mean of the 4 dimensions, banded (issue #53):
+    #   excellent >= 2.75, good >= 2.25, fair >= 1.75, poor < 1.75.
+    def test_excellent_all_good(self):
+        scores = {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}
         assert compute_tier(scores) == NewsletterTier.EXCELLENT
 
-    def test_good(self):
-        assert compute_tier({"simple": 3, "concrete": 3, "personal": 4, "dynamic": 3}) == NewsletterTier.GOOD
-
-    def test_fair(self):
-        assert compute_tier({"simple": 2, "concrete": 2, "personal": 3, "dynamic": 2}) == NewsletterTier.FAIR
-
-    def test_poor(self):
-        assert compute_tier({"simple": 1, "concrete": 1, "personal": 2, "dynamic": 1}) == NewsletterTier.POOR
-
-    def test_boundary_excellent(self):
-        scores = {"simple": 4, "concrete": 4, "personal": 4, "dynamic": 4}
+    def test_excellent_boundary_three_good_one_ok(self):
+        # avg 2.75
+        scores = {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 2}
         assert compute_tier(scores) == NewsletterTier.EXCELLENT
 
-    def test_boundary_good(self):
-        assert compute_tier({"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3}) == NewsletterTier.GOOD
+    def test_good_two_good_two_ok(self):
+        # avg 2.5
+        assert compute_tier({"simple": 3, "concrete": 3, "personal": 2, "dynamic": 2}) == NewsletterTier.GOOD
 
-    def test_boundary_fair(self):
+    def test_good_tolerates_one_poor(self):
+        # 3,3,3,1 -> avg 2.5
+        assert compute_tier({"simple": 3, "concrete": 3, "personal": 3, "dynamic": 1}) == NewsletterTier.GOOD
+
+    def test_good_boundary(self):
+        # 3,3,2,1 -> avg 2.25
+        assert compute_tier({"simple": 3, "concrete": 3, "personal": 2, "dynamic": 1}) == NewsletterTier.GOOD
+
+    def test_fair_all_ok(self):
+        # avg 2.0
         assert compute_tier({"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2}) == NewsletterTier.FAIR
+
+    def test_fair_boundary(self):
+        # 2,2,2,1 -> avg 1.75
+        assert compute_tier({"simple": 2, "concrete": 2, "personal": 2, "dynamic": 1}) == NewsletterTier.FAIR
+
+    def test_poor_two_ok_two_poor(self):
+        # 2,2,1,1 -> avg 1.5
+        assert compute_tier({"simple": 2, "concrete": 2, "personal": 1, "dynamic": 1}) == NewsletterTier.POOR
+
+    def test_poor_all_poor(self):
+        assert compute_tier({"simple": 1, "concrete": 1, "personal": 1, "dynamic": 1}) == NewsletterTier.POOR
+
+
+class TestAggregateThemeGrades:
+    # Cross-story theme merge takes the strongest grade per theme (issue #53).
+    def test_empty(self):
+        assert aggregate_theme_grades([]) == {}
+
+    def test_single_story(self):
+        s = StoryResult(text="a", themes={"scripture": "present", "church": "emphasized"})
+        assert aggregate_theme_grades([s]) == {"scripture": "present", "church": "emphasized"}
+
+    def test_takes_strongest_grade_across_stories(self):
+        s1 = StoryResult(text="a", themes={"scripture": "present"})
+        s2 = StoryResult(text="b", themes={"scripture": "emphasized", "church": "present"})
+        assert aggregate_theme_grades([s1, s2]) == {"scripture": "emphasized", "church": "present"}
+
+    def test_emphasized_not_downgraded_by_later_present(self):
+        s1 = StoryResult(text="a", themes={"scripture": "emphasized"})
+        s2 = StoryResult(text="b", themes={"scripture": "present"})
+        assert aggregate_theme_grades([s1, s2]) == {"scripture": "emphasized"}
 
 
 @pytest.fixture
@@ -259,11 +317,11 @@ class TestExtractStories:
 class TestAssessQuality:
     async def test_scores_story(self, nl_classifier, mock_cloud_llm):
         mock_cloud_llm.complete.return_value = (
-            "SIMPLE: 4\nCONCRETE: 3\nPERSONAL: 5\nDYNAMIC: 2",
+            "SIMPLE: GOOD\nCONCRETE: OK\nPERSONAL: GOOD\nDYNAMIC: POOR",
             "quality reasoning",
         )
         scores, cot = await nl_classifier.assess_quality("Story text")
-        assert scores == {"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2}
+        assert scores == {"simple": 3, "concrete": 2, "personal": 3, "dynamic": 1}
         assert cot == "quality reasoning"
 
     async def test_returns_none_on_parse_failure(self, nl_classifier, mock_cloud_llm):
@@ -273,7 +331,7 @@ class TestAssessQuality:
 
     async def test_passes_text(self, nl_classifier, mock_cloud_llm):
         mock_cloud_llm.complete.return_value = (
-            "SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3",
+            "SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK",
             "",
         )
         await nl_classifier.assess_quality("My story text")
@@ -283,15 +341,18 @@ class TestAssessQuality:
 
 class TestClassifyThemes:
     async def test_classifies_themes(self, nl_classifier, mock_cloud_llm):
-        mock_cloud_llm.complete.return_value = ("SCRIPTURE\nCHURCH", "theme reasoning")
+        mock_cloud_llm.complete.return_value = (
+            "SCRIPTURE: EMPHASIZED\nCHURCH: PRESENT",
+            "theme reasoning",
+        )
         themes, cot = await nl_classifier.classify_themes("Story text")
-        assert themes == ["scripture", "church"]
+        assert themes == {"scripture": "emphasized", "church": "present"}
         assert cot == "theme reasoning"
 
     async def test_returns_empty_for_none(self, nl_classifier, mock_cloud_llm):
         mock_cloud_llm.complete.return_value = ("NONE", "")
         themes, cot = await nl_classifier.classify_themes("Story text")
-        assert themes == []
+        assert themes == {}
 
 
 class TestClassifyNewsletter:
@@ -299,16 +360,16 @@ class TestClassifyNewsletter:
         """Full pipeline: extract 1 story, score it, tag themes."""
         mock_cloud_llm.complete.side_effect = [
             ("STORY: A student named Jake...", ""),
-            ("SIMPLE: 4\nCONCRETE: 5\nPERSONAL: 4\nDYNAMIC: 3", "quality cot"),
-            ("CHRISTLIKENESS\nDISCIPLE_MAKING", "theme cot"),
+            ("SIMPLE: GOOD\nCONCRETE: GOOD\nPERSONAL: GOOD\nDYNAMIC: OK", "quality cot"),
+            ("CHRISTLIKENESS: PRESENT\nDISCIPLE_MAKING: EMPHASIZED", "theme cot"),
         ]
         results = await nl_classifier.classify_newsletter("newsletter body")
         assert len(results) == 1
         assert results[0].text == "A student named Jake..."
-        assert results[0].scores == {"simple": 4, "concrete": 5, "personal": 4, "dynamic": 3}
-        assert results[0].average_score == 4.0
+        assert results[0].scores == {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 2}
+        assert results[0].average_score == 2.75
         assert results[0].tier == NewsletterTier.EXCELLENT
-        assert results[0].themes == ["christlikeness", "disciple_making"]
+        assert results[0].themes == {"christlikeness": "present", "disciple_making": "emphasized"}
         assert results[0].quality_cot == "quality cot"
         assert results[0].theme_cot == "theme cot"
         assert mock_cloud_llm.complete.call_count == 3
@@ -323,32 +384,32 @@ class TestClassifyNewsletter:
         mock_cloud_llm.complete.side_effect = [
             ("STORY: Content here", ""),
             ("garbled quality output", ""),
-            ("SCRIPTURE", "theme cot"),
+            ("SCRIPTURE: PRESENT", "theme cot"),
         ]
         results = await nl_classifier.classify_newsletter("body")
         assert len(results) == 1
         assert results[0].scores is None
         assert results[0].tier is None
-        assert results[0].themes == ["scripture"]
+        assert results[0].themes == {"scripture": "present"}
 
     async def test_theme_failure_preserves_quality(self, nl_classifier, mock_cloud_llm):
         mock_cloud_llm.complete.side_effect = [
             ("STORY: Content", ""),
-            ("SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3", "quality cot"),
+            ("SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK", "quality cot"),
             RuntimeError("LLM error"),
         ]
         results = await nl_classifier.classify_newsletter("body")
         assert len(results) == 1
         assert results[0].scores is not None
-        assert results[0].themes == []
+        assert results[0].themes == {}
 
     async def test_multiple_stories(self, nl_classifier, mock_cloud_llm):
         mock_cloud_llm.complete.side_effect = [
             ("STORY: Content A\n\nSTORY: Content B", ""),
-            ("SIMPLE: 5\nCONCRETE: 5\nPERSONAL: 5\nDYNAMIC: 5", ""),
-            ("SCRIPTURE", ""),
-            ("SIMPLE: 2\nCONCRETE: 2\nPERSONAL: 2\nDYNAMIC: 2", ""),
-            ("CHURCH", ""),
+            ("SIMPLE: GOOD\nCONCRETE: GOOD\nPERSONAL: GOOD\nDYNAMIC: GOOD", ""),
+            ("SCRIPTURE: PRESENT", ""),
+            ("SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK", ""),
+            ("CHURCH: PRESENT", ""),
         ]
         results = await nl_classifier.classify_newsletter("body")
         assert len(results) == 2
@@ -374,25 +435,28 @@ class TestClassifyNewsletterTransientOutage:
     async def test_transient_theme_outage_propagates(self, nl_classifier, mock_cloud_llm):
         """LLMUnavailableError during theme classification propagates too."""
         mock_cloud_llm.complete.side_effect = [
-            ("STORY: Content", ""),                                   # extract_stories
-            ("SIMPLE: 3\nCONCRETE: 3\nPERSONAL: 3\nDYNAMIC: 3", ""),  # assess_quality
-            LLMUnavailableError("cloud endpoint down"),               # classify_themes
+            ("STORY: Content", ""),                                        # extract_stories
+            ("SIMPLE: OK\nCONCRETE: OK\nPERSONAL: OK\nDYNAMIC: OK", ""),    # assess_quality
+            LLMUnavailableError("cloud endpoint down"),                    # classify_themes
         ]
         with pytest.raises(LLMUnavailableError):
             await nl_classifier.classify_newsletter("body")
 
     async def test_non_transient_quality_error_stays_isolated(self, nl_classifier, mock_cloud_llm):
-        """A non-transient per-story error (RuntimeError) is still swallowed: the story
-        gets no scores but themes are still classified and the result is returned."""
+        """A non-transient per-story error (bare RuntimeError) is still swallowed: the
+        story gets no scores but themes are still classified and the result is returned.
+
+        (Issue #30 will add a dedicated LLMContentError subclass that DOES propagate; a
+        bare RuntimeError like this one must remain isolated.)"""
         mock_cloud_llm.complete.side_effect = [
             ("STORY: Content", ""),  # extract_stories
             RuntimeError("malformed story crashed scoring"),  # assess_quality
-            ("SCRIPTURE", "theme cot"),  # classify_themes still runs
+            ("SCRIPTURE: PRESENT", "theme cot"),  # classify_themes still runs
         ]
         results = await nl_classifier.classify_newsletter("body")
         assert len(results) == 1
         assert results[0].scores is None
-        assert results[0].themes == ["scripture"]
+        assert results[0].themes == {"scripture": "present"}
 
 
 class TestWriteAssessment:
@@ -401,10 +465,10 @@ class TestWriteAssessment:
         stories = [
             StoryResult(
                 text="Story content",
-                scores={"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2},
-                average_score=3.5,
+                scores={"simple": 3, "concrete": 2, "personal": 3, "dynamic": 1},
+                average_score=2.25,
                 tier=NewsletterTier.GOOD,
-                themes=["scripture", "church"],
+                themes={"scripture": "present", "church": "emphasized"},
                 quality_cot="quality reasoning",
                 theme_cot="theme reasoning",
             )
@@ -430,8 +494,8 @@ class TestWriteAssessment:
         assert len(record["stories"]) == 1
         assert "title" not in record["stories"][0]
         assert record["stories"][0]["text"] == "Story content"
-        assert record["stories"][0]["scores"]["simple"] == 4
-        assert record["stories"][0]["themes"] == ["scripture", "church"]
+        assert record["stories"][0]["scores"]["simple"] == 3
+        assert record["stories"][0]["themes"] == {"scripture": "present", "church": "emphasized"}
         assert record["stories"][0]["quality_cot"] == "quality reasoning"
         assert "timestamp" in record
 
@@ -472,7 +536,7 @@ class TestWriteAssessment:
             scores=None,
             average_score=None,
             tier=None,
-            themes=["scripture"],
+            themes={"scripture": "present"},
         )
         write_assessment(
             output_file=str(output_file),

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -27,6 +27,8 @@ def _make_record(
     thread_id="t_001",
     message_id="msg_001",
     timestamp="2026-02-20T12:00:00Z",
+    send_date="2026-02-19T09:00:00+00:00",
+    model="claude-sonnet-4-6",
 ):
     if stories is None:
         stories = [
@@ -40,15 +42,23 @@ def _make_record(
                 "theme_cot": "This illustrates Scripture study.",
             }
         ]
-    return {
+    record = {
         "timestamp": timestamp,
         "message_id": message_id,
         "thread_id": thread_id,
         "from": sender,
         "subject": subject,
+        "send_date": send_date,
+        "model": model,
         "overall_tier": overall_tier,
         "stories": stories,
     }
+    # Old records predate these fields; pass None to omit (backward-compat tests).
+    if send_date is None:
+        del record["send_date"]
+    if model is None:
+        del record["model"]
+    return record
 
 
 # ---------------------------------------------------------------------------
@@ -207,6 +217,32 @@ class TestBuildDetailLines:
         lines = build_detail_lines(_make_record(overall_tier="excellent"))
         text = "\n".join(lines)
         assert "excellent" in text
+
+    def test_header_shows_send_date_and_model_and_processed(self):
+        # Issue #35: email send-date grouped with email-intrinsic data, and a
+        # separate classification block with the processed date + model.
+        lines = build_detail_lines(_make_record(
+            send_date="2026-02-19T09:00:00+00:00",
+            model="claude-sonnet-4-6",
+            timestamp="2026-02-20T12:00:00+00:00",
+        ))
+        text = "\n".join(lines)
+        assert "Sent:" in text
+        assert "2026-02-19T09:00:00+00:00" in text  # send-date
+        assert "Processed:" in text
+        assert "2026-02-20T12:00:00+00:00" in text  # processed timestamp
+        assert "Model:" in text
+        assert "claude-sonnet-4-6" in text
+        # The processed date must NOT be presented under a bare "Date:" label
+        # (the exact #35 complaint).
+        assert "Date:" not in text
+
+    def test_header_missing_send_date_and_model_show_placeholders(self):
+        lines = build_detail_lines(_make_record(send_date=None, model=None))
+        text = "\n".join(lines)
+        # Missing send-date must not be misrepresented as the processed date.
+        assert "Sent: unknown" in text
+        assert "Model: —" in text
 
     def test_includes_story_text_excerpt_and_tier(self):
         record = _make_record()

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -121,6 +121,22 @@ class TestLoadAssessments:
         records = load_assessments(f)
         assert records == []
 
+    def test_rejects_old_scheme_list_themes(self, tmp_path):
+        # A pre-#53 record stores story themes as a LIST; build_detail_lines
+        # later does themes.items() and would crash mid-render. Fail fast at
+        # load with an actionable, located error instead (Finding 4).
+        f = tmp_path / "assessments.jsonl"
+        good = _make_record(thread_id="ok")
+        old = _make_record(thread_id="old")
+        old["stories"][0]["themes"] = ["scripture", "church"]
+        f.write_text(json.dumps(good) + "\n" + json.dumps(old) + "\n")
+
+        with pytest.raises(ValueError, match="old-scheme|re-migrat") as exc:
+            load_assessments(f)
+        msg = str(exc.value)
+        assert str(f) in msg  # names the file
+        assert ":2" in msg  # names the offending line number
+
 
 # ---------------------------------------------------------------------------
 # apply_filters

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -241,6 +241,28 @@ class TestBuildDetailLines:
         text = "\n".join(lines)
         assert "scripture" in text
 
+    def test_graded_themes_show_grade(self):
+        # New records carry graded themes (theme -> present/emphasized); the
+        # detail view shows the grade (issue #53).
+        record = _make_record(stories=[{
+            "text": "Content", "scores": None, "average_score": None, "tier": None,
+            "themes": {"scripture": "emphasized", "church": "present"},
+            "quality_cot": "", "theme_cot": "",
+        }])
+        text = "\n".join(build_detail_lines(record))
+        assert "scripture (emphasized)" in text
+        assert "church (present)" in text
+
+    def test_legacy_list_themes_still_render(self):
+        # Old records store a present-only list; still render as plain names.
+        record = _make_record(stories=[{
+            "text": "Content", "scores": None, "average_score": None, "tier": None,
+            "themes": ["scripture", "church"], "quality_cot": "", "theme_cot": "",
+        }])
+        text = "\n".join(build_detail_lines(record))
+        assert "scripture" in text
+        assert "church" in text
+
     def test_handles_missing_scores(self):
         record = _make_record(stories=[{
             "text": "Content without any scores",

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -35,10 +35,10 @@ def _make_record(
         stories = [
             {
                 "text": "Once upon a time in a campus ministry...",
-                "scores": {"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2},
-                "average_score": 3.5,
+                "scores": {"simple": 3, "concrete": 2, "personal": 3, "dynamic": 2},
+                "average_score": 2.5,
                 "tier": "good",
-                "themes": ["scripture", "church"],
+                "themes": {"scripture": "emphasized", "church": "present"},
                 "quality_cot": "The story focuses on one idea.",
                 "theme_cot": "This illustrates Scripture study.",
             }
@@ -127,13 +127,13 @@ class TestApplyFilters:
             _make_record(stories=[{
                 "text": "T", "scores": None,
                 "average_score": None, "tier": None,
-                "themes": ["scripture", "church"],
+                "themes": {"scripture": "emphasized", "church": "present"},
                 "quality_cot": "", "theme_cot": "",
             }]),
             _make_record(stories=[{
                 "text": "T", "scores": None,
                 "average_score": None, "tier": None,
-                "themes": ["disciple_making"],
+                "themes": {"disciple_making": "emphasized"},
                 "quality_cot": "", "theme_cot": "",
             }]),
         ]
@@ -301,8 +301,8 @@ class TestBuildDetailLines:
         record = _make_record()
         lines = build_detail_lines(record)
         text = "\n".join(lines)
-        assert "simple" in text.lower()
-        assert "4" in text
+        assert "Quality scores:" in text
+        assert "simple=Good" in text  # default simple=3 -> Good (issue #53)
 
     def test_dimension_scores_rendered_as_labels(self):
         # 1/2/3 render as Poor/OK/Good in the detail view (issue #53).
@@ -346,21 +346,11 @@ class TestBuildDetailLines:
         assert "scripture (emphasized)" in text
         assert "church (present)" in text
 
-    def test_legacy_list_themes_still_render(self):
-        # Old records store a present-only list; still render as plain names.
-        record = _make_record(stories=[{
-            "text": "Content", "scores": None, "average_score": None, "tier": None,
-            "themes": ["scripture", "church"], "quality_cot": "", "theme_cot": "",
-        }])
-        text = "\n".join(build_detail_lines(record))
-        assert "scripture" in text
-        assert "church" in text
-
     def test_handles_missing_scores(self):
         record = _make_record(stories=[{
             "text": "Content without any scores",
             "scores": None, "average_score": None, "tier": None,
-            "themes": [], "quality_cot": "", "theme_cot": "",
+            "themes": {}, "quality_cot": "", "theme_cot": "",
         }])
         lines = build_detail_lines(record)
         text = "\n".join(lines)
@@ -370,15 +360,15 @@ class TestBuildDetailLines:
         stories = [
             {
                 "text": "Content A about a student",
-                "scores": {"simple": 5, "concrete": 5, "personal": 5, "dynamic": 5},
+                "scores": {"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
                 "average_score": 5.0, "tier": "excellent",
-                "themes": ["scripture"], "quality_cot": "cot A", "theme_cot": "theme A",
+                "themes": {"scripture": "emphasized"}, "quality_cot": "cot A", "theme_cot": "theme A",
             },
             {
                 "text": "Content B about a mentor",
                 "scores": {"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2},
                 "average_score": 2.0, "tier": "fair",
-                "themes": ["church"], "quality_cot": "cot B", "theme_cot": "theme B",
+                "themes": {"church": "emphasized"}, "quality_cot": "cot B", "theme_cot": "theme B",
             },
         ]
         record = _make_record(stories=stories)
@@ -481,7 +471,7 @@ def _ui_records():
             stories=[{
                 "text": "T", "scores": None,
                 "average_score": None, "tier": None,
-                "themes": ["vocation_family"], "quality_cot": "", "theme_cot": "",
+                "themes": {"vocation_family": "emphasized"}, "quality_cot": "", "theme_cot": "",
             }],
         ),
         _make_record(subject="Subject four", overall_tier="fair", sender="erin@other.org"),

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -304,6 +304,18 @@ class TestBuildDetailLines:
         assert "simple" in text.lower()
         assert "4" in text
 
+    def test_dimension_scores_rendered_as_labels(self):
+        # 1/2/3 render as Poor/OK/Good in the detail view (issue #53).
+        record = _make_record(stories=[{
+            "text": "x", "scores": {"simple": 1, "concrete": 2, "personal": 3, "dynamic": 2},
+            "average_score": 2.0, "tier": "fair", "themes": {},
+            "quality_cot": "", "theme_cot": "",
+        }])
+        text = "\n".join(build_detail_lines(record))
+        assert "simple=Poor" in text
+        assert "concrete=OK" in text
+        assert "personal=Good" in text
+
     def test_includes_quality_cot(self):
         record = _make_record()
         lines = build_detail_lines(record)
@@ -805,6 +817,17 @@ class TestReviewAppSort:
 
 
 class TestReviewAppDateFilter:
+    async def test_non_padded_since_date_is_normalized(self):
+        # strptime accepts "2024-2-15" but the lexicographic filter needs a
+        # zero-padded ISO cutoff, else it silently mis-filters (issue #36 fix).
+        app = ReviewApp(_dated_records())
+        async with app.run_test(size=SIZE) as pilot:
+            await pilot.press("f", "d", "s")
+            await pilot.press(*"2024-2-15")
+            await pilot.press("enter")
+            assert app.f_since == "2024-02-15"
+            assert [r["subject"] for r in app.filtered] == ["Mar"]
+
     async def test_since_via_date_menu_narrows(self):
         app = ReviewApp(_dated_records())
         async with app.run_test(size=SIZE) as pilot:

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -3,7 +3,7 @@
 import json
 
 import pytest
-from textual.widgets import ListView, Static
+from textual.widgets import Label, ListView, Static
 
 from newsletter_review.tui import (
     DetailScreen,
@@ -14,6 +14,7 @@ from newsletter_review.tui import (
     format_list_row,
     load_assessments,
     run_review_tui,
+    sort_by_send_date,
     wrap_text,
 )
 
@@ -171,6 +172,41 @@ class TestApplyFilters:
         result = apply_filters([], tier="good")
         assert result == []
 
+    def test_since_filter_keeps_on_or_after_cutoff(self):
+        # Issue #36: date filter on the send-date, inclusive of the boundary.
+        records = [
+            _make_record(thread_id="old", send_date="2024-01-01T00:00:00+00:00"),
+            _make_record(thread_id="edge", send_date="2024-06-15T09:00:00+00:00"),
+            _make_record(thread_id="new", send_date="2024-12-31T00:00:00+00:00"),
+        ]
+        result = apply_filters(records, since="2024-06-15")
+        assert {r["thread_id"] for r in result} == {"edge", "new"}
+
+    def test_since_filter_excludes_records_without_send_date(self):
+        records = [
+            _make_record(thread_id="dated", send_date="2024-12-31T00:00:00+00:00"),
+            _make_record(thread_id="undated", send_date=None),
+        ]
+        result = apply_filters(records, since="2024-01-01")
+        assert [r["thread_id"] for r in result] == ["dated"]
+
+
+class TestSortBySendDate:
+    def test_desc_newest_first(self):
+        recs = [
+            _make_record(thread_id="a", send_date="2024-01-01T00:00:00+00:00"),
+            _make_record(thread_id="b", send_date="2024-03-01T00:00:00+00:00"),
+            _make_record(thread_id="c", send_date="2024-02-01T00:00:00+00:00"),
+        ]
+        assert [r["thread_id"] for r in sort_by_send_date(recs)] == ["b", "c", "a"]
+
+    def test_missing_send_date_sorts_last(self):
+        recs = [
+            _make_record(thread_id="undated", send_date=None),
+            _make_record(thread_id="dated", send_date="2024-01-01T00:00:00+00:00"),
+        ]
+        assert [r["thread_id"] for r in sort_by_send_date(recs)] == ["dated", "undated"]
+
 
 # ---------------------------------------------------------------------------
 # _format_list_row
@@ -200,6 +236,15 @@ class TestFormatListRow:
         row = format_list_row(_make_record(overall_tier=None), 120)
         # Should not crash; should show a placeholder
         assert row  # non-empty string
+
+    def test_includes_send_date(self):
+        # Issue #36: the list date column shows the email SEND date (date part).
+        row = format_list_row(_make_record(send_date="2026-02-19T09:00:00+00:00"), 120)
+        assert "2026-02-19" in row
+
+    def test_missing_send_date_shows_placeholder(self):
+        row = format_list_row(_make_record(send_date=None), 120)
+        assert row.startswith("—")  # date column is first, placeholder for no send-date
 
 
 # ---------------------------------------------------------------------------
@@ -368,6 +413,10 @@ class TestFormatFilterSummary:
         assert "tier:poor" in result
         assert "theme:church" in result
         assert "sender:john" in result
+
+    def test_since_filter(self):
+        result = format_filter_summary(since="2024-06-15")
+        assert "since:2024-06-15" in result
 
     def test_returns_empty_for_all_none(self):
         assert format_filter_summary() == ""
@@ -734,3 +783,61 @@ class TestReviewAppReviewFindings:
             assert len(app.screen_stack) == 2  # base + ONE detail
             await pilot.press("escape")
             assert not isinstance(app.screen, DetailScreen)
+
+
+def _dated_records():
+    """Records with distinct fixed send-dates (all in 2024) for sort/date tests."""
+    return [
+        _make_record(subject="Jan", send_date="2024-01-10T00:00:00+00:00"),
+        _make_record(subject="Mar", send_date="2024-03-10T00:00:00+00:00"),
+        _make_record(subject="Feb", send_date="2024-02-10T00:00:00+00:00"),
+    ]
+
+
+class TestReviewAppSort:
+    async def test_default_sort_by_send_date_desc(self):
+        app = ReviewApp(_dated_records())
+        async with app.run_test(size=SIZE):
+            # Newest send-date first.
+            assert [r["subject"] for r in app.filtered] == ["Mar", "Feb", "Jan"]
+            first_row = str(app.query_one(ListView).children[0].query_one(Label).render())
+            assert first_row.startswith("2024-03-10")
+
+
+class TestReviewAppDateFilter:
+    async def test_since_via_date_menu_narrows(self):
+        app = ReviewApp(_dated_records())
+        async with app.run_test(size=SIZE) as pilot:
+            await pilot.press("f", "d", "s")            # filter -> date -> since…
+            await pilot.press(*"2024-02-15")            # type the date
+            await pilot.press("enter")
+            assert "since:2024-02-15" in _title(app)
+            # Only Mar (2024-03-10) is on/after the cutoff.
+            assert [r["subject"] for r in app.filtered] == ["Mar"]
+
+    async def test_past_30_days_excludes_old_fixed_dates(self):
+        # The fixture's 2024 dates are far older than 30 days from "now", so a
+        # "Past 30 days" filter empties the list — deterministic regardless of clock.
+        app = ReviewApp(_dated_records())
+        async with app.run_test(size=SIZE) as pilot:
+            await pilot.press("f", "d", "3")
+            assert "since:" in _title(app)
+            assert len(app.query_one(ListView)) == 0
+
+    async def test_clear_date_filter_restores_all(self):
+        app = ReviewApp(_dated_records())
+        async with app.run_test(size=SIZE) as pilot:
+            await pilot.press("f", "d", "3")
+            assert len(app.query_one(ListView)) == 0
+            await pilot.press("f", "d", "x")            # clear
+            assert len(app.query_one(ListView)) == 3
+            assert "since:" not in _title(app)
+
+    async def test_invalid_since_date_shows_hint_and_keeps_filter(self):
+        app = ReviewApp(_dated_records())
+        async with app.run_test(size=SIZE) as pilot:
+            await pilot.press("f", "d", "s")
+            await pilot.press(*"not-a-date")
+            await pilot.press("enter")
+            assert app.f_since is None            # rejected
+            assert len(app.query_one(ListView)) == 3  # unfiltered

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -1,6 +1,11 @@
 """Tests for newsletter_review TUI — pure data functions + Pilot UI tests."""
 
 import json
+import os
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
 
 import pytest
 from textual.widgets import Label, ListView, Static
@@ -8,6 +13,7 @@ from textual.widgets import Label, ListView, Static
 from newsletter_review.tui import (
     DetailScreen,
     ReviewApp,
+    _days_ago_cutoff,
     apply_filters,
     build_detail_lines,
     format_filter_summary,
@@ -17,6 +23,24 @@ from newsletter_review.tui import (
     sort_by_send_date,
     wrap_text,
 )
+
+
+@contextmanager
+def _use_tz(name: str):
+    """Run the body under a fixed local timezone (Linux ``tzset``), restoring the
+    previous ``TZ`` afterward. Lets date tests observe the local-calendar
+    conversion regardless of the machine's real timezone."""
+    old = os.environ.get("TZ")
+    os.environ["TZ"] = name
+    time.tzset()
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old
+        time.tzset()
 
 
 def _make_record(
@@ -190,6 +214,45 @@ class TestApplyFilters:
         result = apply_filters(records, since="2024-01-01")
         assert [r["thread_id"] for r in result] == ["dated"]
 
+    def test_since_filter_uses_local_calendar_date(self):
+        # A US-evening send stored as UTC lands on the next UTC day; the since
+        # filter must compare the LOCAL calendar date, not the UTC string.
+        # 2026-07-05T01:00Z is 2026-07-04 20:00 in America/Chicago (CDT = UTC-5).
+        records = [_make_record(thread_id="eve", send_date="2026-07-05T01:00:00+00:00")]
+        with _use_tz("America/Chicago"):
+            # Local date is July 4 -> excluded by a July-5 cutoff...
+            assert apply_filters(records, since="2026-07-05") == []
+            # ...and included by a July-4 cutoff.
+            assert [r["thread_id"] for r in apply_filters(records, since="2026-07-04")] == ["eve"]
+
+
+class TestScoreLabels:
+    def test_labels_derived_from_newsletter_tokens(self):
+        # Single source of truth: the int->label map inverts newsletter._SCORE_TOKENS
+        # rather than re-hardcoding the 1/2/3 <-> Poor/OK/Good mapping.
+        from newsletter import _SCORE_TOKENS
+        from newsletter_review.tui import _SCORE_LABELS
+
+        assert set(_SCORE_LABELS) == set(_SCORE_TOKENS.values())
+        for tok, num in _SCORE_TOKENS.items():
+            assert _SCORE_LABELS[num].upper() == tok
+
+    def test_labels_render_expected_display_text(self):
+        # Byte-identical display text the detail view depends on (issue #53).
+        from newsletter_review.tui import _SCORE_LABELS
+
+        assert _SCORE_LABELS == {1: "Poor", 2: "OK", 3: "Good"}
+
+
+class TestDaysAgoCutoff:
+    def test_cutoff_is_local_calendar_date(self):
+        # The instant 2026-07-05T01:00Z is still 2026-07-04 in Chicago, so a
+        # "past 0 days" cutoff must be July 4 locally, not the UTC July 5.
+        instant = datetime(2026, 7, 5, 1, 0, 0, tzinfo=timezone.utc)
+        with _use_tz("America/Chicago"):
+            assert _days_ago_cutoff(0, now=instant) == "2026-07-04"
+            assert _days_ago_cutoff(2, now=instant) == "2026-07-02"
+
 
 class TestSortBySendDate:
     def test_desc_newest_first(self):
@@ -245,6 +308,17 @@ class TestFormatListRow:
     def test_missing_send_date_shows_placeholder(self):
         row = format_list_row(_make_record(send_date=None), 120)
         assert row.startswith("—")  # date column is first, placeholder for no send-date
+
+    def test_date_column_uses_local_calendar_date(self):
+        # 2026-07-05T01:00Z displays as its LOCAL date (2026-07-04 in Chicago),
+        # matching what Gmail and the Date header show, not the UTC day.
+        with _use_tz("America/Chicago"):
+            row = format_list_row(_make_record(send_date="2026-07-05T01:00:00+00:00"), 120)
+        assert row.startswith("2026-07-04")
+
+    def test_unparseable_send_date_shows_placeholder(self):
+        row = format_list_row(_make_record(send_date="not-a-date"), 120)
+        assert row.startswith("—")
 
 
 # ---------------------------------------------------------------------------
@@ -668,6 +742,30 @@ class TestRunReviewTui:
     def test_empty_records_prints_and_returns(self, capsys):
         run_review_tui([])
         assert "No assessment records" in capsys.readouterr().out
+
+
+class TestCli:
+    def test_since_flag_wired_and_normalized(self, monkeypatch, tmp_path):
+        # --since is passed through to the TUI, normalized to zero-padded ISO the
+        # same way the in-TUI since input is.
+        from newsletter_review import __main__ as main_mod
+
+        f = tmp_path / "a.jsonl"
+        f.write_text("")  # exists + empty -> load_assessments returns []
+        captured = {}
+        monkeypatch.setattr(main_mod, "run_review_tui", lambda records, **kw: captured.update(kw))
+        monkeypatch.setattr(sys, "argv", ["prog", "--file", str(f), "--since", "2026-7-4"])
+        main_mod.cli()
+        assert captured["init_since"] == "2026-07-04"
+
+    def test_since_flag_rejects_invalid_date(self, monkeypatch, capsys):
+        from newsletter_review import __main__ as main_mod
+
+        monkeypatch.setattr(sys, "argv", ["prog", "--since", "not-a-date"])
+        with pytest.raises(SystemExit):
+            main_mod.cli()
+        err = capsys.readouterr().err.lower()
+        assert "yyyy-mm-dd" in err or "invalid date" in err
 
 
 class TestReviewAppRobustness:

--- a/tests/test_tui_common.py
+++ b/tests/test_tui_common.py
@@ -1,0 +1,17 @@
+"""Tests for shared tui_common helpers."""
+
+from tui_common import truncate
+
+
+class TestTruncate:
+    def test_short_text_unchanged(self):
+        assert truncate("hi", 10) == "hi"
+
+    def test_exact_width_unchanged(self):
+        assert truncate("abcde", 5) == "abcde"
+
+    def test_long_text_truncated_with_ellipsis(self):
+        assert truncate("abcdefghij", 6) == "abc..."
+
+    def test_result_never_exceeds_width(self):
+        assert len(truncate("x" * 100, 20)) == 20

--- a/tui_common.py
+++ b/tui_common.py
@@ -15,6 +15,14 @@ from textual.screen import ModalScreen
 from textual.widgets import Input, ListView, Static
 
 
+def truncate(text: str, width: int) -> str:
+    """Truncate *text* to *width* characters, adding a ``...`` ellipsis if it
+    doesn't fit. Shared by the list-row renderers across the TUIs (issue #49)."""
+    if len(text) <= width:
+        return text
+    return text[: width - 3] + "..."
+
+
 class _Cancel:
     """Dismissal sentinel distinct from None (None = "clear").
 


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the all-open-issues roadmap — the *"unblock & protect the
active newsletter-curation frontier"* phase. It lands the newsletter scoring-rubric
change **before** the golden set grows large, fixes a correctness bug that was silently
corrupting the assessment corpus, and adds the curation/review-TUI improvements that
steer that curation — plus opportunistic shared-helper tech-debt folded in while those
files were already open.

Builds directly on the newsletter-evaluation system (#42) and the Textual TUI migration
(#44), both already merged to `main`. **13 commits, +2017 / −612 across 38 files.**

## Highlights

### Newsletter scoring model (#53)
- Storytelling dimensions **1–5 → 3-value Poor/OK/Good** (stored internally as ints 1/2/3; prompt emits `POOR|OK|GOOD`).
- Themes **boolean → 3-value Absent/Present/Emphasized** (stored as `dict[str,str]`, Absent omitted).
- Tier derivation: map Poor/OK/Good → 1/2/3, take the **mean of the four dimensions**, band into excellent (≥2.75) / good (≥2.25) / fair (≥1.75) / poor.
- Gmail theme label `agent/newsletter/theme/<name>` applied **only when Emphasized** — deliberately changes the label's meaning from *present* to *emphasized*. Present/Absent still recorded in the JSONL and scored in the eval.
- Report metrics reworked for the 3-value scheme: within-1 dropped (adds nothing over MAE + exact-match on a 1–3 scale); theme metric split into an **Emphasized-positive primary** (per-theme + micro/macro F1, production-aligned) plus a `themes_detection` **≥Present secondary**.
- **Old-scheme backward-compat fully removed** — all data normalized to the new dict/1–3 shapes (owner decision; parsers still reject stale LLM output as a robustness check).

### Corpus-protection correctness fix (#30, sub-problem (a))
Content-less newsletters (stories extracted but **every** grade errored) previously
swallowed the error and committed an empty `no-stories` grade, polluting the very corpus
being curated. Now a dedicated content-less exception routes to the daemon give-up path
(retry → `agent/attempted`). Genuine `NO_STORIES` (zero extracted) stays a valid
committed outcome. Sub-problem (b) (non-convergence on a flaky endpoint) is deferred as a
filed follow-up.

### Curation & review-TUI improvements
- **#52** — symmetric *exclude* toggle in `evals.review --edit` (only *unexclude* existed), at parity with the newsletter labeler.
- Persist the email **send-date + classifier model** in the assessment JSONL — the shared enabler for the two TUI issues below.
- **#35** — split the newsletter review-TUI detail header into email-intrinsic vs classification data; surface send-date, processed-date, and model.
- **#36** — send-date column, default sort by date desc, and date filters (past 30/90/365 days, since YYYY-MM-DD).
- **#41** — triage of the deferred UX grab-bag: item 7 (`is_available` 404 status detail) done here; items 2 & 3 already delivered by the Textual redesign; items 1/4/5/6 deferred with rationale (see `docs/plans/2026-07-08-phase1-decisions.md`).

### TUI shared-infra tech-debt (folded in while files were open)
- **#50** — extract atomic `atomic_write_jsonl` into `evals/__init__.py`; `save_golden_set` becomes a thin delegating wrapper.
- **#49** — unify the byte-identical `_truncate` into `tui_common.truncate` (`wrap_text`/`excerpt` intentionally left divergent).

### Review hardening
- Fixed **10 findings** from an adversarial review of the Phase 1 diff, including a theme-parse bug.

## Docs added
- `docs/plans/2026-07-08-issue-roadmap.md` — forward plan for all 28 open issues (epics, sizing, dependencies, phased order).
- `docs/plans/2026-07-08-phase1-decisions.md` — confirmed product/representation decisions for this phase.

## Issues

- **Closes #53, #52, #35, #36, #50.**
- **Partially addresses** (intentionally not auto-closed): **#30** (correctness bug (a) fixed; (b) deferred), **#41** (triage — several items deferred with rationale), **#49** (`truncate` unified; `wrap_text`/`excerpt` left divergent by design).

## Testing

`uv run --extra dev pytest tests/` → **1110 passed, 107 subtests** in ~71s. All behavior
changes built red/green per the repo's TDD rule; after-the-fact tests proven by mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
