### PR TITLE
Phase 2: golden-set curation tooling, routine-outage logging, doc fixes, #28 decision

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,10 +24,10 @@ CLOUD_LLM_API_KEY=your_api_key_here
 # NEWSLETTER_LLM_URL=https://api.anthropic.com/v1/chat/completions
 # NEWSLETTER_LLM_API_KEY=sk-ant-your_key_here
 
-# Local LLM Configuration (MLX/Qwen3 via Tailscale)
+# Local LLM Configuration (MLX/Qwen3.6 via Tailscale)
 MLX_URL=http://macbook:8080/v1/chat/completions
 # Model name — shared with email-agent (referenced in config.toml as {env.MLX_MODEL})
-MLX_MODEL=qwen/qwen3-14b
+MLX_MODEL=qwen/qwen3.6-27b
 
 # User identity for prompt personalization
 # Referenced in config.toml as {env.USER_NAME}

--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ CLOUD_LLM_API_KEY=your_api_key_here
 # Local LLM Configuration (MLX/Qwen3.6 via Tailscale)
 MLX_URL=http://macbook:8080/v1/chat/completions
 # Model name — shared with email-agent (referenced in config.toml as {env.MLX_MODEL})
-MLX_MODEL=qwen/qwen3.6-27b
+MLX_MODEL=mlx-community/Qwen3.6-27B-8bit
 
 # User identity for prompt personalization
 # Referenced in config.toml as {env.USER_NAME}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Background daemon that continuously polls Gmail for unclassified emails and appl
 
 ## Privacy Invariant
 
-Person email bodies NEVER leave the local network. Cloud LLM only sees metadata (sender, subject, snippet) for Stage 1 classification. Person email bodies are processed by local MLX/Qwen3 only.
+Person email bodies NEVER leave the local network. Cloud LLM only sees metadata (sender, subject, snippet) for Stage 1 classification. Person email bodies are processed by local MLX/Qwen3.6 only.
 
 ## Package Management
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -183,6 +183,7 @@ mlx_lm.server --model <mlx-model> --host 0.0.0.0 --port 8080 --temp 0 \
 - The request's `model` field must match the loaded `--model`, or mlx_lm.server returns `404 Not Found`. So `MLX_MODEL` must name the served model.
 - `--prompt-cache-size N` bounds how many past request KV caches are retained for reuse. The default (10) accumulates several GB of KV across distinct emails (which share no prefix) and can exhaust GPU memory; **2 is recommended** for this workload.
 - `--decode-concurrency` sizes the continuous-batching slots; it only matters when the daemon sends concurrent requests (`local_parallel` > 1).
+- To verify continuous batching actually engages, run `scripts/smoke_concurrency.py` (stdlib-only) against the server: it times N concurrent requests vs. one — with batching working, N concurrent finish in roughly the wall time of a single request; ~1× throughput means requests are serializing.
 
 ### The GPU memory ceiling (why it OOM-crashes)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The system uses two classification stages to achieve this:
 
 2. **Stage 2** routes based on the Stage 1 result:
    - **Service emails** have their full body sent to the cloud LLM for classification. This is safe because service emails (receipts, newsletters, notifications) contain no personal correspondence.
-   - **Person emails** have their full body sent to a local MLX/Qwen3 instance running on the same network. The body never leaves the local network.
+   - **Person emails** have their full body sent to a local MLX/Qwen3.6 instance running on the same network. The body never leaves the local network.
 
 If the local LLM is unavailable, person emails are silently skipped and retried on the next poll cycle. They are never sent to the cloud as a fallback.
 
@@ -123,7 +123,7 @@ PROXY_API_KEY=aproxy_your_key_here
 CLOUD_LLM_URL=https://your-llm-provider.com/v1/chat/completions
 CLOUD_LLM_API_KEY=your_api_key_here
 MLX_URL=http://macbook:8080/v1/chat/completions
-MLX_MODEL=qwen/qwen3-14b
+MLX_MODEL=qwen/qwen3.6-27b
 ```
 
 See [README-technical.md](README-technical.md#environment-variables) for the full variable reference.
@@ -192,7 +192,9 @@ The daemon is designed to run unattended and recover from transient failures:
 
 - **Exponential backoff**: If a poll cycle fails, the sleep interval doubles (up to 10x the base interval), then resets on the next successful cycle.
 - **Per-email error isolation**: If one email fails to classify, the error is logged and the loop continues with the next email.
-- **MLX graceful degradation**: If the local MLX server is unreachable, person emails are skipped (retried next cycle) while service emails continue to be classified via the cloud LLM.
+- **Transient vs. request-specific failures**: An unavailable LLM endpoint — connection refused, a connect timeout, or a connection dropped/reset mid-request — raises a clear, dedicated error and is simply retried next cycle; it never counts against the thread. Failures specific to one thread (a request timeout on an oversized transcript, a persistent per-thread proxy error) fall under the give-up rule below instead.
+- **Stuck-thread give-up**: A thread that keeps failing for a thread-specific reason is abandoned after repeated attempts (default 5) and marked `agent/attempted`, so one poison thread can't be retried forever — it stays findable under that label. The per-cycle summary reports abandonments distinctly: `Processed N/M threads (K of them abandoned after repeated failures: [...])`.
+- **MLX graceful degradation**: If the local MLX server is unreachable, person emails are skipped (retried next cycle) while service emails continue to be classified via the cloud LLM. Because the local machine is expected to be offline for stretches, an outage is treated as routine: one summary line per cycle (`Local LLM offline — deferred N person email thread(s) this cycle`), not a warning per email.
 - **Safe defaults**: Unrecognizable sender type → SERVICE (safe). Unrecognizable classification → LOW_PRIORITY (archived, not deleted).
 - **Startup validation**: The daemon verifies all required Gmail labels exist before entering the poll loop.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ PROXY_API_KEY=aproxy_your_key_here
 CLOUD_LLM_URL=https://your-llm-provider.com/v1/chat/completions
 CLOUD_LLM_API_KEY=your_api_key_here
 MLX_URL=http://macbook:8080/v1/chat/completions
-MLX_MODEL=qwen/qwen3.6-27b
+MLX_MODEL=mlx-community/Qwen3.6-27B-8bit
 ```
 
 See [README-technical.md](README-technical.md#environment-variables) for the full variable reference.

--- a/daemon.py
+++ b/daemon.py
@@ -285,6 +285,7 @@ async def process_single_thread(
     failure_tracker: "FailureTracker | None" = None,
     fetch_sem: asyncio.Semaphore | None = None,
     write_sem: asyncio.Semaphore | None = None,
+    local_deferrals: list[str] | None = None,
 ) -> bool:
     """Process a single thread through the classification pipeline.
 
@@ -495,7 +496,18 @@ async def process_single_thread(
         # LLM endpoint unreachable or dropped mid-request (server down, connect
         # timeout, reset) — transient. Don't count it toward give-up; just retry
         # next cycle (preserves graceful degradation of the privacy invariant).
-        log.warning("LLM unavailable processing thread %s: %s", thread_id, exc)
+        #
+        # The LOCAL tier being down is a routine operating condition (the MLX
+        # laptop is deliberately offline for hours at a time), not an incident:
+        # log per-thread detail at DEBUG and count the deferral so the poll loop
+        # can emit a single per-cycle INFO summary instead of N warnings
+        # (issue #24). A cloud (or tier-less) outage stays a WARNING.
+        if exc.tier == "local":
+            log.debug("Local LLM unavailable processing thread %s: %s", thread_id, exc)
+            if local_deferrals is not None:
+                local_deferrals.append(thread_id)
+        else:
+            log.warning("LLM unavailable processing thread %s: %s", thread_id, exc)
         return False
     except ProxyUnavailableError as exc:
         # api-proxy unavailable for THIS thread's call — connection refused, a timeout,
@@ -559,6 +571,20 @@ def summarize_cycle(
     return processed, given_up
 
 
+def log_local_deferrals(deferred: list[str]) -> None:
+    """One INFO line per cycle when person threads deferred on a local-LLM outage.
+
+    The per-thread handler logs each deferral at DEBUG (issue #24: a closed
+    laptop with N person emails used to emit N WARNINGs every cycle for hours);
+    this summary is the single visible trace of a routine local outage.
+    """
+    if deferred:
+        log.info(
+            "Local LLM offline — deferred %d person email thread(s) this cycle",
+            len(deferred),
+        )
+
+
 async def verify_labels_with_retry(
     label_manager: LabelManager,
     initial_backoff: int = 5,
@@ -620,6 +646,7 @@ async def run_daemon() -> None:
         temperature=config["llm"]["cloud"]["temperature"],
         timeout=config["llm"]["cloud"]["timeout"],
         extra_body=config["llm"]["cloud"].get("extra_body"),
+        tier="cloud",
     )
     local_llm = LLMClient(
         base_url=os.environ.get("MLX_URL", ""),
@@ -629,6 +656,7 @@ async def run_daemon() -> None:
         temperature=config["llm"]["local"]["temperature"],
         timeout=config["llm"]["local"]["timeout"],
         extra_body=config["llm"]["local"].get("extra_body"),
+        tier="local",
     )
 
     classifier = EmailClassifier(
@@ -655,6 +683,7 @@ async def run_daemon() -> None:
                 temperature=nl_llm_config.get("temperature", 0),
                 timeout=nl_llm_config.get("timeout", 60),
                 extra_body=nl_llm_config.get("extra_body"),
+                tier="cloud",
             )
         else:
             nl_llm = cloud_llm
@@ -726,6 +755,7 @@ async def run_daemon() -> None:
 
             max_thread_chars = daemon_config.get("max_thread_chars", DEFAULT_MAX_THREAD_CHARS)
             thread_items = list(threads.items())
+            local_deferrals: list[str] = []
             results = await asyncio.gather(
                 *(
                     process_single_thread(
@@ -744,12 +774,14 @@ async def run_daemon() -> None:
                         failure_tracker=failure_tracker,
                         fetch_sem=fetch_sem,
                         write_sem=write_sem,
+                        local_deferrals=local_deferrals,
                     )
                     for tid, msg_ids in thread_items
                 ),
                 return_exceptions=True,
             )
             processed, given_up = summarize_cycle(thread_items, results, failure_tracker)
+            log_local_deferrals(local_deferrals)
             if threads:
                 if given_up:
                     log.info(

--- a/docs/plans/2026-07-09-phase2-decisions.md
+++ b/docs/plans/2026-07-09-phase2-decisions.md
@@ -1,0 +1,96 @@
+# Phase 2 implementation — confirmed decisions
+
+Companion to `docs/plans/2026-07-08-issue-roadmap.md` (Phase 2 — Measurement &
+decisions) and sibling to `2026-07-08-phase1-decisions.md`. Implemented on branch
+`claude/phase2-measurement`, red/green TDD per `CLAUDE.md`, one commit per task.
+
+Phase 2 scope: **#13 (tooling sub-tasks) → #15 (doc fixes) → #28 (product
+decision) → #24 (log-noise fix)**, with #2 folded into #13's curation activity.
+
+## Confirmed product decision (owner, 2026-07-09)
+
+### #28 — proxy 403 (rejected/blocked write) semantics: **Option A**
+
+A `ProxyForbiddenError` (403) on a write means an operator rejected the gated
+write in the approval UI (or the op is blocked). Chosen semantics: **re-surface,
+never give up** —
+
+- Catch `ProxyForbiddenError` distinctly in the per-thread path: log one clean
+  line (no traceback), do **not** record a failure toward give-up, return False
+  so the thread is re-offered next cycle. "Rejected" = "ask me again later";
+  the human stays in control, and a rejection can never cause `agent/attempted`.
+- The same policy must cover the **marker-write path**: a 403 on the
+  `agent/attempted` write during `_give_up_if_stuck` is logged distinctly (no
+  traceback spam) and the give-up is not recorded — current behavior minus noise.
+- Accepted residual: a *permanently blocked* op re-asks every cycle (bounded:
+  one log line + one pending approval per cycle). If that becomes annoying,
+  revisit the deferred option — teaching the proxy to distinguish "operator
+  rejected" from "permanently blocked" (separate status/body) and applying B/C
+  to the latter — as a follow-up, since it needs cross-repo api-proxy changes.
+- **Implementation is Phase 3** (per the roadmap). It must add the missing test
+  exercising a 403 through `process_single_thread` (today only the HTTP layer's
+  `test_403_not_retried` covers 403 at all).
+
+## Task dispositions (this branch)
+
+### #13 — golden-set growth tooling (both sub-tasks shipped)
+
+- `evals.review --stats`: read-only composition dashboard —
+  total / excluded / unreviewed-pending / reviewed-&-unexcluded partition plus a
+  sender × label crosstab over the reviewed-&-unexcluded set (the population
+  `run_eval` scores). Unknown sender/label values get their own row/column so
+  totals never silently undercount. Pure `format_stats_summary()` for testability
+  (mirrors `newsletter_run.format_load_summary` precedent).
+- `evals.review --sender-type person|service`: mirrors `run_eval`'s flag name;
+  applies in review mode (via `select_review_threads`) and in `--edit` mode,
+  where — matching `--filter-label`'s existing semantics — an explicit filter
+  replaces the reviewed-only default.
+- The **count** target (≥60) is already met (252 reviewed & usable of 401 at
+  last measurement); the remaining lever is **person coverage** (~22%). That is
+  a human reviewing task: drain the ~147 pending threads with
+  `evals.review --unreviewed-only --sender-type person`, watching `--stats`.
+  Then re-baseline accuracy (feeds #14).
+
+### #2 — already-replied consistency (folded into #13, no code)
+
+- The golden-set reconciliation ("rate the thread as a whole; already-replied →
+  FYI") is part of the owner's curation pass — same activity, same data — aided
+  by `--show-labels` review and the new `--stats`/`--sender-type` tooling. The
+  golden set is gitignored, so no repo change is possible here.
+- The **optional prompt rule** ("a message that called for a reply no longer
+  needs one if you've already replied") is **deferred to #14**: it's a
+  prompt-criteria change and must be measured against the re-baselined set
+  (roadmap rule 1: don't tune what you can't measure). The issue itself notes
+  the CoT already applies this reasoning unprompted.
+
+### #24 — local-LLM outage logging (shipped)
+
+- Tier-awareness lives **on the exception**: `LLMClient(tier="cloud"|"local")`
+  and `LLMUnavailableError.tier`, set at both raise sites (connect-class
+  failures and mid-request drops). The daemon handler can't infer which endpoint
+  failed (Stage 1 is cloud, Stage 2 is either), so provenance is attached where
+  it's known. Eval/newsletter constructions stay tier-less → keep WARNING.
+- Local-tier outage: per-thread at **DEBUG** + one per-cycle **INFO** summary
+  (`log_local_deferrals`, fed by a per-cycle accumulator passed like
+  `failure_tracker`). Cloud/tier-less: WARNING unchanged. Deferral semantics
+  untouched (no give-up, no cloud fallback).
+- The issue's `is_available()` pre-check suggestion was obsolete — Phase 1
+  replaced it with `probe()`. A probe-based short-circuit of N doomed Stage-2b
+  calls was **not** added (acceptance didn't need it; adjacent to #29's
+  wasted-work concern — note it there if picked up).
+
+### #15 — human-README gaps (shipped)
+
+- README.md Resilience now documents: transient-vs-request-specific split,
+  stuck-thread give-up (`agent/attempted`, distinct per-cycle abandonment
+  summary), and the routine-local-outage summary line (from #24, same branch).
+- evals/README.md gained the per-endpoint `--*-timeout` / `--*-extra-body` /
+  `--*-no-think` examples and a "Thinking on/off A/B" Typical Workflow (incl.
+  the GLM-native note and the cache-key independence point).
+- `scripts/smoke_concurrency.py` referenced from README-technical's Local Model
+  Serving section.
+- Stale model example: `qwen/qwen3-14b` → **`qwen/qwen3.6-27b`** in README.md
+  and `.env.example` ("MLX/Qwen3" mentions → "MLX/Qwen3.6"). ⚠ The exact HF id
+  was inferred from issue #15's "Qwen3.6-27B actually in use" — owner should
+  confirm it matches the id the server actually serves (`MLX_MODEL` must equal
+  the served model name or mlx_lm.server 404s).

--- a/docs/plans/2026-07-09-phase2-decisions.md
+++ b/docs/plans/2026-07-09-phase2-decisions.md
@@ -89,8 +89,8 @@ never give up** —
   the GLM-native note and the cache-key independence point).
 - `scripts/smoke_concurrency.py` referenced from README-technical's Local Model
   Serving section.
-- Stale model example: `qwen/qwen3-14b` → **`qwen/qwen3.6-27b`** in README.md
-  and `.env.example` ("MLX/Qwen3" mentions → "MLX/Qwen3.6"). ⚠ The exact HF id
-  was inferred from issue #15's "Qwen3.6-27B actually in use" — owner should
-  confirm it matches the id the server actually serves (`MLX_MODEL` must equal
-  the served model name or mlx_lm.server 404s).
+- Stale model example: `qwen/qwen3-14b` → **`mlx-community/Qwen3.6-27B-8bit`**
+  in README.md, `.env.example`, and the evals/README.md `--local-model` example
+  ("MLX/Qwen3" mentions → "MLX/Qwen3.6"). The id was confirmed by the owner from
+  the deployed `.env` (2026-07-09); `MLX_MODEL` must equal the served model name
+  or mlx_lm.server 404s.

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -27,6 +27,7 @@ Harvest always appends to `--output`, deduplicating by thread ID. There is no ov
 | `--stage` | Review only stage 1 (sender) or stage 2 (label) |
 | `--unreviewed-only` | Show only threads not yet reviewed |
 | `--filter-label` | Show only threads with this label |
+| `--sender-type` | Show only threads with this expected sender type (`person` or `service`). In `--edit` mode, like `--filter-label`, an explicit filter replaces the reviewed-only default |
 | `--start-at` | Start at thread index (0-based) |
 | `--stats` | Print a composition summary and exit (read-only, no TUI): total / excluded / unreviewed-pending / reviewed-&-unexcluded counts, plus a sender × label crosstab of the reviewed-&-unexcluded set (what `run_eval` scores) |
 

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -28,6 +28,7 @@ Harvest always appends to `--output`, deduplicating by thread ID. There is no ov
 | `--unreviewed-only` | Show only threads not yet reviewed |
 | `--filter-label` | Show only threads with this label |
 | `--start-at` | Start at thread index (0-based) |
+| `--stats` | Print a composition summary and exit (read-only, no TUI): total / excluded / unreviewed-pending / reviewed-&-unexcluded counts, plus a sender × label crosstab of the reviewed-&-unexcluded set (what `run_eval` scores) |
 
 Review hotkeys: `p`/`s` sender (person/service); `r`/`f`/`l` label (needs_response/fyi/low_priority); `n` notes; `z` undo; `k` skip; `e` exclude; `q` quit. **Skip** (`k`) leaves the thread unreviewed so it reappears later. **Exclude** (`e`) sets `excluded=True` (also marks reviewed): excluded threads are dropped from the review queue here and from `run_eval` entirely. In the `--edit` TUI detail view, `e` is a symmetric **toggle** (exclude an included thread / un-exclude an excluded one; `reviewed` is left untouched). The `excluded` field is persisted in the golden set JSONL; legacy records using the old `skipped` key are still read as excluded.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -104,7 +104,7 @@ uv run python -m evals.run_eval --stages stage1_only
 uv run python -m evals.run_eval --stages stage2_only
 
 # Override model without editing config.toml
-uv run python -m evals.run_eval --local-model qwen/qwen3.6-27b --tag qwen3.6-27b
+uv run python -m evals.run_eval --local-model mlx-community/Qwen3.6-27B-8bit --tag qwen3.6-27b
 
 # Per-endpoint request overrides, also without touching config.toml:
 # a longer timeout for slow prefills, or arbitrary request-body JSON

--- a/evals/README.md
+++ b/evals/README.md
@@ -104,7 +104,15 @@ uv run python -m evals.run_eval --stages stage1_only
 uv run python -m evals.run_eval --stages stage2_only
 
 # Override model without editing config.toml
-uv run python -m evals.run_eval --local-model qwen/qwen3-14b --tag qwen3-14b
+uv run python -m evals.run_eval --local-model qwen/qwen3.6-27b --tag qwen3.6-27b
+
+# Per-endpoint request overrides, also without touching config.toml:
+# a longer timeout for slow prefills, or arbitrary request-body JSON
+uv run python -m evals.run_eval --local-timeout 300
+uv run python -m evals.run_eval --cloud-extra-body '{"top_p": 0.9}'
+
+# Disable reasoning/thinking for a run (see the A/B workflow below)
+uv run python -m evals.run_eval --local-no-think
 
 # Dry run — show what would be evaluated
 uv run python -m evals.run_eval --dry-run
@@ -289,6 +297,25 @@ uv run python -m evals.run_eval --tag baseline
 uv run python -m evals.run_eval --tag new-prompts
 uv run python -m evals.report --compare evals/results/*baseline*.jsonl evals/results/*new-prompts*.jsonl
 ```
+
+**Thinking on/off A/B (reasoning models):**
+
+The local model reasons in `<think>` tags by default; that costs tokens and
+latency. To measure what disabling it does to accuracy *before* changing
+`config.toml`, run the same person-thread evaluation both ways and compare:
+
+```bash
+uv run python -m evals.run_eval --stages stage2_only --sender-type person --tag think-on
+uv run python -m evals.run_eval --stages stage2_only --sender-type person \
+    --local-no-think --tag think-off
+uv run python -m evals.report --compare evals/results/*think-on*.jsonl evals/results/*think-off*.jsonl
+```
+
+`--local-no-think` / `--cloud-no-think` emit the `chat_template_kwargs` disable
+form (Qwen / LM Studio) and also natively disable thinking on GLM-style cloud
+models. If your server expects a different flag, pass it explicitly via
+`--local-extra-body` / `--cloud-extra-body`. The extra body is part of the LLM
+cache key, so the two runs cache independently — no `--no-cache` needed.
 
 **Model swap:**
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -75,6 +75,10 @@ uv run python -m evals.review --stage 2
 # Only review unreviewed threads
 uv run python -m evals.review --unreviewed-only
 
+# Drain the unreviewed backlog toward a thin cell in the crosstab, e.g.
+# person threads only (--sender-type also combines with --filter-label)
+uv run python -m evals.review --unreviewed-only --sender-type person
+
 # Where does the set stand? Composition dashboard (read-only, no TUI):
 # total / excluded / pending counts plus a sender × label crosstab of the
 # reviewed & unexcluded threads — the set run_eval actually scores.

--- a/evals/README.md
+++ b/evals/README.md
@@ -74,7 +74,16 @@ uv run python -m evals.review --stage 2
 
 # Only review unreviewed threads
 uv run python -m evals.review --unreviewed-only
+
+# Where does the set stand? Composition dashboard (read-only, no TUI):
+# total / excluded / pending counts plus a sender × label crosstab of the
+# reviewed & unexcluded threads — the set run_eval actually scores.
+uv run python -m evals.review --stats
 ```
+
+Use `--stats` to steer curation: the crosstab makes thin cells (e.g. few
+`person`/`needs_response` threads) obvious, so you can target harvesting and
+reviewing at the gaps instead of guessing.
 
 ## 3. Run — Replay golden set through the classifier
 

--- a/evals/review.py
+++ b/evals/review.py
@@ -440,7 +440,11 @@ def format_stats_summary(threads: list[GoldenThread]) -> str:
 
 
 def select_review_threads(
-    threads: list[GoldenThread], *, unreviewed_only: bool = False, filter_label: str | None = None
+    threads: list[GoldenThread],
+    *,
+    unreviewed_only: bool = False,
+    filter_label: str | None = None,
+    sender_type: str | None = None,
 ) -> list[GoldenThread]:
     """Threads to queue for review.
 
@@ -452,6 +456,8 @@ def select_review_threads(
         result = [t for t in result if not t.reviewed]
     if filter_label:
         result = [t for t in result if t.expected_label == filter_label]
+    if sender_type:
+        result = [t for t in result if t.expected_sender_type == sender_type]
     return result
 
 
@@ -480,6 +486,10 @@ def cli():
     )
     parser.add_argument("--unreviewed-only", action="store_true", help="Show only unreviewed threads")
     parser.add_argument("--filter-label", choices=LABELS, help="Show only threads with this label")
+    parser.add_argument(
+        "--sender-type", choices=SENDER_TYPES,
+        help="Show only threads with this expected sender type",
+    )
     parser.add_argument(
         "--start-at", type=int, default=0,
         help="Start at this index into the review queue (0-based, after excluded "
@@ -516,11 +526,13 @@ def cli():
         threads = all_threads
         if args.unreviewed_only:
             threads = [t for t in threads if not t.reviewed]
-        elif not args.filter_label:
-            # Default: show only reviewed threads
+        elif not args.filter_label and not args.sender_type:
+            # Default: show only reviewed threads (an explicit filter replaces it)
             threads = [t for t in threads if t.reviewed]
         if args.filter_label:
             threads = [t for t in threads if t.expected_label == args.filter_label]
+        if args.sender_type:
+            threads = [t for t in threads if t.expected_sender_type == args.sender_type]
 
         if not threads:
             print("No threads match the filters.", file=sys.stderr)
@@ -531,7 +543,10 @@ def cli():
 
     # Regular review mode. Excluded threads are never queued; un-exclude via --edit.
     threads = select_review_threads(
-        all_threads, unreviewed_only=args.unreviewed_only, filter_label=args.filter_label
+        all_threads,
+        unreviewed_only=args.unreviewed_only,
+        filter_label=args.filter_label,
+        sender_type=args.sender_type,
     )
 
     if not threads:

--- a/evals/review.py
+++ b/evals/review.py
@@ -384,6 +384,61 @@ class ReviewApp(App):
         self.push_screen(PromptLineScreen("Notes:", initial=thread.notes), apply)
 
 
+def format_stats_summary(threads: list[GoldenThread]) -> str:
+    """Composition dashboard for the golden set (issue #13).
+
+    Header counts partition the whole file: excluded (regardless of reviewed
+    state), unreviewed pending, and reviewed & unexcluded — the last being the
+    set ``run_eval`` actually scores, so it is the number the ≥N growth target
+    tracks. The sender × label crosstab covers only that scored set. Values
+    outside the canonical SENDER_TYPES/LABELS get their own row/column so the
+    totals always account for every scored thread.
+    """
+    total = len(threads)
+    excluded = sum(1 for t in threads if t.excluded)
+    pending = sum(1 for t in threads if not t.excluded and not t.reviewed)
+    scored = [t for t in threads if t.reviewed and not t.excluded]
+
+    sender_types = SENDER_TYPES + sorted(
+        {t.expected_sender_type for t in scored} - set(SENDER_TYPES)
+    )
+    labels = LABELS + sorted({t.expected_label for t in scored} - set(LABELS))
+
+    counts = {(s, label): 0 for s in sender_types for label in labels}
+    for t in scored:
+        counts[(t.expected_sender_type, t.expected_label)] += 1
+
+    rows = []
+    for s in sender_types:
+        row = [counts[(s, label)] for label in labels]
+        rows.append((s, row + [sum(row)]))
+    col_totals = [sum(counts[(s, label)] for s in sender_types) for label in labels]
+    rows.append(("total", col_totals + [len(scored)]))
+
+    headers = labels + ["total"]
+    name_width = max(len(name) for name, _ in rows)
+    col_widths = [
+        max(len(h), *(len(str(row[i])) for _, row in rows)) for i, h in enumerate(headers)
+    ]
+
+    lines = [
+        f"Total records:           {total}",
+        f"  Excluded:              {excluded}",
+        f"  Unreviewed (pending):  {pending}",
+        f"  Reviewed & unexcluded: {len(scored)}  (the set run_eval scores)",
+        "",
+        "Reviewed & unexcluded, sender type × label:",
+        "",
+        "  " + " " * name_width + "  " + "  ".join(h.rjust(w) for h, w in zip(headers, col_widths)),
+    ]
+    for name, row in rows:
+        lines.append(
+            "  " + name.rjust(name_width) + "  "
+            + "  ".join(str(v).rjust(w) for v, w in zip(row, col_widths))
+        )
+    return "\n".join(lines)
+
+
 def select_review_threads(
     threads: list[GoldenThread], *, unreviewed_only: bool = False, filter_label: str | None = None
 ) -> list[GoldenThread]:
@@ -431,6 +486,11 @@ def cli():
              "threads and any --filter-label/--unreviewed-only filters are applied)",
     )
     parser.add_argument("--edit", action="store_true", help="TUI for editing reviewed threads")
+    parser.add_argument(
+        "--stats", action="store_true",
+        help="Print a golden-set composition summary (counts + sender × label "
+             "crosstab of the reviewed & unexcluded set) and exit — no TUI, no writes",
+    )
     args = parser.parse_args()
 
     path = Path(args.golden_set)
@@ -443,6 +503,11 @@ def cli():
     if not all_threads:
         print("Golden set is empty.", file=sys.stderr)
         sys.exit(1)
+
+    # Stats mode: read-only composition dashboard, then out.
+    if args.stats:
+        print(format_stats_summary(all_threads))
+        return
 
     # Edit mode: default to reviewed-only, but respect explicit filters
     if args.edit:

--- a/llm_client.py
+++ b/llm_client.py
@@ -59,7 +59,16 @@ class LLMUnavailableError(Exception):
     timeout means the *request* is the problem (too-large input, bad payload) and
     is eligible for the daemon's give-up logic, whereas an unavailable endpoint is
     a transient outage that should simply be retried next cycle.
+
+    ``tier`` identifies the raising client ("cloud" / "local" / None when the
+    client didn't declare one). Both tiers raise this same type; the tier is what
+    lets the daemon treat a routine local outage (the MLX laptop is offline for
+    hours at a time) as INFO-grade while a cloud outage stays WARNING (issue #24).
     """
+
+    def __init__(self, message: str, *, tier: str | None = None):
+        super().__init__(message)
+        self.tier = tier
 
 
 class LLMContentError(RuntimeError):
@@ -87,6 +96,7 @@ class LLMClient:
         temperature: float = 0.2,
         timeout: int = 60,
         extra_body: dict | None = None,
+        tier: str | None = None,
     ):
         self.base_url = base_url
         self.api_key = api_key
@@ -95,6 +105,9 @@ class LLMClient:
         self.temperature = temperature
         self.timeout = timeout
         self.extra_body = extra_body or {}
+        # "cloud" / "local" — carried on LLMUnavailableError so callers can tell
+        # a routine local outage from a surprising cloud one (issue #24).
+        self.tier = tier
 
     def _is_glm_model(self) -> bool:
         """Check if model uses GLM-style reasoning_content instead of inline think tags."""
@@ -171,7 +184,8 @@ class LLMClient:
             # up on a thread. NOTE: ConnectTimeout/PoolTimeout subclass
             # TimeoutException, so they must be caught before the timeout clause.
             raise LLMUnavailableError(
-                f"LLM endpoint {self.model} unavailable ({type(exc).__name__}): {exc}"
+                f"LLM endpoint {self.model} unavailable ({type(exc).__name__}): {exc}",
+                tier=self.tier,
             ) from exc
         except httpx.TimeoutException:
             # Connection established but the response was too slow (read/write
@@ -187,7 +201,8 @@ class LLMClient:
             # or flapped — an availability event, also transient. (Some of these
             # stringify to ""; the wrapper guarantees an informative, non-empty msg.)
             raise LLMUnavailableError(
-                f"LLM connection to {self.model} dropped ({type(exc).__name__}): {exc}"
+                f"LLM connection to {self.model} dropped ({type(exc).__name__}): {exc}",
+                tier=self.tier,
             ) from exc
 
         if response.status_code != 200:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -19,6 +19,7 @@ from daemon import (
     FailureTracker,
     format_thread_transcript,
     load_config,
+    log_local_deferrals,
     process_single_thread,
     resolve_int_env,
     summarize_cycle,
@@ -409,6 +410,55 @@ class TestProcessSingleThread:
 
         mock_label_manager.mark_processed.assert_not_called()
 
+    async def test_local_tier_outage_defers_quietly_and_is_counted(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+        mock_thread_response, caplog,
+    ):
+        """A LOCAL-tier LLM outage is a routine condition (issue #24): the laptop
+        serving MLX is expected to be offline for hours. The per-thread handler must
+        log below WARNING and count the deferral for the one-line cycle summary,
+        while still deferring the thread (no give-up, no cloud fallback).
+        """
+        mock_proxy.get_thread.return_value = mock_thread_response
+        mock_classifier.classify_sender.side_effect = LLMUnavailableError(
+            "MLX endpoint down", tier="local"
+        )
+        deferrals = []
+
+        with caplog.at_level(logging.DEBUG, logger="email-labeler"):
+            result = await process_single_thread(
+                "thread_local", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, local_deferrals=deferrals,
+            )
+
+        assert result is False
+        assert deferrals == ["thread_local"]
+        outage_logs = [r for r in caplog.records if "unavailable" in r.getMessage().lower()]
+        assert outage_logs, "expected the outage to still be logged (at DEBUG)"
+        assert all(r.levelno < logging.WARNING for r in outage_logs)
+        mock_label_manager.mark_processed.assert_not_called()
+
+    async def test_cloud_or_tierless_outage_still_warns(
+        self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
+        mock_thread_response, caplog,
+    ):
+        """Cloud (and tier-less) LLM outages remain surprising: keep the WARNING
+        and don't count them as local deferrals."""
+        mock_proxy.get_thread.return_value = mock_thread_response
+        mock_classifier.classify_sender.side_effect = LLMUnavailableError("cloud down")
+        deferrals = []
+
+        with caplog.at_level(logging.DEBUG, logger="email-labeler"):
+            result = await process_single_thread(
+                "thread_cloud", ["msg_1"], mock_proxy, mock_classifier, mock_label_manager,
+                cloud_sem, local_sem, max_thread_chars=16000, local_deferrals=deferrals,
+            )
+
+        assert result is False
+        assert deferrals == []
+        outage_logs = [r for r in caplog.records if "unavailable" in r.getMessage().lower()]
+        assert any(r.levelno == logging.WARNING for r in outage_logs)
+
     async def test_proxy_unavailable_is_give_up_eligible_per_thread(
         self, mock_proxy, mock_classifier, mock_label_manager, cloud_sem, local_sem,
     ):
@@ -755,6 +805,24 @@ class TestSummarizeCycle:
         # This cycle only has "active"; "stale" is gone from the query.
         summarize_cycle([("active", ["1"])], [False], t)
         assert t.should_give_up("stale") is False  # pruned
+
+
+class TestLogLocalDeferrals:
+    """One INFO summary per cycle for local-LLM deferrals (issue #24) — the
+    per-thread handler stays below WARNING, this is the single visible line."""
+
+    def test_emits_one_info_line_with_the_count(self, caplog):
+        with caplog.at_level(logging.INFO, logger="email-labeler"):
+            log_local_deferrals(["t1", "t2", "t3"])
+        lines = [r for r in caplog.records if "Local LLM offline" in r.getMessage()]
+        assert len(lines) == 1
+        assert lines[0].levelno == logging.INFO
+        assert "3" in lines[0].getMessage()
+
+    def test_silent_when_nothing_deferred(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="email-labeler"):
+            log_local_deferrals([])
+        assert caplog.records == []
 
 
 class TestLoadConfig:

--- a/tests/test_eval_review.py
+++ b/tests/test_eval_review.py
@@ -387,6 +387,86 @@ class TestSelectReviewThreads:
 
 
 # ---------------------------------------------------------------------------
+# --stats: golden-set composition summary (issue #13)
+# ---------------------------------------------------------------------------
+
+def _crosstab_row(summary: str, row_name: str) -> list[int]:
+    """Ints from the crosstab row whose first token is *row_name*."""
+    for line in summary.splitlines():
+        tokens = line.split()
+        if tokens and tokens[0] == row_name and all(t.isdigit() for t in tokens[1:]) and len(tokens) > 1:
+            return [int(t) for t in tokens[1:]]
+    raise AssertionError(f"no crosstab row {row_name!r} in:\n{summary}")
+
+
+class TestFormatStatsSummary:
+    def _threads(self):
+        return [
+            # Scored set (reviewed & unexcluded): the crosstab population
+            _golden("a", reviewed=True, expected_sender_type="person", expected_label="needs_response"),
+            _golden("b", reviewed=True, expected_sender_type="person", expected_label="fyi"),
+            _golden("c", reviewed=True, expected_sender_type="service", expected_label="fyi"),
+            _golden("d", reviewed=True, expected_sender_type="service", expected_label="low_priority"),
+            _golden("e", reviewed=True, expected_sender_type="service", expected_label="low_priority"),
+            # Pending (unreviewed, unexcluded)
+            _golden("p1", reviewed=False),
+            _golden("p2", reviewed=False),
+            # Excluded — counted as excluded regardless of reviewed state
+            _golden("x1", reviewed=True, excluded=True),
+            _golden("x2", reviewed=False, excluded=True),
+        ]
+
+    def test_header_counts_partition_the_set(self):
+        import re
+
+        summary = review.format_stats_summary(self._threads())
+        assert re.search(r"Total records:\s+9\b", summary)
+        assert re.search(r"Excluded:\s+2\b", summary)
+        assert re.search(r"Unreviewed \(pending\):\s+2\b", summary)
+        assert re.search(r"Reviewed & unexcluded[^:]*:\s+5\b", summary)
+
+    def test_crosstab_covers_only_the_scored_set(self):
+        summary = review.format_stats_summary(self._threads())
+        assert _crosstab_row(summary, "person") == [1, 1, 0, 2]
+        assert _crosstab_row(summary, "service") == [0, 1, 2, 3]
+        assert _crosstab_row(summary, "total") == [1, 2, 2, 5]
+
+    def test_crosstab_columns_follow_canonical_label_order(self):
+        import re
+
+        summary = review.format_stats_summary(self._threads())
+        assert re.search(r"needs_response\s+fyi\s+low_priority\s+total", summary)
+
+    def test_unexpected_values_get_their_own_bucket(self):
+        threads = [
+            _golden("a", reviewed=True, expected_sender_type="person", expected_label="fyi"),
+            _golden("b", reviewed=True, expected_sender_type="bot", expected_label="weird"),
+        ]
+        summary = review.format_stats_summary(threads)
+        assert "bot" in summary and "weird" in summary
+        assert _crosstab_row(summary, "total")[-1] == 2  # nothing silently dropped
+
+
+class TestCliStats:
+    def test_stats_prints_and_exits_without_tui_or_save(self, tmp_path, monkeypatch, capsys):
+        import json
+
+        path = tmp_path / "golden.jsonl"
+        path.write_text(json.dumps(_golden("a", reviewed=True).to_dict()) + "\n")
+
+        def boom(*args, **kwargs):
+            raise AssertionError("--stats must not launch the TUI or save")
+
+        monkeypatch.setattr(review, "review_loop", boom)
+        monkeypatch.setattr(review, "save_golden_set", boom)
+        monkeypatch.setattr(sys, "argv", ["review", "--golden-set", str(path), "--stats"])
+        review.cli()
+
+        out = capsys.readouterr().out
+        assert "Total records:" in out
+
+
+# ---------------------------------------------------------------------------
 # cli() integration — excluded threads stay in the file, never queued
 # ---------------------------------------------------------------------------
 

--- a/tests/test_eval_review.py
+++ b/tests/test_eval_review.py
@@ -385,6 +385,23 @@ class TestSelectReviewThreads:
         selected = select_review_threads(threads, filter_label="needs_response")
         assert [t.thread_id for t in selected] == ["b"]
 
+    def test_sender_type_filter_applies(self):
+        threads = [
+            _golden("a", expected_sender_type="person"),
+            _golden("b", expected_sender_type="service"),
+        ]
+        selected = select_review_threads(threads, sender_type="service")
+        assert [t.thread_id for t in selected] == ["b"]
+
+    def test_sender_type_combines_with_unreviewed_only(self):
+        threads = [
+            _golden("a", expected_sender_type="person", reviewed=False),
+            _golden("b", expected_sender_type="person", reviewed=True),
+            _golden("c", expected_sender_type="service", reviewed=False),
+        ]
+        selected = select_review_threads(threads, unreviewed_only=True, sender_type="person")
+        assert [t.thread_id for t in selected] == ["a"]
+
 
 # ---------------------------------------------------------------------------
 # --stats: golden-set composition summary (issue #13)
@@ -527,6 +544,54 @@ class TestCliPreservesExcluded:
         dup_labels = sorted(t.expected_label for t in saved if t.thread_id == "dup")
         assert dup_labels == ["fyi", "needs_response"]  # both judgments kept
         assert all(t.reviewed for t in saved if t.thread_id == "dup")
+
+
+class TestCliSenderType:
+    def _write(self, path):
+        import json
+
+        path.write_text(
+            "".join(json.dumps(t.to_dict()) + "\n" for t in [
+                _golden("p_rev", expected_sender_type="person", reviewed=True),
+                _golden("p_unrev", expected_sender_type="person", reviewed=False),
+                _golden("s_rev", expected_sender_type="service", reviewed=True),
+            ])
+        )
+
+    def test_sender_type_limits_review_queue(self, tmp_path, monkeypatch):
+        path = tmp_path / "golden.jsonl"
+        self._write(path)
+        seen = {}
+
+        def fake_review_loop(threads, **kwargs):
+            seen["ids"] = [t.thread_id for t in threads]
+
+        monkeypatch.setattr(review, "review_loop", fake_review_loop)
+        monkeypatch.setattr(
+            sys, "argv", ["review", "--golden-set", str(path), "--sender-type", "person"]
+        )
+        review.cli()
+        assert seen["ids"] == ["p_rev", "p_unrev"]
+
+    def test_edit_mode_sender_type_drops_reviewed_only_default(self, tmp_path, monkeypatch):
+        # Mirrors --filter-label: an explicit filter replaces the edit-mode
+        # "reviewed threads only" default, so both reviewed and unreviewed
+        # person threads are shown.
+        import evals.edit_tui as edit_tui
+
+        path = tmp_path / "golden.jsonl"
+        self._write(path)
+        seen = {}
+
+        def fake_run_edit_tui(threads, all_threads, p):
+            seen["ids"] = [t.thread_id for t in threads]
+
+        monkeypatch.setattr(edit_tui, "run_edit_tui", fake_run_edit_tui)
+        monkeypatch.setattr(
+            sys, "argv", ["review", "--golden-set", str(path), "--edit", "--sender-type", "person"]
+        )
+        review.cli()
+        assert seen["ids"] == ["p_rev", "p_unrev"]
 
 
 class TestScrollAndStages:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -304,6 +304,58 @@ class TestComplete:
             mock_client_cls.assert_called_once_with(timeout=60)
 
 
+class TestTier:
+    """LLMUnavailableError carries the raising client's tier (issue #24).
+
+    Cloud and local clients raise the same exception type; the tier attribute is
+    what lets the daemon log a routine local outage (laptop offline for hours)
+    at a lower level than a surprising cloud outage.
+    """
+
+    def _down_client(self, exc, **client_kwargs):
+        client = LLMClient(
+            base_url="http://localhost:8080/v1/chat/completions",
+            api_key="", model="test-model", timeout=60, **client_kwargs,
+        )
+        patcher = patch("llm_client.httpx.AsyncClient")
+        mock_client_cls = patcher.start()
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = exc
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        return client, patcher
+
+    async def test_connect_error_carries_client_tier(self):
+        client, patcher = self._down_client(httpx.ConnectError("refused"), tier="local")
+        try:
+            with pytest.raises(LLMUnavailableError) as exc_info:
+                await client.complete("sys", "user")
+        finally:
+            patcher.stop()
+        assert exc_info.value.tier == "local"
+
+    async def test_mid_request_drop_carries_client_tier(self):
+        client, patcher = self._down_client(httpx.ReadError("reset"), tier="local")
+        try:
+            with pytest.raises(LLMUnavailableError) as exc_info:
+                await client.complete("sys", "user")
+        finally:
+            patcher.stop()
+        assert exc_info.value.tier == "local"
+
+    async def test_tier_defaults_to_none(self, cloud_client):
+        """Clients that don't declare a tier (evals, older call sites) stay tier-less."""
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.ConnectError("refused")
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(LLMUnavailableError) as exc_info:
+                await cloud_client.complete("sys", "user")
+        assert exc_info.value.tier is None
+
+
 class TestContentlessResponse:
     """A response message lacking usable content must raise a clear, non-KeyError error.
 


### PR DESCRIPTION
## Summary

Implements **Phase 2 — Measurement & decisions** of [`docs/plans/2026-07-08-issue-roadmap.md`](docs/plans/2026-07-08-issue-roadmap.md): the #13 tooling sub-tasks, the #24 log-noise fix, the #15 human-README gaps, and the #28 product decision (recorded, implementation lands in Phase 3). Decisions and dispositions are in [`docs/plans/2026-07-09-phase2-decisions.md`](docs/plans/2026-07-09-phase2-decisions.md).

### #13 — golden-set curation tooling (issue stays open for the human review pass)
- **`evals.review --stats`**: read-only composition dashboard — total / excluded / unreviewed-pending / reviewed-&-unexcluded partition plus a sender × label crosstab of the reviewed-&-unexcluded set (the population `run_eval` scores). Unknown sender/label values get their own row/column so totals never silently undercount.
- **`evals.review --sender-type person|service`**: mirrors `run_eval`'s flag; applies in review mode and `--edit` mode (where, like `--filter-label`, an explicit filter replaces the reviewed-only default). Together these let the curation drain the ~147-thread unreviewed backlog toward thin crosstab cells (person coverage).

### #24 — local-LLM outages treated as routine (closes #24)
- `LLMClient` gains an optional `tier` (`"cloud"`/`"local"`), carried on `LLMUnavailableError` from both raise sites (connect-class failures and mid-request drops).
- Daemon logs local-tier outages per-thread at **DEBUG** and emits **one INFO summary per cycle** (`Local LLM offline — deferred N person email thread(s) this cycle`); cloud/tier-less outages keep their WARNING. Deferral semantics unchanged (no give-up, no cloud fallback — privacy invariant preserved).
- The issue's `is_available()` suggestion was stale (Phase 1 replaced it with `probe()`); tier-on-the-exception is the adapted design.

### #15 — human-README gaps (closes #15)
- README.md Resilience: transient-vs-request-specific split, stuck-thread give-up (`agent/attempted` + distinct abandonment summary), routine-local-outage summary line.
- evals/README.md: per-endpoint `--*-timeout` / `--*-extra-body` / `--*-no-think` examples + a "Thinking on/off A/B" Typical Workflow (incl. GLM-native note and cache-key independence).
- README-technical.md: `scripts/smoke_concurrency.py` pointer in Local Model Serving.
- Stale `qwen/qwen3-14b` examples → `mlx-community/Qwen3.6-27B-8bit` (README.md, .env.example, evals/README.md, CLAUDE.md mention) — id confirmed by the owner from the deployed `.env`.

### #28 — product decision recorded (implementation is Phase 3)
**Option A — re-surface, never give up**: a 403 (rejected/blocked write) logs one clean line, never counts toward give-up, and is re-offered next cycle; same policy covers the `agent/attempted` marker-write path. Recorded in the decisions doc and on issue #28.

### #2 — folded into #13
Golden-set already-replied reconciliation is part of the owner's curation pass (data is gitignored); the optional prompt rule is deferred to #14 so it's measured against the re-baselined set.

## Test plan

- Red/green TDD throughout (every new test watched failing for the expected reason first)
- Full suite: **1161 tests + 109 subtests pass**; `ruff check .` clean
- TUI regression harness: **69/69 scenarios pass**
- `--stats` driven end-to-end on synthetic data reproducing the production set's shape (401 total / 252 scored crosstab)
- Multi-agent adversarial review (4 dimensions × 3-lens refuter panels, 22 agents): 0 confirmed defects; the one accepted nit (CLAUDE.md model mention) fixed in `8935946`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
