### PR TITLE
Make newsletter assessment storage durable and self-diagnosing, and migrate pre-#53 records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,10 @@ python -m newsletter_review --file path/to/file.jsonl  # Custom JSONL path
 The listing shows a send-date column and is sorted by send-date descending (newest
 first; records with no send-date sort last). The header names the resolved file
 path, the newsletter count, and the newest send date, so a stale copy of the
-assessments file is recognizable rather than indistinguishable from a live one.
-Records are deduped per `thread_id` on read (newest wins) — see Design Decision 6.
+assessments file is recognizable rather than indistinguishable from a live one
+(printed too when the file holds no records, which is when it matters most).
+Records are deduped per `thread_id` on read (newest `timestamp` wins) — see
+Design Decision 6.
 
 Hotkeys: `f` opens the filter menu (`t` tier → `e/g/f/p/c`, `h` theme → `s/c/h/v/d/x`, `s` sender text input, `d` date → `3`=past 30d / `9`=past 90d / `y`=past 365d / `s`=since YYYY-MM-DD / `x`=clear), `Enter` opens detail, `Esc` back, `q` quit.
 
@@ -108,7 +110,7 @@ cheap and self-identifying. See `evals/README.md` (workflows) and
 3. **MLX degradation**: If local MLX is down, person emails are skipped (retried next cycle). Privacy invariant preserved.
 4. **No web server**: Pure asyncio daemon. Health check via file timestamp + Docker HEALTHCHECK.
 5. **Out-of-funds halt**: A provider balance error (HTTP 402, or a 400/403 whose body carries a balance signature like `NOT_ENOUGH_BALANCE` or Anthropic's "credit balance is too low" → `LLMBalanceError`) is account-wide, not a poison thread: the daemon halts polling entirely (in-memory `DaemonHalt`; restart is the only reset), leaves the thread unprocessed (no `agent/attempted`), logs "add funds … restart the daemon" at ERROR each cycle, and keeps the healthcheck heartbeat fresh (halted by design, not hung). 429s never halt — quota phrasing on a rate limit is indistinguishable from transient throttling.
-6. **Assessment record before labels**: the newsletter JSONL is the only durable copy of a grading (Gmail keeps just the coarse tier/theme labels), and `apply_newsletter_classification` also applies `agent/processed`, which drops the thread out of `gmail_query` for good. So the record is written first: a sink fault (unwritable path, full disk) leaves the thread unprocessed and retried rather than labeled-but-lost, and is logged at ERROR with the resolved path instead of swallowed. The sink is preflighted at startup — resolved path + existing record count, plus an ERROR when it isn't writable or (in a container) isn't covered by a volume. Cost: a label failure after a successful write re-grades and re-appends next cycle, so `load_assessments` keeps only the newest record per `thread_id`.
+6. **Assessment record before labels**: the newsletter JSONL is the only durable copy of a grading (Gmail keeps just the coarse tier/theme labels), and `apply_newsletter_classification` also applies `agent/processed`, which drops the thread out of `gmail_query` for good. So the record is written first: a sink fault (unwritable path, full disk) leaves the thread unprocessed and retried rather than labeled-but-lost, and is logged at ERROR with the resolved path instead of swallowed. The sink is preflighted at startup — resolved path + existing record count, plus an ERROR when it isn't a readable/writable file or (in a container) isn't covered by a durable volume (a tmpfs over it counts as no volume). Cost: a label failure after a successful write re-grades and re-appends next cycle, so `load_assessments` keeps only the newest record per `thread_id`, chosen by the record's own `timestamp` (file position is only the tie-break — files get merged, not just appended).
 7. **Bounded-concurrency processing**: Threads in a poll cycle are processed concurrently, bounded by the `cloud_parallel`/`local_parallel` semaphores. `local_parallel` defaults to **1** (env override: `LOCAL_PARALLEL`): each concurrent local request needs its own KV cache, and long transcripts make those multi-GB, so concurrent requests can exceed the GPU's Metal working set and OOM-crash the local server. Raise it only after confirming the model + N KV caches fit; keep ≤ 8. See README-technical "Local Model Serving & Memory".
 
 ## Labels (must be pre-created in Gmail)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ uv run --extra dev ruff check .  # Lint
 - `gmail_utils.py` — Header/body parsing (copied from email-agent)
 - `config.toml` — Label definitions, prompts, operational params
 - `newsletter_review/` — Textual TUI for browsing newsletter assessment results (`python -m newsletter_review`)
+- `scripts/migrate_assessments.py` — Convert pre-#53 records in an assessments JSONL (list themes → graded dicts, 1-5 scores → Poor/OK/Good) so the review TUI can open a file with old history; tiers are preserved verbatim. Dry-run by default, `--in-place` applies (keeps `.bak`)
 - `tui_common.py` — Shared Textual widgets/screens for all TUIs (see README-technical "TUI Conventions")
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,10 @@ python -m newsletter_review --file path/to/file.jsonl  # Custom JSONL path
 ```
 
 The listing shows a send-date column and is sorted by send-date descending (newest
-first; records with no send-date sort last).
+first; records with no send-date sort last). The header names the resolved file
+path, the newsletter count, and the newest send date, so a stale copy of the
+assessments file is recognizable rather than indistinguishable from a live one.
+Records are deduped per `thread_id` on read (newest wins) — see Design Decision 6.
 
 Hotkeys: `f` opens the filter menu (`t` tier → `e/g/f/p/c`, `h` theme → `s/c/h/v/d/x`, `s` sender text input, `d` date → `3`=past 30d / `9`=past 90d / `y`=past 365d / `s`=since YYYY-MM-DD / `x`=clear), `Enter` opens detail, `Esc` back, `q` quit.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ Poll loop → find unprocessed newsletters (To/Cc matches config recipient)
   → Score each story on 4 quality dimensions (simple, concrete, personal, dynamic) as Poor/OK/Good (Cloud LLM)
   → Grade each story against Ends Statement themes as Absent/Present/Emphasized (Cloud LLM)
   → Compute overall tier (excellent/good/fair/poor) from the averaged dimension scores (Poor/OK/Good → 1/2/3; excellent ≥ 2.75, good ≥ 2.25, fair ≥ 1.75, else poor)
+  → Append assessment record to JSONL file  ← before labeling, see Design Decision 6
   → Apply tier + theme labels via api-proxy → Gmail
-  → Append assessment record to JSONL file
 ```
 
 Newsletter uses its own `[newsletter.llm]` config (currently Sonnet 4.6) independent of the email classification LLM settings.
@@ -104,7 +104,8 @@ cheap and self-identifying. See `evals/README.md` (workflows) and
 3. **MLX degradation**: If local MLX is down, person emails are skipped (retried next cycle). Privacy invariant preserved.
 4. **No web server**: Pure asyncio daemon. Health check via file timestamp + Docker HEALTHCHECK.
 5. **Out-of-funds halt**: A provider balance error (HTTP 402, or a 400/403 whose body carries a balance signature like `NOT_ENOUGH_BALANCE` or Anthropic's "credit balance is too low" → `LLMBalanceError`) is account-wide, not a poison thread: the daemon halts polling entirely (in-memory `DaemonHalt`; restart is the only reset), leaves the thread unprocessed (no `agent/attempted`), logs "add funds … restart the daemon" at ERROR each cycle, and keeps the healthcheck heartbeat fresh (halted by design, not hung). 429s never halt — quota phrasing on a rate limit is indistinguishable from transient throttling.
-6. **Bounded-concurrency processing**: Threads in a poll cycle are processed concurrently, bounded by the `cloud_parallel`/`local_parallel` semaphores. `local_parallel` defaults to **1** (env override: `LOCAL_PARALLEL`): each concurrent local request needs its own KV cache, and long transcripts make those multi-GB, so concurrent requests can exceed the GPU's Metal working set and OOM-crash the local server. Raise it only after confirming the model + N KV caches fit; keep ≤ 8. See README-technical "Local Model Serving & Memory".
+6. **Assessment record before labels**: the newsletter JSONL is the only durable copy of a grading (Gmail keeps just the coarse tier/theme labels), and `apply_newsletter_classification` also applies `agent/processed`, which drops the thread out of `gmail_query` for good. So the record is written first: a sink fault (unwritable path, full disk) leaves the thread unprocessed and retried rather than labeled-but-lost, and is logged at ERROR with the resolved path instead of swallowed. The sink is preflighted at startup — resolved path + existing record count, plus an ERROR when it isn't writable or (in a container) isn't covered by a volume. Cost: a label failure after a successful write re-grades and re-appends next cycle, so `load_assessments` keeps only the newest record per `thread_id`.
+7. **Bounded-concurrency processing**: Threads in a poll cycle are processed concurrently, bounded by the `cloud_parallel`/`local_parallel` semaphores. `local_parallel` defaults to **1** (env override: `LOCAL_PARALLEL`): each concurrent local request needs its own KV cache, and long transcripts make those multi-GB, so concurrent requests can exceed the GPU's Metal working set and OOM-crash the local server. Raise it only after confirming the model + N KV caches fit; keep ≤ 8. See README-technical "Local Model Serving & Memory".
 
 ## Labels (must be pre-created in Gmail)
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -193,6 +193,11 @@ preflights it before grading anything and reports what it found:
 
 ```
 INFO  Newsletter assessments append to: /app/data/newsletter_assessments.jsonl (412 existing record(s))
+INFO  Assessments are persisted by the mount at /app/data (source /home/you/stack/data on the
+      host) — confirm that is the directory you review
+ERROR Newsletter classification is enabled but [newsletter] output_file is not set in
+      config.toml — newsletters will be graded and labeled, but no assessment records
+      will be written
 ERROR Newsletter assessments resolve to /app/data/newsletter_assessments.jsonl, which no
       volume covers — it is inside the container's writable layer. Writes will appear to
       succeed, but the records are invisible on the host and are DESTROYED when the
@@ -212,6 +217,13 @@ ERROR Newsletter assessments sink is not writable: /app/data. Newsletters will b
   the container root itself. A bind mount over the directory *or* over the file
   silences it; an unreadable `mountinfo` (non-Linux) means no evidence, so no
   warning.
+* **The mount source** is logged when a real mount *does* hold the sink, because
+  no check can know which host directory you meant: a volume aimed at the wrong
+  one fails as silently as no volume at all. The source is `mountinfo` field 4 —
+  the path within the mount's own filesystem, which for a Docker bind mount is
+  the host directory (`/var/lib/docker/volumes/<name>/_data` for a named volume).
+* **A missing `output_file`** — `[newsletter]` configured with no sink at all —
+  is its own ERROR: grading and labeling proceed, nothing is ever recorded.
 * **The writability check** uses the nearest existing ancestor when the file
   doesn't exist yet (`write_assessment` creates missing parents).
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -197,8 +197,8 @@ preflights it before grading anything and reports what it found:
 
 ```
 INFO  Newsletter assessments append to: /app/data/newsletter_assessments.jsonl (412 existing record(s))
-INFO  Assessments are persisted by the mount at /app/data (source /home/you/stack/data on the
-      host) — confirm that is the directory you review
+INFO  Assessments are persisted by the ext4 mount at /app/data (source /home/you/stack/data,
+      relative to that filesystem's root) — confirm that is the directory you review
 ERROR Newsletter classification is enabled but [newsletter] output_file is not set in
       config.toml — newsletters will be graded and labeled, but no assessment records
       will be written
@@ -217,19 +217,30 @@ ERROR Newsletter assessments sink is not writable: /app/data. Newsletters will b
   appending to the file you review.
 * **The persistence check** compares the resolved path against
   `/proc/self/mountinfo`: it fires only inside a container (`/.dockerenv` or
-  `/run/.containerenv`) and only when the nearest mount enclosing the path is
-  the container root itself. A bind mount over the directory *or* over the file
-  silences it; an unreadable `mountinfo` (non-Linux) means no evidence, so no
-  warning.
-* **The mount source** is logged when a real mount *does* hold the sink, because
-  no check can know which host directory you meant: a volume aimed at the wrong
-  one fails as silently as no volume at all. The source is `mountinfo` field 4 —
-  the path within the mount's own filesystem, which for a Docker bind mount is
-  the host directory (`/var/lib/docker/volumes/<name>/_data` for a named volume).
+  `/run/.containerenv`), and only when the nearest mount enclosing the path is
+  the container root itself *or* is an ephemeral filesystem (`tmpfs`, `ramfs`,
+  another `overlay`) — a tmpfs over the directory looks like a volume to a
+  mount-point check but dies with the container just the same. A durable bind
+  mount over the directory *or* over the file silences it; an unreadable
+  `mountinfo` (non-Linux) means no evidence, so no warning. Note this only
+  detects containers that drop one of those two marker files — Docker and Podman
+  do, containerd under Kubernetes does not.
+* **The mount source and fstype** are logged when a real mount *does* hold the
+  sink, because no check can know which host directory you meant: a volume aimed
+  at the wrong one fails as silently as no volume at all. The source is
+  `mountinfo` field 4 — the path within the mount's own filesystem
+  (`/var/lib/docker/volumes/<name>/_data` for a named volume). It is *relative to
+  that filesystem's root*, not to the host's `/`: if the host keeps `/srv` on its
+  own filesystem, a bind of `/srv/stack/data` is reported as `/stack/data`, so
+  compare the tail rather than expecting a path that resolves on the host.
 * **A missing `output_file`** — `[newsletter]` configured with no sink at all —
   is its own ERROR: grading and labeling proceed, nothing is ever recorded.
 * **The writability check** uses the nearest existing ancestor when the file
-  doesn't exist yet (`write_assessment` creates missing parents).
+  doesn't exist yet (`write_assessment` creates missing parents), and rejects an
+  `output_file` that names a directory — fatal for every grading, yet `os.access`
+  calls a directory writable.
+* **An unreadable sink** (the count comes back unknown) is an ERROR too, not a
+  footnote on the INFO line: nothing below it can vouch for the path.
 
 #### Migrating pre-#53 records
 
@@ -246,9 +257,18 @@ python -m scripts.migrate_assessments data/newsletter_assessments.jsonl         
 python -m scripts.migrate_assessments data/newsletter_assessments.jsonl --in-place  # apply (keeps .bak)
 ```
 
+Run this **on the host**, against the host copy of the file: the image is built
+with `COPY *.py ./`, so `scripts/` is not in it and `python -m
+scripts.migrate_assessments` has nothing to import inside the container. If the
+records are still stranded in the container layer, `docker compose cp` them out
+first (see [README.md](README.md)).
+
 Stop the daemon first — it appends to this file. Every line is parsed and
-converted before anything is written, so a malformed file aborts with the
-original untouched, and the rewrite goes through a temp file + `os.replace`.
+converted before anything is written, so a malformed file (or a dimension score
+outside the old 1-5 rubric) aborts with the original untouched, and the rewrite
+goes through a temp file + `os.replace`. An `--in-place` run with nothing left to
+migrate is a no-op — it does not rewrite the file, and does not overwrite the
+`.bak` the first run left.
 
 What the conversion can and cannot preserve:
 
@@ -273,7 +293,7 @@ never re-graded. Writing first inverts the failure mode:
 | Fault | Outcome |
 |---|---|
 | Sink write fails | `OSError` logged at ERROR naming the resolved path, thread left unprocessed → retried next cycle → persistent fault ends at the give-up path's findable `agent/attempted` |
-| Labels fail after a successful write | Thread unprocessed → re-graded next cycle → a second record for that `thread_id`; `load_assessments` keeps the newest per thread, so the review TUI still shows one row |
+| Labels fail after a successful write | Thread unprocessed → re-graded next cycle → a second record for that `thread_id`; `load_assessments` keeps the newest per thread — by the record's own `timestamp`, not by file position, so merging a rescued copy of the file cannot resurrect an older grading — and the review TUI still shows one row |
 
 ### Prompt templates
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -34,6 +34,10 @@ email-labeler/
 ├── newsletter_review/  Textual TUI for browsing newsletter assessments
 │   ├── __main__.py     CLI entry point (python -m newsletter_review)
 │   └── tui.py          Pure data helpers + Textual app
+├── scripts/
+│   ├── eval_model.py           One-command-per-model eval wrapper
+│   ├── migrate_assessments.py  Convert pre-#53 records in an assessments JSONL
+│   └── smoke_concurrency.py    Local-serving concurrency smoke test
 └── tests/
     ├── conftest.py          Shared fixtures and sample Gmail data
     ├── test_llm_client.py   LLM client tests
@@ -227,6 +231,35 @@ ERROR Newsletter assessments sink is not writable: /app/data. Newsletters will b
 * **The writability check** uses the nearest existing ancestor when the file
   doesn't exist yet (`write_assessment` creates missing parents).
 
+#### Migrating pre-#53 records
+
+Issue #53 replaced the 1-5 dimension scores with the 3-value Poor/OK/Good rubric
+and list-shaped story themes with theme->grade dicts, and the readers were then
+made to **reject** the old shapes (`70c1a02`) on the premise that affected data
+would be regenerated. That premise held for the eval golden set. It does not hold
+for this file: it is append-only and is the only copy of every grading ever made,
+so a single pre-#53 record at the top makes the whole file unopenable in the
+review TUI. Convert it in place:
+
+```bash
+python -m scripts.migrate_assessments data/newsletter_assessments.jsonl             # dry run: counts
+python -m scripts.migrate_assessments data/newsletter_assessments.jsonl --in-place  # apply (keeps .bak)
+```
+
+Stop the daemon first — it appends to this file. Every line is parsed and
+converted before anything is written, so a malformed file aborts with the
+original untouched, and the rewrite goes through a temp file + `os.replace`.
+
+What the conversion can and cannot preserve:
+
+| Field | Treatment |
+|---|---|
+| `stories[].themes` | List -> `{theme: "present"}`. Exact in meaning: the old list asserted presence with no emphasis judgment. Nothing becomes `emphasized`, so no migrated record implies a theme label — matching the labels those emails carry. |
+| `stories[].scores` | Bucketed 1-2 -> Poor(1), 3 -> OK(2), 4-5 -> Good(3). Lossy by construction — 5 values onto 3. |
+| `stories[].average_score` | Recomputed from the bucketed scores so it agrees with the labels the detail view renders. |
+| `overall_tier`, `stories[].tier` | **Preserved verbatim, never recomputed.** The tier is what the grader concluded under the old rubric and what was applied to the email as a Gmail label; deriving a new one from re-bucketed dimensions would leave the record disagreeing with the message. |
+| `migrated_from` | Added (`"pre-#53"`). The review TUI's detail view surfaces it, so re-bucketed scores are never mistaken for what the grader emitted. |
+
 #### Write-before-label ordering
 
 The assessment record is written **before** `apply_newsletter_classification`
@@ -377,4 +410,5 @@ Conventions shared by every TUI:
 | `test_eval_newsletter_label.py` | `evals/newsletter_label.py` | Story curation + per-story scoring/theme pure functions, tier derivation, undo + Pilot UI tests (seed guard, undo stack, delete/label flows, selection, skip-through, autosave) |
 | `test_eval_newsletter_run.py` | `evals/newsletter_run.py` | `prompt_hash`, cache reuse, extraction vs quality/theme modes |
 | `test_eval_newsletter_report.py` | `evals/newsletter_report.py` | `match_stories`, tier/dimension/theme metrics, comparison deltas |
-| `test_newsletter_review.py` | `newsletter_review/tui.py` | Pure helpers (loading, per-thread dedup, filtering, formatting, source line) + Pilot UI tests (navigation, drill-down, tier/theme/sender filters, source header, quit) |
+| `test_newsletter_review.py` | `newsletter_review/tui.py` | Pure helpers (loading, per-thread dedup, filtering, formatting, source line, migrated-record note) + Pilot UI tests (navigation, drill-down, tier/theme/sender filters, source header, quit) |
+| `test_migrate_assessments.py` | `scripts/migrate_assessments.py` | Old-scheme detection, theme/score conversion, tier preservation, atomic in-place rewrite + abort-on-malformed, round-trip through `load_assessments` |

--- a/README-technical.md
+++ b/README-technical.md
@@ -377,4 +377,4 @@ Conventions shared by every TUI:
 | `test_eval_newsletter_label.py` | `evals/newsletter_label.py` | Story curation + per-story scoring/theme pure functions, tier derivation, undo + Pilot UI tests (seed guard, undo stack, delete/label flows, selection, skip-through, autosave) |
 | `test_eval_newsletter_run.py` | `evals/newsletter_run.py` | `prompt_hash`, cache reuse, extraction vs quality/theme modes |
 | `test_eval_newsletter_report.py` | `evals/newsletter_report.py` | `match_stories`, tier/dimension/theme metrics, comparison deltas |
-| `test_newsletter_review.py` | `newsletter_review/tui.py` | Pure helpers (loading, per-thread dedup, filtering, formatting) + Pilot UI tests (navigation, drill-down, tier/theme/sender filters, quit) |
+| `test_newsletter_review.py` | `newsletter_review/tui.py` | Pure helpers (loading, per-thread dedup, filtering, formatting, source line) + Pilot UI tests (navigation, drill-down, tier/theme/sender filters, source header, quit) |

--- a/README-technical.md
+++ b/README-technical.md
@@ -185,11 +185,50 @@ services:
       - ./data:/app/data
 ```
 
-The daemon logs the resolved absolute destination at startup —
-`Newsletter assessments append to: /app/data/newsletter_assessments.jsonl (persist
-this path via a volume mount when running in Docker)` — so a missing mount is
-diagnosable from the first log lines: verify the logged path is covered by a
-mount in `docker inspect <container> --format '{{json .Mounts}}'`.
+#### Sink preflight (startup)
+
+Every way this sink fails is silent in normal operation — an unmounted path
+accepts writes right up until the container is recreated — so the daemon
+preflights it before grading anything and reports what it found:
+
+```
+INFO  Newsletter assessments append to: /app/data/newsletter_assessments.jsonl (412 existing record(s))
+ERROR Newsletter assessments resolve to /app/data/newsletter_assessments.jsonl, which no
+      volume covers — it is inside the container's writable layer. Writes will appear to
+      succeed, but the records are invisible on the host and are DESTROYED when the
+      container is recreated. Mount the directory you review, e.g. '- ./data:/app/data'
+      under the service's volumes.
+ERROR Newsletter assessments sink is not writable: /app/data. Newsletters will be left
+      unprocessed (and eventually marked agent/attempted) rather than graded into a
+      record that cannot be saved.
+```
+
+* **The record count** is the tell for a *misdirected* sink: a daemon that has
+  been grading for weeks against a path holding `0 existing record(s)` is not
+  appending to the file you review.
+* **The persistence check** compares the resolved path against
+  `/proc/self/mountinfo`: it fires only inside a container (`/.dockerenv` or
+  `/run/.containerenv`) and only when the nearest mount enclosing the path is
+  the container root itself. A bind mount over the directory *or* over the file
+  silences it; an unreadable `mountinfo` (non-Linux) means no evidence, so no
+  warning.
+* **The writability check** uses the nearest existing ancestor when the file
+  doesn't exist yet (`write_assessment` creates missing parents).
+
+#### Write-before-label ordering
+
+The assessment record is written **before** `apply_newsletter_classification`
+commits the Gmail labels. The JSONL is the only durable copy of a grading —
+Gmail keeps just the coarse tier/theme labels — and those labels include
+`agent/processed`, which drops the thread out of `gmail_query` permanently.
+Labeling first and writing after (with the write error swallowed) turned any
+sink fault into silent, unrecoverable loss: labels applied, grading gone, thread
+never re-graded. Writing first inverts the failure mode:
+
+| Fault | Outcome |
+|---|---|
+| Sink write fails | `OSError` logged at ERROR naming the resolved path, thread left unprocessed → retried next cycle → persistent fault ends at the give-up path's findable `agent/attempted` |
+| Labels fail after a successful write | Thread unprocessed → re-graded next cycle → a second record for that `thread_id`; `load_assessments` keeps the newest per thread, so the review TUI still shows one row |
 
 ### Prompt templates
 
@@ -315,9 +354,9 @@ Conventions shared by every TUI:
 | `test_llm_client.py` | `llm_client.py` | Request format, auth headers, `<think>` tag stripping, error handling, out-of-funds (`LLMBalanceError`) detection, availability checks |
 | `test_classifier.py` | `classifier.py` | `parse_sender` formats, `parse_sender_type` edge cases and defaults, `parse_email_label` edge cases and defaults, cloud/local routing, full pipeline |
 | `test_labeler.py` | `labeler.py` | Label verification (all present, partial, none), label ID mapping, inbox/archive actions, single API call per email |
-| `test_daemon.py` | `daemon.py` | Service email path, person email path, MLX-unavailable skip, error isolation, out-of-funds halt, config loading |
+| `test_daemon.py` | `daemon.py` | Service email path, person email path, MLX-unavailable skip, error isolation, out-of-funds halt, config loading, assessment-sink preflight + write-before-label durability |
 | `test_config_utils.py` | `config_utils.py` | Config loading, `{env.VAR}` substitution |
-| `test_newsletter.py` | `newsletter.py` | Newsletter story extraction, quality scoring, theme classification |
+| `test_newsletter.py` | `newsletter.py` | Newsletter story extraction, quality scoring, theme classification, assessment record writing, sink persistence/writability diagnostics |
 | `test_eval_schemas.py` | `evals/schemas.py` | GoldenThread/PredictionResult/RunMeta serialization round-trips |
 | `test_eval_harvest.py` | `evals/harvest.py` | Ground truth inference from labels, deduplication |
 | `test_eval_report.py` | `evals/report.py` | Confusion matrix, precision/recall/F1, accuracy, privacy violation metrics |
@@ -326,4 +365,4 @@ Conventions shared by every TUI:
 | `test_eval_newsletter_label.py` | `evals/newsletter_label.py` | Story curation + per-story scoring/theme pure functions, tier derivation, undo + Pilot UI tests (seed guard, undo stack, delete/label flows, selection, skip-through, autosave) |
 | `test_eval_newsletter_run.py` | `evals/newsletter_run.py` | `prompt_hash`, cache reuse, extraction vs quality/theme modes |
 | `test_eval_newsletter_report.py` | `evals/newsletter_report.py` | `match_stories`, tier/dimension/theme metrics, comparison deltas |
-| `test_newsletter_review.py` | `newsletter_review/tui.py` | Pure helpers (loading, filtering, formatting) + Pilot UI tests (navigation, drill-down, tier/theme/sender filters, quit) |
+| `test_newsletter_review.py` | `newsletter_review/tui.py` | Pure helpers (loading, per-thread dedup, filtering, formatting) + Pilot UI tests (navigation, drill-down, tier/theme/sender filters, quit) |

--- a/README.md
+++ b/README.md
@@ -254,6 +254,29 @@ If you ran the daemon in Docker, point `--file` at the host path you mounted (or
 run the command from the directory holding `data/`) — the default path is
 relative to the current directory.
 
+#### "old-scheme record" on startup
+
+```
+Error loading …/newsletter_assessments.jsonl: …:1: old-scheme record — story themes
+are a list (['vocation_family']), not a theme->grade dict.
+```
+
+Records written before the scoring-scheme change (July 2026) store story themes
+as a plain list and dimension scores on a 1-5 scale. The reader rejects those
+outright, so one old record at the top of the file blocks the whole file. Convert
+it — with the daemon stopped, since it appends there:
+
+```bash
+python -m scripts.migrate_assessments path/to/newsletter_assessments.jsonl             # counts only
+python -m scripts.migrate_assessments path/to/newsletter_assessments.jsonl --in-place  # apply
+```
+
+A `.bak` copy is kept. Old themes become `present`, old scores are bucketed into
+Poor/OK/Good, and each record's tier is left exactly as graded — so it still
+matches the label on the email. Migrated records say so in their detail view.
+See [README-technical.md](README-technical.md#migrating-pre-53-records) for what
+the conversion can and cannot preserve.
+
 ## Resilience
 
 The daemon is designed to run unattended and recover from transient failures:

--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ docker compose cp email-labeler:/app/data/newsletter_assessments.jsonl ./recover
 ```
 
 Then append `recovered.jsonl` to your host file (the review TUI keeps the newest
-record per newsletter, so overlapping entries are harmless).
+record per newsletter, decided by each record's own timestamp rather than by
+where it landed in the file, so overlapping entries are harmless in either
+order).
 
 ### Newsletter review TUI
 
@@ -271,7 +273,8 @@ python -m scripts.migrate_assessments path/to/newsletter_assessments.jsonl      
 python -m scripts.migrate_assessments path/to/newsletter_assessments.jsonl --in-place  # apply
 ```
 
-A `.bak` copy is kept. Old themes become `present`, old scores are bucketed into
+Run it from a checkout on the host — `scripts/` is not inside the Docker image.
+A `.bak` copy is kept (a second run changes nothing and leaves that copy alone). Old themes become `present`, old scores are bucketed into
 Poor/OK/Good, and each record's tier is left exactly as graded — so it still
 matches the label on the email. Migrated records say so in their detail view.
 See [README-technical.md](README-technical.md#migrating-pre-53-records) for what

--- a/README.md
+++ b/README.md
@@ -200,8 +200,23 @@ services:
       - ./data:/app/data   # or an absolute host path
 ```
 
-The daemon logs the resolved absolute path at startup
-(`Newsletter assessments append to: ...`) — check it points at the mount.
+The daemon checks this for you at startup. It logs the resolved absolute path
+along with how many records that file already holds
+(`Newsletter assessments append to: /app/data/newsletter_assessments.jsonl (412
+existing record(s))`) — a long-running daemon reporting `0 existing record(s)` is
+writing somewhere other than the file you browse. If nothing is mounted over the
+path, it says so as an ERROR on the next line.
+
+If you have already been running without the mount, the records so far are still
+inside the *running* container and will be destroyed the moment it is recreated.
+Rescue them before your next `docker compose up -d`:
+
+```bash
+docker compose cp email-labeler:/app/data/newsletter_assessments.jsonl ./recovered.jsonl
+```
+
+Then append `recovered.jsonl` to your host file (the review TUI keeps the newest
+record per newsletter, so overlapping entries are harmless).
 
 ### Newsletter review TUI
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ The listing shows one row per newsletter, newest send-date first. Press `Enter`
 to open a newsletter and see its stories with their dimension scores and themes,
 `Esc` to go back, `f` to open the filter menu, and `q` to quit.
 
+The header names the file it read, how many newsletters are in it, and the newest
+send date — e.g. `/srv/stack/data/newsletter_assessments.jsonl — 253 newsletters,
+newest sent 2026-07-29`. That is deliberate: a stale copy of the file, or a copy
+from a path the daemon no longer writes to, looks exactly like a working one until
+you notice its newest newsletter is weeks old. Cross-check it against the path the
+daemon logs at startup.
+
 Filters are also available up front, so you can open straight into a slice:
 
 ```bash

--- a/daemon.py
+++ b/daemon.py
@@ -28,6 +28,7 @@ from newsletter import (
     NewsletterTier,
     aggregate_theme_grades,
     count_records,
+    covering_mount,
     is_newsletter,
     parse_send_date,
     read_mountinfo,
@@ -782,9 +783,23 @@ def preflight_assessment_sink(output_file: str) -> None:
         log.error("%s", writability)
 
     if running_in_container():
-        persistence = sink_persistence_warning(path, read_mountinfo())
+        mountinfo = read_mountinfo()
+        persistence = sink_persistence_warning(path, mountinfo)
         if persistence:
             log.error("%s", persistence)
+        else:
+            # A mount holds the sink, but only the operator knows whether it is
+            # the directory they review: a volume pointed somewhere else fails
+            # just as silently as no volume at all. Name the source so the
+            # answer is one log line away instead of a docker inspect away.
+            mount = covering_mount(path, mountinfo)
+            if mount:
+                log.info(
+                    "Assessments are persisted by the mount at %s (source %s on the "
+                    "host) — confirm that is the directory you review",
+                    mount[0],
+                    mount[1],
+                )
 
 
 async def run_daemon() -> None:

--- a/daemon.py
+++ b/daemon.py
@@ -848,6 +848,14 @@ async def run_daemon() -> None:
         log.info("Newsletter classification enabled for: %s", newsletter_recipient)
         if newsletter_output_file:
             preflight_assessment_sink(newsletter_output_file)
+        else:
+            # Grading with no sink is silent by construction: labels apply, the
+            # per-thread summary logs, and nothing is ever recorded to review.
+            log.error(
+                "Newsletter classification is enabled but [newsletter] output_file is "
+                "not set in config.toml — newsletters will be graded and labeled, but "
+                "no assessment records will be written"
+            )
 
     newsletter_only = os.environ.get("NEWSLETTER_ONLY", "").strip().lower() in ("1", "true", "yes")
     if newsletter_only:

--- a/daemon.py
+++ b/daemon.py
@@ -30,10 +30,10 @@ from newsletter import (
     count_records,
     covering_mount,
     is_newsletter,
+    mount_persistence_warning,
     parse_send_date,
     read_mountinfo,
     running_in_container,
-    sink_persistence_warning,
     sink_writability_warning,
     write_assessment,
 )
@@ -765,41 +765,52 @@ def preflight_assessment_sink(output_file: str) -> None:
         working directory (``/app`` in the image), plus how many records it
         already holds — a long-running daemon reporting 0 is appending
         somewhere other than the file being reviewed;
-      * an ERROR when the path is not writable (a read-only mount), which now
-        blocks labeling rather than being swallowed; and
+      * an ERROR when the path is not writable (a read-only mount) or is not a
+        file at all, which now blocks labeling rather than being swallowed; and
       * an ERROR when nothing persists the path — in a container with no volume
-        over it, writes succeed and every record dies with the container.
+        over it (or only a tmpfs), writes succeed and every record dies with the
+        container.
     """
     path = Path(output_file).resolve()
     existing = count_records(path)
-    tally = (
-        f"{existing} existing record(s)" if existing is not None
-        else "existing record count unreadable"
-    )
-    log.info("Newsletter assessments append to: %s (%s)", path, tally)
+    if existing is None:
+        # Not merely uninformative: the sink cannot be read, so nothing below can
+        # vouch for it and write_assessment is very likely to fail the same way.
+        log.error(
+            "Newsletter assessments append to: %s — but that path cannot be read, so "
+            "its existing records cannot be counted and writes are likely to fail too",
+            path,
+        )
+    else:
+        log.info("Newsletter assessments append to: %s (%d existing record(s))", path, existing)
 
     writability = sink_writability_warning(path)
     if writability:
         log.error("%s", writability)
 
     if running_in_container():
-        mountinfo = read_mountinfo()
-        persistence = sink_persistence_warning(path, mountinfo)
+        # One mountinfo read AND one parse serve both the warning and the source
+        # line below — they answer the same question about the same mount.
+        mount = covering_mount(path, read_mountinfo())
+        persistence = mount_persistence_warning(path, mount)
         if persistence:
             log.error("%s", persistence)
-        else:
+        elif mount:
             # A mount holds the sink, but only the operator knows whether it is
             # the directory they review: a volume pointed somewhere else fails
-            # just as silently as no volume at all. Name the source so the
-            # answer is one log line away instead of a docker inspect away.
-            mount = covering_mount(path, mountinfo)
-            if mount:
-                log.info(
-                    "Assessments are persisted by the mount at %s (source %s on the "
-                    "host) — confirm that is the directory you review",
-                    mount[0],
-                    mount[1],
-                )
+            # just as silently as no volume at all. Name the source so the answer
+            # is one log line away instead of a docker inspect away. It is the
+            # path within the source FILESYSTEM, so it lacks that filesystem's
+            # own host mount point (a bind of /srv/stack/data reports
+            # /stack/data when /srv is a separate filesystem) — say so rather
+            # than claiming a host path that may not exist.
+            log.info(
+                "Assessments are persisted by the %s mount at %s (source %s, relative "
+                "to that filesystem's root) — confirm that is the directory you review",
+                mount[2],
+                mount[0],
+                mount[1],
+            )
 
 
 async def run_daemon() -> None:

--- a/daemon.py
+++ b/daemon.py
@@ -27,8 +27,13 @@ from newsletter import (
     NewsletterClassifier,
     NewsletterTier,
     aggregate_theme_grades,
+    count_records,
     is_newsletter,
     parse_send_date,
+    read_mountinfo,
+    running_in_container,
+    sink_persistence_warning,
+    sink_writability_warning,
     write_assessment,
 )
 from proxy_client import (
@@ -421,14 +426,16 @@ async def process_single_thread(
                 # Merge graded themes across stories (strongest grade per theme)
                 all_themes = aggregate_theme_grades(story_results)
 
-                async with (write_sem or nullcontext()):
-                    await label_manager.apply_newsletter_classification(
-                        message_ids=all_msg_ids,
-                        tier=best_tier,
-                        themes=all_themes,
-                    )
-
-                # Write structured results
+                # Persist the assessment BEFORE the labels commit. The JSONL record
+                # is the only durable copy of the grading — Gmail keeps just the
+                # coarse tier/theme labels, and apply_newsletter_classification also
+                # adds agent/processed, which drops the thread out of gmail_query for
+                # good. Writing afterwards (and swallowing the error) turned any sink
+                # fault — a bind mount gone read-only, a full disk, bad permissions —
+                # into permanent silent data loss: labels applied, grading gone,
+                # thread never re-graded. Writing first means a sink fault leaves the
+                # thread unprocessed, so the next cycle retries it (and a persistent
+                # fault ends at the give-up path's findable agent/attempted).
                 if newsletter_output_file:
                     try:
                         write_assessment(
@@ -442,8 +449,25 @@ async def process_single_thread(
                             send_date=send_date,
                             model=newsletter_classifier.cloud_llm.model,
                         )
-                    except Exception:
-                        log.exception("Failed to write newsletter assessment for thread %s", thread_id)
+                    except OSError as exc:
+                        # Named at ERROR with the resolved path so a sink fault is
+                        # distinguishable from a grading fault at a glance.
+                        log.error(
+                            "Cannot write newsletter assessment to %s: %s — thread %s "
+                            "left unprocessed for retry (check the path exists, is "
+                            "writable, and is volume-mounted)",
+                            Path(newsletter_output_file).resolve(),
+                            exc,
+                            thread_id,
+                        )
+                        raise
+
+                async with (write_sem or nullcontext()):
+                    await label_manager.apply_newsletter_classification(
+                        message_ids=all_msg_ids,
+                        tier=best_tier,
+                        themes=all_themes,
+                    )
 
                 story_count = len(story_results)
                 log.info(
@@ -729,6 +753,40 @@ async def verify_labels_with_retry(
             backoff = min(backoff * 2, max_backoff)
 
 
+def preflight_assessment_sink(output_file: str) -> None:
+    """Report — loudly, at startup — where newsletter assessments will land and
+    whether that destination can actually keep them.
+
+    Every way this sink fails is silent in normal operation, so each one gets a
+    line the operator can act on before a single newsletter is graded:
+
+      * the RESOLVED absolute path, since ``output_file`` is relative to the
+        working directory (``/app`` in the image), plus how many records it
+        already holds — a long-running daemon reporting 0 is appending
+        somewhere other than the file being reviewed;
+      * an ERROR when the path is not writable (a read-only mount), which now
+        blocks labeling rather than being swallowed; and
+      * an ERROR when nothing persists the path — in a container with no volume
+        over it, writes succeed and every record dies with the container.
+    """
+    path = Path(output_file).resolve()
+    existing = count_records(path)
+    tally = (
+        f"{existing} existing record(s)" if existing is not None
+        else "existing record count unreadable"
+    )
+    log.info("Newsletter assessments append to: %s (%s)", path, tally)
+
+    writability = sink_writability_warning(path)
+    if writability:
+        log.error("%s", writability)
+
+    if running_in_container():
+        persistence = sink_persistence_warning(path, read_mountinfo())
+        if persistence:
+            log.error("%s", persistence)
+
+
 async def run_daemon() -> None:
     """Main polling loop."""
     config = load_config()
@@ -789,16 +847,7 @@ async def run_daemon() -> None:
         newsletter_output_file = nl_config.get("output_file", "")
         log.info("Newsletter classification enabled for: %s", newsletter_recipient)
         if newsletter_output_file:
-            # Log the RESOLVED path: output_file is relative to the process
-            # working directory, so in Docker (WORKDIR /app) a missing bind
-            # mount for this directory silently strands assessments in the
-            # container layer — lost on the next recreate. Making the absolute
-            # destination visible up front is the deployment sanity check.
-            log.info(
-                "Newsletter assessments append to: %s (persist this path via a "
-                "volume mount when running in Docker)",
-                Path(newsletter_output_file).resolve(),
-            )
+            preflight_assessment_sink(newsletter_output_file)
 
     newsletter_only = os.environ.get("NEWSLETTER_ONLY", "").strip().lower() in ("1", "true", "yes")
     if newsletter_only:

--- a/newsletter.py
+++ b/newsletter.py
@@ -7,6 +7,7 @@ and tags them with Ends Statement themes. All LLM calls use the cloud endpoint
 
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -296,6 +297,129 @@ def write_assessment(
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "a") as f:
         f.write(json.dumps(record) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Assessment sink diagnostics
+#
+# The JSONL sink is the only durable copy of a newsletter's grading, and the
+# ways it goes wrong are all silent: writes to an unmounted container path
+# succeed right up until the container is recreated, and a read-only mount only
+# surfaces per-thread, mid-cycle. These preflight the sink at startup so a
+# misconfigured deployment announces itself instead of quietly grading into the
+# void.
+# ---------------------------------------------------------------------------
+
+# Marker files every mainstream container runtime drops in the root filesystem.
+_CONTAINER_MARKERS = (Path("/.dockerenv"), Path("/run/.containerenv"))
+_MOUNTINFO = Path("/proc/self/mountinfo")
+
+
+def running_in_container() -> bool:
+    """True when this process looks like it is running inside a container."""
+    return any(marker.exists() for marker in _CONTAINER_MARKERS)
+
+
+def read_mountinfo(path: Path = _MOUNTINFO) -> str | None:
+    """Read ``/proc/self/mountinfo``, or None where it isn't available (macOS)."""
+    try:
+        return path.read_text()
+    except OSError:
+        return None
+
+
+def mount_points(mountinfo: str) -> set[str]:
+    """Extract the mount points (field 5) from ``/proc/self/mountinfo`` text.
+
+    Paths containing spaces, tabs, newlines, or backslashes are octal-escaped in
+    mountinfo; ``\\040`` (space) is the one worth decoding for a bind-mounted
+    host directory. Malformed lines are skipped rather than raising — this is a
+    diagnostic, and it must never be the thing that breaks startup.
+    """
+    points = set()
+    for line in mountinfo.splitlines():
+        fields = line.split(" ")
+        if len(fields) < 10:  # a real mountinfo line has at least 10 fields
+            continue
+        points.add(fields[4].replace("\\040", " "))
+    return points
+
+
+def sink_persistence_warning(path: Path, mountinfo: str | None) -> str | None:
+    """Warn when *path* resolves into a container's throwaway writable layer.
+
+    The daemon's ``output_file`` is relative to the working directory (``/app``
+    in the image), so without a volume mount the assessments land in the
+    container layer: every write succeeds, the review TUI on the host sees
+    nothing new, and the records are destroyed on the next ``docker compose up``.
+    Detection is "which mount covers this path" — the nearest enclosing mount
+    point. If that is the container root itself, nothing is persisting it.
+
+    Returns None when there's no evidence to act on (mountinfo unreadable), so
+    the check never cries wolf on a platform it can't inspect.
+    """
+    if mountinfo is None:
+        return None
+
+    # Nearest enclosing mount = the longest mount point that is the path itself
+    # or one of its ancestors. Compared as paths, not strings, so /app/dataset
+    # is never mistaken for a mount covering /app/data.
+    nearest = ""
+    for point in mount_points(mountinfo):
+        candidate = Path(point)
+        if path == candidate or path.is_relative_to(candidate):
+            if len(str(candidate)) > len(nearest):
+                nearest = str(candidate)
+
+    if nearest != "/":
+        return None
+
+    return (
+        f"Newsletter assessments resolve to {path}, which no volume covers — it is "
+        "inside the container's writable layer. Writes will appear to succeed, but "
+        "the records are invisible on the host and are DESTROYED when the container "
+        "is recreated. Mount the directory you review, e.g. '- ./data:/app/data' "
+        "under the service's volumes."
+    )
+
+
+def sink_writability_warning(path: Path) -> str | None:
+    """Warn when *path* cannot be appended to (read-only mount, permissions).
+
+    ``write_assessment`` creates missing parents, so a not-yet-existing file is
+    fine as long as the nearest existing ancestor is writable — that ancestor is
+    what gets checked, and named, when the file itself isn't there yet.
+    """
+    if path.exists():
+        if os.access(path, os.W_OK):
+            return None
+        target = path
+    else:
+        target = next((p for p in path.parents if p.exists()), Path(path.anchor or "."))
+        if os.access(target, os.W_OK | os.X_OK):
+            return None
+
+    return (
+        f"Newsletter assessments sink is not writable: {target}. Newsletters will be "
+        "left unprocessed (and eventually marked agent/attempted) rather than graded "
+        "into a record that cannot be saved."
+    )
+
+
+def count_records(path: Path) -> int | None:
+    """Count non-blank lines in the assessments JSONL, or None if unreadable.
+
+    Reported at startup: a daemon that has been grading for weeks against a sink
+    holding 0 records is writing somewhere other than the file being reviewed —
+    the single number that makes a misdirected sink obvious.
+    """
+    try:
+        with open(path) as f:
+            return sum(1 for line in f if line.strip())
+    except FileNotFoundError:
+        return 0
+    except OSError:
+        return None
 
 
 def is_newsletter(messages: list[dict], recipient: str) -> bool:

--- a/newsletter.py
+++ b/newsletter.py
@@ -328,21 +328,47 @@ def read_mountinfo(path: Path = _MOUNTINFO) -> str | None:
         return None
 
 
-def mount_points(mountinfo: str) -> set[str]:
-    """Extract the mount points (field 5) from ``/proc/self/mountinfo`` text.
+def parse_mounts(mountinfo: str) -> dict[str, str]:
+    """Map mount point -> source from ``/proc/self/mountinfo`` text.
+
+    Fields 5 and 4 respectively: the mount point, and the source path *within
+    its own filesystem* — for a Docker bind mount that is the host directory
+    (``/var/lib/docker/volumes/<name>/_data`` for a named volume), which is what
+    makes "am I appending to the directory I actually review?" answerable from
+    inside the container.
 
     Paths containing spaces, tabs, newlines, or backslashes are octal-escaped in
     mountinfo; ``\\040`` (space) is the one worth decoding for a bind-mounted
     host directory. Malformed lines are skipped rather than raising — this is a
     diagnostic, and it must never be the thing that breaks startup.
     """
-    points = set()
+    mounts = {}
     for line in mountinfo.splitlines():
         fields = line.split(" ")
         if len(fields) < 10:  # a real mountinfo line has at least 10 fields
             continue
-        points.add(fields[4].replace("\\040", " "))
-    return points
+        mounts[fields[4].replace("\\040", " ")] = fields[3].replace("\\040", " ")
+    return mounts
+
+
+def covering_mount(path: Path, mountinfo: str | None) -> tuple[str, str] | None:
+    """The mount actually holding *path*, as ``(mount_point, source)``.
+
+    The nearest enclosing mount: the longest mount point that is *path* itself or
+    one of its ancestors. Compared as paths, not strings, so ``/app/dataset`` is
+    never mistaken for a mount covering ``/app/data``. Returns None when
+    mountinfo is unreadable (non-Linux) — no evidence, no claim.
+    """
+    if mountinfo is None:
+        return None
+
+    nearest: tuple[str, str] | None = None
+    for point, source in parse_mounts(mountinfo).items():
+        candidate = Path(point)
+        if path == candidate or path.is_relative_to(candidate):
+            if nearest is None or len(point) > len(nearest[0]):
+                nearest = (point, source)
+    return nearest
 
 
 def sink_persistence_warning(path: Path, mountinfo: str | None) -> str | None:
@@ -352,26 +378,14 @@ def sink_persistence_warning(path: Path, mountinfo: str | None) -> str | None:
     in the image), so without a volume mount the assessments land in the
     container layer: every write succeeds, the review TUI on the host sees
     nothing new, and the records are destroyed on the next ``docker compose up``.
-    Detection is "which mount covers this path" — the nearest enclosing mount
-    point. If that is the container root itself, nothing is persisting it.
+    If the mount covering the path is the container root itself, nothing is
+    persisting it.
 
     Returns None when there's no evidence to act on (mountinfo unreadable), so
     the check never cries wolf on a platform it can't inspect.
     """
-    if mountinfo is None:
-        return None
-
-    # Nearest enclosing mount = the longest mount point that is the path itself
-    # or one of its ancestors. Compared as paths, not strings, so /app/dataset
-    # is never mistaken for a mount covering /app/data.
-    nearest = ""
-    for point in mount_points(mountinfo):
-        candidate = Path(point)
-        if path == candidate or path.is_relative_to(candidate):
-            if len(str(candidate)) > len(nearest):
-                nearest = str(candidate)
-
-    if nearest != "/":
+    mount = covering_mount(path, mountinfo)
+    if mount is None or mount[0] != "/":
         return None
 
     return (

--- a/newsletter.py
+++ b/newsletter.py
@@ -328,14 +328,25 @@ def read_mountinfo(path: Path = _MOUNTINFO) -> str | None:
         return None
 
 
-def parse_mounts(mountinfo: str) -> dict[str, str]:
-    """Map mount point -> source from ``/proc/self/mountinfo`` text.
+# Filesystem types that do not outlive the container, whatever they are mounted
+# over: RAM-backed, or another copy-on-write layer discarded with it. A mount of
+# one of these is not persistence, so a mount-point-only check would clear a
+# tmpfs over the sink directory that loses every record on restart.
+_EPHEMERAL_FSTYPES = frozenset({"tmpfs", "ramfs", "overlay", "overlayfs", "aufs", "devtmpfs"})
 
-    Fields 5 and 4 respectively: the mount point, and the source path *within
-    its own filesystem* — for a Docker bind mount that is the host directory
+
+def parse_mounts(mountinfo: str) -> dict[str, tuple[str, str]]:
+    """Map mount point -> ``(source, fstype)`` from ``/proc/self/mountinfo`` text.
+
+    The mount point is field 5. The source is field 4: the path *within its own
+    filesystem* — for a Docker bind mount that is the host directory
     (``/var/lib/docker/volumes/<name>/_data`` for a named volume), which is what
     makes "am I appending to the directory I actually review?" answerable from
-    inside the container.
+    inside the container. Note it is relative to the ROOT OF THAT FILESYSTEM, not
+    to the host's ``/``: if the host keeps ``/srv`` on its own filesystem, a bind
+    of ``/srv/stack/data`` reports ``/stack/data``. The fstype is the first field
+    after the ``-`` separator, and is what distinguishes a durable bind mount from
+    a tmpfs.
 
     Paths containing spaces, tabs, newlines, or backslashes are octal-escaped in
     mountinfo; ``\\040`` (space) is the one worth decoding for a bind-mounted
@@ -347,12 +358,18 @@ def parse_mounts(mountinfo: str) -> dict[str, str]:
         fields = line.split(" ")
         if len(fields) < 10:  # a real mountinfo line has at least 10 fields
             continue
-        mounts[fields[4].replace("\\040", " ")] = fields[3].replace("\\040", " ")
+        # Optional fields sit between field 7 and the "-", so the fstype's index
+        # varies: find the separator rather than assuming a position.
+        try:
+            fstype = fields[fields.index("-", 6) + 1]
+        except (ValueError, IndexError):
+            continue
+        mounts[fields[4].replace("\\040", " ")] = (fields[3].replace("\\040", " "), fstype)
     return mounts
 
 
-def covering_mount(path: Path, mountinfo: str | None) -> tuple[str, str] | None:
-    """The mount actually holding *path*, as ``(mount_point, source)``.
+def covering_mount(path: Path, mountinfo: str | None) -> tuple[str, str, str] | None:
+    """The mount actually holding *path*, as ``(mount_point, source, fstype)``.
 
     The nearest enclosing mount: the longest mount point that is *path* itself or
     one of its ancestors. Compared as paths, not strings, so ``/app/dataset`` is
@@ -362,38 +379,57 @@ def covering_mount(path: Path, mountinfo: str | None) -> tuple[str, str] | None:
     if mountinfo is None:
         return None
 
-    nearest: tuple[str, str] | None = None
-    for point, source in parse_mounts(mountinfo).items():
-        candidate = Path(point)
-        if path == candidate or path.is_relative_to(candidate):
+    nearest: tuple[str, str, str] | None = None
+    for point, (source, fstype) in parse_mounts(mountinfo).items():
+        # is_relative_to is already true for an equal path, so this covers a bind
+        # mount of the sink file itself as well as one of a parent directory.
+        if path.is_relative_to(Path(point)):
             if nearest is None or len(point) > len(nearest[0]):
-                nearest = (point, source)
+                nearest = (point, source, fstype)
     return nearest
 
 
 def sink_persistence_warning(path: Path, mountinfo: str | None) -> str | None:
-    """Warn when *path* resolves into a container's throwaway writable layer.
+    """:func:`mount_persistence_warning` against raw ``mountinfo`` text."""
+    return mount_persistence_warning(path, covering_mount(path, mountinfo))
+
+
+def mount_persistence_warning(path: Path, mount: tuple[str, str, str] | None) -> str | None:
+    """Warn when *mount* — the mount covering *path* — is not keeping it.
 
     The daemon's ``output_file`` is relative to the working directory (``/app``
     in the image), so without a volume mount the assessments land in the
     container layer: every write succeeds, the review TUI on the host sees
     nothing new, and the records are destroyed on the next ``docker compose up``.
-    If the mount covering the path is the container root itself, nothing is
-    persisting it.
+    Two shapes mean exactly that, and both look fine to a mount-point-only check:
 
+      * the mount covering the path IS the container root — nothing was mounted
+        over it; and
+      * something *was* mounted over it, but with an ephemeral filesystem: a
+        tmpfs is RAM, another overlay is another throwaway layer.
+
+    Takes the already-resolved mount so a caller that also wants to *report* the
+    mount (the startup preflight does) reads and parses ``mountinfo`` once.
     Returns None when there's no evidence to act on (mountinfo unreadable), so
     the check never cries wolf on a platform it can't inspect.
     """
-    mount = covering_mount(path, mountinfo)
-    if mount is None or mount[0] != "/":
+    if mount is None:
+        return None
+    point, _source, fstype = mount
+    if point != "/" and fstype not in _EPHEMERAL_FSTYPES:
         return None
 
+    covers = (
+        "which no volume covers — it is inside the container's writable layer"
+        if point == "/"
+        else f"which is covered only by a {fstype} mount at {point} — that filesystem "
+        "does not outlive the container"
+    )
     return (
-        f"Newsletter assessments resolve to {path}, which no volume covers — it is "
-        "inside the container's writable layer. Writes will appear to succeed, but "
-        "the records are invisible on the host and are DESTROYED when the container "
-        "is recreated. Mount the directory you review, e.g. '- ./data:/app/data' "
-        "under the service's volumes."
+        f"Newsletter assessments resolve to {path}, {covers}. Writes will appear to "
+        "succeed, but the records are invisible on the host and are DESTROYED when the "
+        "container is recreated. Mount the directory you review, e.g. "
+        "'- ./data:/app/data' under the service's volumes."
     )
 
 
@@ -403,7 +439,18 @@ def sink_writability_warning(path: Path) -> str | None:
     ``write_assessment`` creates missing parents, so a not-yet-existing file is
     fine as long as the nearest existing ancestor is writable — that ancestor is
     what gets checked, and named, when the file itself isn't there yet.
+
+    An ``output_file`` naming an existing DIRECTORY is caught here too: it is
+    fatal for every grading (``open(dir, "a")`` raises ``IsADirectoryError``) yet
+    ``os.access`` reports a directory as perfectly writable, so the permission
+    check alone would wave the one guaranteed-fatal misconfiguration through.
     """
+    if path.is_dir():
+        return (
+            f"Newsletter assessments sink is a directory, not a file: {path}. Every "
+            "grading will fail to save. Point [newsletter] output_file at a file "
+            "inside it (e.g. data/newsletter_assessments.jsonl)."
+        )
     if path.exists():
         if os.access(path, os.W_OK):
             return None

--- a/newsletter_review/__main__.py
+++ b/newsletter_review/__main__.py
@@ -68,6 +68,7 @@ def cli() -> None:
 
     run_review_tui(
         records,
+        source=args.file,
         init_tier=args.tier,
         init_theme=args.theme,
         init_sender=args.sender,

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -45,6 +45,13 @@ _COL_GAP = 2
 def load_assessments(path: Path) -> list[dict]:
     """Load newsletter assessment records from a JSONL file.
 
+    One row per newsletter: a thread graded more than once keeps only its last
+    (newest) record. The daemon persists the assessment *before* committing the
+    Gmail labels, so a newsletter whose labels fail to apply stays unprocessed
+    and is re-graded — and re-appended — next cycle. Deduping on read keeps that
+    durability guarantee from showing up as duplicate rows here. Records with no
+    ``thread_id`` have no identity to dedupe on and are all kept.
+
     Fails fast on pre-#53 old-scheme records whose story ``themes`` are stored
     as a LIST instead of a theme->grade dict: they would otherwise crash the
     detail view mid-render (``build_detail_lines`` calls ``themes.items()``).
@@ -52,6 +59,7 @@ def load_assessments(path: Path) -> list[dict]:
     clear, located error naming the file + line so the reader knows to
     re-migrate rather than seeing an opaque ``AttributeError`` (Finding 4)."""
     records = []
+    by_thread: dict[str, int] = {}  # thread_id -> index of its latest record
     with open(path) as f:
         for lineno, line in enumerate(f, 1):
             if not line.strip():
@@ -65,6 +73,12 @@ def load_assessments(path: Path) -> list[dict]:
                         "file predates the #53 theme-dict migration and must be "
                         "re-migrated before it can be browsed."
                     )
+            thread_id = record.get("thread_id")
+            if thread_id and thread_id in by_thread:
+                records[by_thread[thread_id]] = record  # supersede in place
+                continue
+            if thread_id:
+                by_thread[thread_id] = len(records)
             records.append(record)
     return records
 

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -42,15 +42,34 @@ _COL_GAP = 2
 # Pure data functions (no UI, fully testable)
 # ---------------------------------------------------------------------------
 
+def _processed_at(record: dict) -> datetime | None:
+    """A record's processed time as a comparable datetime, or None if unusable.
+
+    Naive timestamps are read as UTC — ``write_assessment`` has always written an
+    aware UTC value, but a hand-edited or hand-merged record may not, and mixing
+    aware and naive datetimes raises on comparison."""
+    try:
+        stamp = datetime.fromisoformat(record.get("timestamp") or "")
+    except (TypeError, ValueError):
+        return None
+    return stamp if stamp.tzinfo else stamp.replace(tzinfo=timezone.utc)
+
+
 def load_assessments(path: Path) -> list[dict]:
     """Load newsletter assessment records from a JSONL file.
 
-    One row per newsletter: a thread graded more than once keeps only its last
-    (newest) record. The daemon persists the assessment *before* committing the
-    Gmail labels, so a newsletter whose labels fail to apply stays unprocessed
-    and is re-graded — and re-appended — next cycle. Deduping on read keeps that
-    durability guarantee from showing up as duplicate rows here. Records with no
-    ``thread_id`` have no identity to dedupe on and are all kept.
+    One row per newsletter: a thread graded more than once keeps only its NEWEST
+    record, decided by the record's own ``timestamp`` rather than by its position
+    in the file. The daemon persists the assessment *before* committing the Gmail
+    labels, so a newsletter whose labels fail to apply stays unprocessed and is
+    re-graded — and re-appended — next cycle. Deduping on read keeps that
+    durability guarantee from showing up as duplicate rows here.
+
+    Position is only the tie-break (later line wins) when neither record carries a
+    comparable timestamp: files get *merged*, not just appended — README.md has
+    operators concatenate a rescued copy of the assessments file onto their host
+    file — so "last line" is not a reliable stand-in for "latest grading".
+    Records with no ``thread_id`` have no identity to dedupe on and are all kept.
 
     Fails fast on pre-#53 old-scheme records whose story ``themes`` are stored
     as a LIST instead of a theme->grade dict: they would otherwise crash the
@@ -75,7 +94,10 @@ def load_assessments(path: Path) -> list[dict]:
                     )
             thread_id = record.get("thread_id")
             if thread_id and thread_id in by_thread:
-                records[by_thread[thread_id]] = record  # supersede in place
+                kept = records[by_thread[thread_id]]
+                new_at, kept_at = _processed_at(record), _processed_at(kept)
+                if new_at is None or kept_at is None or new_at >= kept_at:
+                    records[by_thread[thread_id]] = record  # supersede in place
                 continue
             if thread_id:
                 by_thread[thread_id] = len(records)
@@ -633,7 +655,12 @@ def run_review_tui(
     values from CLI args are passed via init_tier/init_theme/init_sender/init_since.
     """
     if not records:
+        # Name the file even here — especially here. An empty listing is exactly
+        # when a wrong or stale path is indistinguishable from an idle daemon, and
+        # the TUI (which carries the source line) never opens on this path.
         print("No assessment records to display.")
+        if source is not None:
+            print(format_source_line(source, records))
         return
     ReviewApp(
         records,

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -270,8 +270,17 @@ def build_detail_lines(record: dict, width: int = 80) -> list[str]:
         f"Model: {model}",
         f"Overall: {overall_tier}",
         f"Stories: {len(stories)}",
-        "",
     ]
+
+    # A migrated record's dimension labels are 5-point scores re-bucketed into
+    # Poor/OK/Good (scripts/migrate_assessments.py); its tier is the one the
+    # grader actually concluded. Say so rather than presenting a precision the
+    # grader never expressed.
+    migrated = record.get("migrated_from")
+    if migrated:
+        lines.append(f"Scores: re-bucketed from the {migrated} 5-point rubric")
+
+    lines.append("")
 
     if not stories:
         lines.append("No stories extracted from this newsletter.")

--- a/newsletter_review/tui.py
+++ b/newsletter_review/tui.py
@@ -201,6 +201,21 @@ def format_filter_summary(
     return "  ".join(parts)
 
 
+def format_source_line(path: Path, records: list[dict]) -> str:
+    """Identify the file being browsed: resolved path, record count, newest send.
+
+    The reader is one half of a pair — the daemon logs where it *writes*, this
+    says what was *read*. Without it, a stale copy of the assessments file is
+    indistinguishable from a live one, which is exactly how a daemon recording
+    newsletters daily can look like it stopped weeks ago. The newest send date is
+    the tell, and it's shown as a local calendar date to match the list column.
+    """
+    dates = [d for d in (_local_date(r.get("send_date")) for r in records) if d]
+    newest = max(dates) if dates else "—"
+    noun = "newsletter" if len(records) == 1 else "newsletters"
+    return f"{path.resolve()} — {len(records)} {noun}, newest sent {newest}"
+
+
 def _list_date(record: dict) -> str:
     """The send-date's LOCAL calendar date for the list column, or ``—`` if
     absent/unparseable (#36)."""
@@ -429,12 +444,16 @@ class ReviewApp(App):
     ReviewApp #header {
         text-style: underline;
     }
+    ReviewApp #source {
+        color: $text-muted;
+    }
     """
 
     def __init__(
         self,
         records: list[dict],
         *,
+        source: Path | None = None,
         init_tier: str | None = None,
         init_theme: str | None = None,
         init_sender: str | None = None,
@@ -443,6 +462,7 @@ class ReviewApp(App):
         super().__init__()
         # Default ordering is send-date descending, newest first (issue #36).
         self.all_records = sort_by_send_date(records)
+        self.source = source
         self.filtered = self.all_records
         self.f_tier = init_tier
         self.f_theme = init_theme
@@ -451,6 +471,13 @@ class ReviewApp(App):
 
     def compose(self) -> ComposeResult:
         yield Static(id="title", markup=False)
+        if self.source is not None:
+            # Which file this listing came from — omitted only when the caller
+            # supplied records with no path behind them (tests, embedding).
+            yield Static(
+                format_source_line(self.source, self.all_records),
+                id="source", markup=False,
+            )
         hdr = (
             f"{'Date':<{_COL_DATE}}"
             f"  {'Tier':<{_COL_TIER}}"
@@ -584,6 +611,7 @@ class ReviewApp(App):
 def run_review_tui(
     records: list[dict],
     *,
+    source: Path | None = None,
     init_tier: str | None = None,
     init_theme: str | None = None,
     init_sender: str | None = None,
@@ -591,14 +619,16 @@ def run_review_tui(
 ) -> None:
     """Launch the newsletter review TUI.
 
-    *records* is the full (unfiltered) set. Initial filter values from CLI
-    args are passed via init_tier/init_theme/init_sender/init_since.
+    *records* is the full (unfiltered) set, and *source* the file they were read
+    from (shown in the header so a stale file is recognizable). Initial filter
+    values from CLI args are passed via init_tier/init_theme/init_sender/init_since.
     """
     if not records:
         print("No assessment records to display.")
         return
     ReviewApp(
         records,
+        source=source,
         init_tier=init_tier, init_theme=init_theme, init_sender=init_sender,
         init_since=init_since,
     ).run()

--- a/scripts/migrate_assessments.py
+++ b/scripts/migrate_assessments.py
@@ -82,7 +82,21 @@ def _migrate_story(story: dict) -> dict:
 
     scores = story.get("scores")
     if scores:
-        bucketed = {dim: _SCORE_BUCKETS.get(value, value) for dim, value in scores.items()}
+        bucketed = {}
+        for dim, value in scores.items():
+            try:
+                bucketed[dim] = _SCORE_BUCKETS[value]
+            except (KeyError, TypeError):
+                # Refuse rather than pass it through. A value the old rubric never
+                # produced leaves the record permanently flagged old-scheme (still
+                # outside 1-3), so the next run would re-bucket its already-correct
+                # siblings, walking Good(3) -> OK(2) -> Poor(1); a non-numeric one
+                # would instead raise TypeError from the average, which the CLI does
+                # not catch. Abort with the value named, original untouched.
+                raise ValueError(
+                    f"story dimension {dim!r} has score {value!r}, which is not a "
+                    f"1-5 value the pre-#53 rubric could produce — refusing to guess"
+                ) from None
         migrated["scores"] = bucketed
         migrated["average_score"] = sum(bucketed.values()) / len(bucketed)
 
@@ -116,6 +130,11 @@ def migrate_file(
     converted before anything is written, so a malformed file aborts with the
     original untouched — half-migrating the only copy of the grading history is
     not a recoverable state.
+
+    An ``in_place`` run with nothing to migrate is a no-op: it neither rewrites
+    the file nor touches the backup. Otherwise a second run (out of doubt, or
+    from a script) would replace the only pre-migration copy of an append-only,
+    irreplaceable file with the already-migrated content.
     """
     stats = MigrationStats()
     lines = []
@@ -128,12 +147,15 @@ def migrate_file(
             except json.JSONDecodeError as exc:
                 raise ValueError(f"{path}: line {lineno} is not valid JSON: {exc}") from None
             stats.total += 1
-            migrated, changed = migrate_record(record)
+            try:
+                migrated, changed = migrate_record(record)
+            except ValueError as exc:
+                raise ValueError(f"{path}: line {lineno}: {exc}") from None
             stats.migrated += changed
             lines.append(json.dumps(migrated) + "\n")
 
     destination = out if out is not None else (path if in_place else None)
-    if destination is None:
+    if destination is None or (in_place and out is None and not stats.migrated):
         return stats
 
     if in_place and out is None:
@@ -175,6 +197,11 @@ def cli(argv: list[str] | None = None) -> int:
     print(f"{stats.total} records, {stats.migrated} pre-#53 record(s) to migrate")
     if where is None:
         print("Dry run — nothing written. Re-run with --in-place (or --out PATH) to apply.")
+    elif args.in_place and not stats.migrated:
+        # Say what actually happened: claiming a write (and a backup) that was
+        # deliberately skipped would send the reader looking for a .bak that the
+        # first, real run left — or that never existed.
+        print("Already migrated — file and backup left untouched.")
     else:
         print(f"Wrote {where}")
         if args.in_place:

--- a/scripts/migrate_assessments.py
+++ b/scripts/migrate_assessments.py
@@ -1,0 +1,186 @@
+"""Migrate pre-#53 records in a newsletter assessments JSONL to the current scheme.
+
+Issue #53 replaced the 1-5 dimension scores with the 3-value Poor/OK/Good rubric
+and list-shaped story themes with theme->grade dicts, and the readers were then
+made to reject the old shapes outright — on the premise that the affected data
+would simply be regenerated. That premise holds for the eval golden set. It
+cannot hold for the production assessments JSONL: it is append-only and is the
+only copy of every grading ever made, so its pre-#53 history has to be converted
+instead. Until it is, one old record at the top of the file makes the whole file
+unopenable in the review TUI.
+
+What the conversion can and cannot preserve:
+
+* **Themes** convert exactly in meaning: the old list asserted a theme was
+  present, with no emphasis judgment, so each entry becomes ``present``. (Nothing
+  becomes ``emphasized``, so no migrated record implies a theme label — matching
+  the labels those emails actually carry.)
+* **Dimension scores** cannot round-trip: 5 values are being mapped onto 3.
+  They are bucketed 1-2 -> Poor, 3 -> OK, 4-5 -> Good, and ``average_score`` is
+  recomputed so it agrees with the labels the detail view renders.
+* **Tiers are preserved verbatim**, never recomputed. The tier is what the grader
+  concluded under the old rubric, and it is what was applied to the email as a
+  Gmail label; deriving a new one from re-bucketed dimensions would leave the
+  record disagreeing with the label on the message.
+* Migrated records are stamped ``"migrated_from": "pre-#53"`` so their Poor/OK/Good
+  values are recognizable as re-bucketed 5-point judgments.
+
+Stop the daemon before migrating in place — it appends to this file.
+
+Usage::
+
+    python -m scripts.migrate_assessments data/newsletter_assessments.jsonl
+    python -m scripts.migrate_assessments data/newsletter_assessments.jsonl --in-place
+    python -m scripts.migrate_assessments data/newsletter_assessments.jsonl --out new.jsonl
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Old 1-5 dimension score -> new 3-value rubric (1=Poor, 2=OK, 3=Good).
+_SCORE_BUCKETS = {1: 1, 2: 1, 3: 2, 4: 3, 5: 3}
+_VALID_SCORES = (1, 2, 3)
+MIGRATION_STAMP = "pre-#53"
+
+
+@dataclass
+class MigrationStats:
+    """How many records were read, and how many needed converting."""
+
+    total: int = 0
+    migrated: int = 0
+
+
+def is_old_scheme(record: dict) -> bool:
+    """True when *record* was written before the #53 scheme change.
+
+    Two independent markers, either of which is conclusive: a story whose
+    ``themes`` is a list (the old grader wrote ``[]`` even for no themes, so the
+    shape alone identifies it), or a dimension score outside 1-3. A record with
+    no stories carries neither marker — and has nothing to convert.
+    """
+    for story in record.get("stories", []):
+        if isinstance(story.get("themes"), list):
+            return True
+        scores = story.get("scores") or {}
+        if any(value not in _VALID_SCORES for value in scores.values()):
+            return True
+    return False
+
+
+def _migrate_story(story: dict) -> dict:
+    migrated = dict(story)
+
+    themes = story.get("themes")
+    if isinstance(themes, list):
+        migrated["themes"] = {theme: "present" for theme in themes}
+
+    scores = story.get("scores")
+    if scores:
+        bucketed = {dim: _SCORE_BUCKETS.get(value, value) for dim, value in scores.items()}
+        migrated["scores"] = bucketed
+        migrated["average_score"] = sum(bucketed.values()) / len(bucketed)
+
+    return migrated
+
+
+def migrate_record(record: dict) -> tuple[dict, bool]:
+    """Return ``(record, changed)``; new-scheme records pass through untouched.
+
+    Never mutates the input.
+    """
+    if not is_old_scheme(record):
+        return record, False
+
+    migrated = dict(record)
+    migrated["stories"] = [_migrate_story(story) for story in record.get("stories", [])]
+    migrated["migrated_from"] = MIGRATION_STAMP
+    return migrated, True
+
+
+def migrate_file(
+    path: Path,
+    *,
+    in_place: bool = False,
+    out: Path | None = None,
+) -> MigrationStats:
+    """Migrate the records in *path*, reporting what was found.
+
+    Without ``in_place`` or ``out`` this only counts (a dry run). ``in_place``
+    rewrites *path* after copying it to ``<path>.bak``. Every line is parsed and
+    converted before anything is written, so a malformed file aborts with the
+    original untouched — half-migrating the only copy of the grading history is
+    not a recoverable state.
+    """
+    stats = MigrationStats()
+    lines = []
+    with open(path) as f:
+        for lineno, line in enumerate(f, 1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}: line {lineno} is not valid JSON: {exc}") from None
+            stats.total += 1
+            migrated, changed = migrate_record(record)
+            stats.migrated += changed
+            lines.append(json.dumps(migrated) + "\n")
+
+    destination = out if out is not None else (path if in_place else None)
+    if destination is None:
+        return stats
+
+    if in_place and out is None:
+        shutil.copy2(path, path.with_suffix(path.suffix + ".bak"))
+
+    # Write beside the destination, then swap: an interrupted write must not be
+    # able to leave a truncated assessments file behind.
+    temp = destination.with_suffix(destination.suffix + ".tmp")
+    temp.write_text("".join(lines))
+    os.replace(temp, destination)
+    return stats
+
+
+def cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Migrate pre-#53 newsletter assessment records to the current scheme.",
+    )
+    parser.add_argument("path", type=Path, help="Assessments JSONL to migrate")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Rewrite the file (a .bak copy is kept). Stop the daemon first — it appends here.",
+    )
+    group.add_argument("--out", type=Path, help="Write the migrated records to this path instead")
+    args = parser.parse_args(argv)
+
+    if not args.path.exists():
+        print(f"Error: file not found: {args.path}", file=sys.stderr)
+        return 1
+
+    try:
+        stats = migrate_file(args.path, in_place=args.in_place, out=args.out)
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    where = args.out or (args.path if args.in_place else None)
+    print(f"{stats.total} records, {stats.migrated} pre-#53 record(s) to migrate")
+    if where is None:
+        print("Dry run — nothing written. Re-run with --in-place (or --out PATH) to apply.")
+    else:
+        print(f"Wrote {where}")
+        if args.in_place:
+            print(f"Backup: {args.path.with_suffix(args.path.suffix + '.bak')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(cli())

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1301,6 +1301,36 @@ class TestNewsletterOutputPathLogging:
             f"no startup ERROR warned that {sink} is not persisted; errors={errors}"
         )
 
+    async def test_startup_names_the_host_directory_behind_the_mount(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """A mount pointing at a host directory other than the one being reviewed
+        fails exactly like no mount at all — records accumulate somewhere nobody
+        looks — but no check can know which directory the operator *meant*. So
+        name the source: the one line that makes it verifiable at a glance."""
+        sink = tmp_path / "data" / "assessments.jsonl"
+        monkeypatch.setattr(daemon, "running_in_container", lambda: True)
+        monkeypatch.setattr(
+            daemon, "read_mountinfo",
+            lambda: (
+                "1450 1449 0:118 / / rw,relatime - overlay overlay rw,lowerdir=/l/A\n"
+                f"1470 1450 259:2 /srv/elsewhere/data {tmp_path / 'data'} rw,relatime "
+                "- ext4 /dev/sda1 rw\n"
+            ),
+        )
+
+        with caplog.at_level(logging.INFO, logger="email-labeler"):
+            await run_poll_cycles(
+                monkeypatch, tmp_path, [{"messages": []}],
+                keep_newsletter=True, newsletter_output_file=sink,
+            )
+
+        assert any(
+            "/srv/elsewhere/data" in r.getMessage() for r in caplog.records
+        ), "startup did not name the host source of the mount holding the sink"
+        # A real mount covers it, so the container-layer ERROR must stay quiet.
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
     async def test_no_persistence_error_outside_a_container(
         self, monkeypatch, tmp_path, caplog
     ):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1368,6 +1368,28 @@ class TestNewsletterOutputPathLogging:
             f"startup did not flag the missing assessments sink; errors={errors}"
         )
 
+    async def test_startup_errors_when_the_sink_cannot_be_read(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """An unreadable sink is reported, not shrugged at. The realistic cause is
+        an ``output_file`` naming a directory: ``os.access`` calls a directory
+        writable, so without this the one guaranteed-fatal misconfiguration
+        produces nothing louder than an INFO — and then every newsletter is graded
+        and abandoned to agent/attempted."""
+        sink = tmp_path / "data" / "assessments.jsonl"
+        sink.mkdir(parents=True)
+
+        with caplog.at_level(logging.INFO, logger="email-labeler"):
+            await run_poll_cycles(
+                monkeypatch, tmp_path, [{"messages": []}],
+                keep_newsletter=True, newsletter_output_file=sink,
+            )
+
+        errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any(str(sink) in m for m in errors), (
+            f"an unreadable/misshapen sink produced no startup ERROR; errors={errors}"
+        )
+
     async def test_startup_errors_when_the_sink_is_not_writable(
         self, monkeypatch, tmp_path, caplog
     ):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1321,6 +1321,23 @@ class TestNewsletterOutputPathLogging:
 
         assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
 
+    async def test_startup_errors_when_no_sink_is_configured(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """The third silent way assessments go missing: [newsletter] with no
+        output_file at all. Grading runs, labels apply, the per-thread INFO
+        summary prints — and nothing is ever recorded. Startup must say so."""
+        with caplog.at_level(logging.INFO, logger="email-labeler"):
+            await run_poll_cycles(
+                monkeypatch, tmp_path, [{"messages": []}],
+                keep_newsletter=True, newsletter_output_file="",
+            )
+
+        errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("output_file" in m for m in errors), (
+            f"startup did not flag the missing assessments sink; errors={errors}"
+        )
+
     async def test_startup_errors_when_the_sink_is_not_writable(
         self, monkeypatch, tmp_path, caplog
     ):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1035,7 +1035,7 @@ class _StopLoop(Exception):
 
 async def run_poll_cycles(
     monkeypatch, tmp_path, poll_outcomes, process_mock=None, cycles=None,
-    keep_newsletter=False,
+    keep_newsletter=False, newsletter_output_file=None,
 ):
     """Drive run_daemon through poll cycles, then stop; returns the proxy mock.
 
@@ -1047,12 +1047,15 @@ async def run_poll_cycles(
     replaces the default always-succeeds process_single_thread stub — halted
     cycles sleep without polling, so cycles may exceed len(poll_outcomes).
     `keep_newsletter` retains the [newsletter] config so startup wiring (e.g.
-    the assessments-path log line) can be exercised; NEWSLETTER_ONLY stays
-    unset so the loop itself remains on the plain email pipeline.
+    the assessments-path log line and the sink preflight) can be exercised;
+    NEWSLETTER_ONLY stays unset so the loop itself remains on the plain email
+    pipeline. `newsletter_output_file` overrides the configured sink path.
     """
     config = copy.deepcopy(load_config())
     if not keep_newsletter:
         config.pop("newsletter", None)  # keep the loop on the plain email pipeline
+    elif newsletter_output_file is not None:
+        config["newsletter"]["output_file"] = str(newsletter_output_file)
     config["daemon"]["healthcheck_file"] = str(tmp_path / "healthcheck")
     monkeypatch.setattr(daemon, "load_config", lambda: config)
 
@@ -1253,6 +1256,88 @@ class TestNewsletterOutputPathLogging:
             f"no startup log line contains the resolved assessments path {expected}"
         )
 
+    async def test_startup_reports_how_many_records_the_sink_already_holds(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """The count is the tell for a misdirected sink: a daemon that has been
+        grading for weeks against a path holding 0 records is not appending to
+        the file the operator reviews."""
+        sink = tmp_path / "data" / "assessments.jsonl"
+        sink.parent.mkdir()
+        sink.write_text('{"thread_id": "a"}\n{"thread_id": "b"}\n')
+
+        with caplog.at_level(logging.INFO, logger="email-labeler"):
+            await run_poll_cycles(
+                monkeypatch, tmp_path, [{"messages": []}],
+                keep_newsletter=True, newsletter_output_file=sink,
+            )
+
+        assert any(
+            str(sink) in r.getMessage() and "2 existing" in r.getMessage()
+            for r in caplog.records
+        ), "startup line did not report the sink's existing record count"
+
+    async def test_startup_errors_when_the_sink_is_not_persisted(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """The silent failure this guards: in a container with no volume over the
+        assessments directory, every write succeeds and every record is lost on
+        the next recreate. It must be an ERROR at startup, not a surprise later."""
+        sink = tmp_path / "data" / "assessments.jsonl"
+        monkeypatch.setattr(daemon, "running_in_container", lambda: True)
+        monkeypatch.setattr(
+            daemon, "read_mountinfo",
+            lambda: "1450 1449 0:118 / / rw,relatime - overlay overlay rw,lowerdir=/l/A\n",
+        )
+
+        with caplog.at_level(logging.INFO, logger="email-labeler"):
+            await run_poll_cycles(
+                monkeypatch, tmp_path, [{"messages": []}],
+                keep_newsletter=True, newsletter_output_file=sink,
+            )
+
+        errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any(str(sink) in m and "volume" in m.lower() for m in errors), (
+            f"no startup ERROR warned that {sink} is not persisted; errors={errors}"
+        )
+
+    async def test_no_persistence_error_outside_a_container(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """On a host, a path on the root filesystem is perfectly durable — the
+        check must not fire there."""
+        monkeypatch.setattr(daemon, "running_in_container", lambda: False)
+        monkeypatch.setattr(
+            daemon, "read_mountinfo",
+            lambda: "1450 1449 0:118 / / rw,relatime - overlay overlay rw,lowerdir=/l/A\n",
+        )
+
+        with caplog.at_level(logging.INFO, logger="email-labeler"):
+            await run_poll_cycles(
+                monkeypatch, tmp_path, [{"messages": []}],
+                keep_newsletter=True,
+                newsletter_output_file=tmp_path / "data" / "assessments.jsonl",
+            )
+
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+    async def test_startup_errors_when_the_sink_is_not_writable(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        sink = tmp_path / "data" / "assessments.jsonl"
+        monkeypatch.setattr(daemon, "sink_writability_warning", lambda _p: "sink is read-only")
+
+        with caplog.at_level(logging.INFO, logger="email-labeler"):
+            await run_poll_cycles(
+                monkeypatch, tmp_path, [{"messages": []}],
+                keep_newsletter=True, newsletter_output_file=sink,
+            )
+
+        assert any(
+            "sink is read-only" in r.getMessage()
+            for r in caplog.records if r.levelno >= logging.ERROR
+        )
+
 
 class TestLoadConfig:
     def test_loads_config_toml(self):
@@ -1407,7 +1492,12 @@ class TestResolveIntEnv:
 
 @pytest.fixture
 def mock_newsletter_classifier():
-    return AsyncMock()
+    classifier = AsyncMock()
+    # A real model string, not an AsyncMock attribute: the assessment record is
+    # JSON-serialized before the labels commit, so a non-serializable model would
+    # fail the write (and, by design, block labeling) in every newsletter test.
+    classifier.cloud_llm.model = "claude-sonnet-4-6"
+    return classifier
 
 
 @pytest.fixture
@@ -1448,6 +1538,7 @@ class TestNewsletterRouting:
         cloud_sem,
         local_sem,
         newsletter_thread_response,
+        tmp_path,
     ):
         mock_proxy.get_thread.return_value = newsletter_thread_response
         mock_newsletter_classifier.classify_newsletter.return_value = [
@@ -1471,7 +1562,7 @@ class TestNewsletterRouting:
             max_thread_chars=50000,
             newsletter_classifier=mock_newsletter_classifier,
             newsletter_recipient="newsletters@dm.org",
-            newsletter_output_file="/tmp/test.jsonl",
+            newsletter_output_file=str(tmp_path / "assessments.jsonl"),
         )
 
         assert result is True
@@ -1596,6 +1687,7 @@ class TestNewsletterRouting:
         cloud_sem,
         local_sem,
         mock_thread_response,
+        tmp_path,
     ):
         mock_proxy.get_thread.return_value = mock_thread_response
 
@@ -1610,7 +1702,7 @@ class TestNewsletterRouting:
             max_thread_chars=50000,
             newsletter_classifier=mock_newsletter_classifier,
             newsletter_recipient="newsletters@dm.org",
-            newsletter_output_file="/tmp/test.jsonl",
+            newsletter_output_file=str(tmp_path / "assessments.jsonl"),
         )
 
         assert result is True
@@ -1627,6 +1719,7 @@ class TestNewsletterRouting:
         cloud_sem,
         local_sem,
         newsletter_thread_response,
+        tmp_path,
     ):
         mock_proxy.get_thread.return_value = newsletter_thread_response
         mock_newsletter_classifier.classify_newsletter.return_value = []
@@ -1642,7 +1735,7 @@ class TestNewsletterRouting:
             max_thread_chars=50000,
             newsletter_classifier=mock_newsletter_classifier,
             newsletter_recipient="newsletters@dm.org",
-            newsletter_output_file="/tmp/test.jsonl",
+            newsletter_output_file=str(tmp_path / "assessments.jsonl"),
         )
 
         assert result is True
@@ -1659,6 +1752,7 @@ class TestNewsletterRouting:
         cloud_sem,
         local_sem,
         mock_thread_response,
+        tmp_path,
     ):
         mock_proxy.get_thread.return_value = mock_thread_response
 
@@ -1673,7 +1767,7 @@ class TestNewsletterRouting:
             max_thread_chars=50000,
             newsletter_classifier=mock_newsletter_classifier,
             newsletter_recipient="newsletters@dm.org",
-            newsletter_output_file="/tmp/test.jsonl",
+            newsletter_output_file=str(tmp_path / "assessments.jsonl"),
             newsletter_only=True,
         )
 
@@ -1691,6 +1785,7 @@ class TestNewsletterRouting:
         cloud_sem,
         local_sem,
         newsletter_thread_response,
+        tmp_path,
     ):
         mock_proxy.get_thread.return_value = newsletter_thread_response
         mock_newsletter_classifier.classify_newsletter.return_value = [
@@ -1714,7 +1809,7 @@ class TestNewsletterRouting:
             max_thread_chars=50000,
             newsletter_classifier=mock_newsletter_classifier,
             newsletter_recipient="newsletters@dm.org",
-            newsletter_output_file="/tmp/test.jsonl",
+            newsletter_output_file=str(tmp_path / "assessments.jsonl"),
             newsletter_only=True,
         )
 
@@ -1746,6 +1841,155 @@ class TestNewsletterRouting:
 
         assert result is True
         mock_classifier.classify_sender.assert_called_once()
+
+
+class TestNewsletterAssessmentDurability:
+    """The assessment JSONL is the only place a newsletter's grading survives —
+    Gmail keeps just the coarse tier/theme labels, and the labels include
+    ``agent/processed``, which drops the thread out of ``gmail_query`` forever.
+
+    So the record must be persisted BEFORE the labels commit. Committing first
+    and writing after makes any sink failure (missing bind mount made
+    read-only, full disk, bad permissions) permanently lose that newsletter's
+    grade: the thread is already marked processed, so it is never re-graded.
+    """
+
+    @staticmethod
+    def _story():
+        return StoryResult(
+            text="Content",
+            scores={"simple": 3, "concrete": 3, "personal": 3, "dynamic": 3},
+            average_score=3.0,
+            tier=NewsletterTier.EXCELLENT,
+            themes={"scripture": "emphasized"},
+        )
+
+    async def test_record_is_on_disk_before_labels_are_applied(
+        self,
+        mock_proxy,
+        mock_classifier,
+        mock_label_manager,
+        mock_newsletter_classifier,
+        cloud_sem,
+        local_sem,
+        newsletter_thread_response,
+        tmp_path,
+    ):
+        mock_proxy.get_thread.return_value = newsletter_thread_response
+        mock_newsletter_classifier.classify_newsletter.return_value = [self._story()]
+        out = tmp_path / "assessments.jsonl"
+
+        seen_at_label_time = {}
+
+        async def _capture(**_kwargs):
+            seen_at_label_time["text"] = out.read_text() if out.exists() else ""
+
+        mock_label_manager.apply_newsletter_classification.side_effect = _capture
+
+        result = await process_single_thread(
+            "thread_nl",
+            ["msg_nl_001"],
+            mock_proxy,
+            mock_classifier,
+            mock_label_manager,
+            cloud_sem,
+            local_sem,
+            max_thread_chars=50000,
+            newsletter_classifier=mock_newsletter_classifier,
+            newsletter_recipient="newsletters@dm.org",
+            newsletter_output_file=str(out),
+        )
+
+        assert result is True
+        assert seen_at_label_time["text"].strip(), (
+            "labels were applied while the assessment file was still empty — a "
+            "sink failure at that point loses the grading permanently"
+        )
+
+    async def test_sink_failure_leaves_thread_unlabeled_for_retry(
+        self,
+        monkeypatch,
+        mock_proxy,
+        mock_classifier,
+        mock_label_manager,
+        mock_newsletter_classifier,
+        cloud_sem,
+        local_sem,
+        newsletter_thread_response,
+    ):
+        """An unwritable sink must NOT be swallowed: no labels, no
+        agent/processed, and a False return so the thread is retried next
+        cycle (and, if the fault persists, given up as agent/attempted)."""
+        mock_proxy.get_thread.return_value = newsletter_thread_response
+        mock_newsletter_classifier.classify_newsletter.return_value = [self._story()]
+
+        def _boom(**_kwargs):
+            raise OSError(30, "Read-only file system")
+
+        monkeypatch.setattr(daemon, "write_assessment", _boom)
+        tracker = FailureTracker(max_failures=3)  # below threshold -> retry, not give up
+
+        result = await process_single_thread(
+            "thread_nl",
+            ["msg_nl_001"],
+            mock_proxy,
+            mock_classifier,
+            mock_label_manager,
+            cloud_sem,
+            local_sem,
+            max_thread_chars=50000,
+            newsletter_classifier=mock_newsletter_classifier,
+            newsletter_recipient="newsletters@dm.org",
+            newsletter_output_file="/nonexistent/assessments.jsonl",
+            failure_tracker=tracker,
+        )
+
+        assert result is False
+        mock_label_manager.apply_newsletter_classification.assert_not_called()
+        mock_label_manager.mark_processed.assert_not_called()
+
+    async def test_sink_failure_names_the_path_at_error_level(
+        self,
+        monkeypatch,
+        mock_proxy,
+        mock_classifier,
+        mock_label_manager,
+        mock_newsletter_classifier,
+        cloud_sem,
+        local_sem,
+        newsletter_thread_response,
+        caplog,
+    ):
+        """The operator has to be able to tell a sink fault from a grading fault,
+        so the failing path is named at ERROR."""
+        mock_proxy.get_thread.return_value = newsletter_thread_response
+        mock_newsletter_classifier.classify_newsletter.return_value = [self._story()]
+
+        def _boom(**_kwargs):
+            raise OSError(30, "Read-only file system")
+
+        monkeypatch.setattr(daemon, "write_assessment", _boom)
+
+        with caplog.at_level(logging.ERROR, logger="email-labeler"):
+            await process_single_thread(
+                "thread_nl",
+                ["msg_nl_001"],
+                mock_proxy,
+                mock_classifier,
+                mock_label_manager,
+                cloud_sem,
+                local_sem,
+                max_thread_chars=50000,
+                newsletter_classifier=mock_newsletter_classifier,
+                newsletter_recipient="newsletters@dm.org",
+                newsletter_output_file="/nonexistent/assessments.jsonl",
+            )
+
+        assert any(
+            "/nonexistent/assessments.jsonl" in r.getMessage()
+            for r in caplog.records
+            if r.levelno >= logging.ERROR
+        ), "no ERROR log line named the assessments path that failed to write"
 
 
 class TestVerifyLabelsWithRetry:

--- a/tests/test_migrate_assessments.py
+++ b/tests/test_migrate_assessments.py
@@ -150,6 +150,22 @@ class TestMigrateRecord:
         out, _ = migrate_record(_old_record())
         assert out["migrated_from"] == "pre-#53"
 
+    def test_a_score_outside_the_old_rubric_is_rejected_not_passed_through(self):
+        """Silently keeping an unmappable value is the worst option: the record
+        stays flagged old-scheme forever (its value is still outside 1-3), so a
+        second run re-buckets its already-converted siblings — Good(3) -> OK(2) ->
+        Poor(1) — and a non-numeric one blows up in the average instead."""
+        r = _old_record()
+        r["stories"][0]["scores"] = {"simple": 7, "concrete": 3, "personal": 3, "dynamic": 3}
+        with pytest.raises(ValueError, match="7"):
+            migrate_record(r)
+
+    def test_a_non_numeric_score_is_rejected(self):
+        r = _old_record()
+        r["stories"][0]["scores"] = {"simple": "4", "concrete": 3, "personal": 3, "dynamic": 3}
+        with pytest.raises(ValueError):
+            migrate_record(r)
+
     def test_other_fields_are_untouched(self):
         out, _ = migrate_record(_old_record())
         for key in ("timestamp", "message_id", "thread_id", "from", "subject"):
@@ -193,6 +209,45 @@ class TestMigrateFile:
             "vocation_family": "present", "scripture": "present",
         }
         assert (tmp_path / "a.jsonl.bak").read_text() == before
+
+    def test_a_second_run_does_not_destroy_the_original_backup(self, tmp_path):
+        """The .bak is the only pre-migration copy of an append-only, irreplaceable
+        file. Re-running --in-place (out of doubt, or in a script) must not replace
+        it with the already-migrated content."""
+        f = tmp_path / "a.jsonl"
+        self._write(f, [_old_record()])
+        original = f.read_text()
+
+        migrate_file(f, in_place=True)
+        migrated = f.read_text()
+        migrate_file(f, in_place=True)
+
+        assert (tmp_path / "a.jsonl.bak").read_text() == original
+        assert f.read_text() == migrated  # and the file itself is unchanged
+
+    def test_nothing_to_migrate_leaves_the_file_and_backup_alone(self, tmp_path):
+        f = tmp_path / "a.jsonl"
+        self._write(f, [_new_record()])
+        before = f.read_text()
+
+        stats = migrate_file(f, in_place=True)
+
+        assert (stats.total, stats.migrated) == (1, 0)
+        assert f.read_text() == before
+        assert not (tmp_path / "a.jsonl.bak").exists()
+
+    def test_a_bad_score_aborts_before_anything_is_written(self, tmp_path):
+        f = tmp_path / "a.jsonl"
+        bad = _old_record()
+        bad["stories"][0]["scores"] = {"simple": 9}
+        f.write_text(json.dumps(_old_record()) + "\n" + json.dumps(bad) + "\n")
+        before = f.read_text()
+
+        with pytest.raises(ValueError, match="line 2"):
+            migrate_file(f, in_place=True)
+
+        assert f.read_text() == before
+        assert not (tmp_path / "a.jsonl.bak").exists()
 
     def test_record_order_is_preserved(self, tmp_path):
         f = tmp_path / "a.jsonl"

--- a/tests/test_migrate_assessments.py
+++ b/tests/test_migrate_assessments.py
@@ -1,0 +1,245 @@
+"""Tests for the pre-#53 assessment-record migration (scripts/migrate_assessments.py).
+
+The production assessments JSONL is append-only and can never be regenerated —
+it is the only copy of every grading ever made. When #53 replaced the 1-5
+dimension scores with 3-value Poor/OK/Good and list-shaped story themes with
+theme->grade dicts, the readers were made to reject the old shapes outright, on
+the assumption that the data would be regenerated. That holds for the eval
+golden set; it cannot hold for this file, so its pre-#53 history needs
+converting in place instead.
+"""
+
+import json
+
+import pytest
+
+from newsletter_review.tui import load_assessments
+from scripts.migrate_assessments import (
+    is_old_scheme,
+    migrate_file,
+    migrate_record,
+)
+
+
+def _old_record(**overrides):
+    """A pre-#53 record: 1-5 dimension scores, list-shaped themes, no
+    send_date/model keys (both landed with the same release)."""
+    record = {
+        "timestamp": "2026-06-02T12:00:00+00:00",
+        "message_id": "msg_old",
+        "thread_id": "t_old",
+        "from": "staff@dm.org",
+        "subject": "June Update",
+        "overall_tier": "good",
+        "stories": [
+            {
+                "text": "A story about ministry.",
+                "scores": {"simple": 4, "concrete": 3, "personal": 5, "dynamic": 2},
+                "average_score": 3.5,
+                "tier": "good",
+                "themes": ["vocation_family", "scripture"],
+                "quality_cot": "reasoning",
+                "theme_cot": "reasoning",
+            }
+        ],
+    }
+    record.update(overrides)
+    return record
+
+
+def _new_record(**overrides):
+    record = {
+        "timestamp": "2026-07-29T12:00:00+00:00",
+        "message_id": "msg_new",
+        "thread_id": "t_new",
+        "from": "staff@dm.org",
+        "subject": "God has done it!",
+        "send_date": "2026-07-29T09:00:00+00:00",
+        "model": "claude-sonnet-4-6",
+        "overall_tier": "good",
+        "stories": [
+            {
+                "text": "A story about ministry.",
+                "scores": {"simple": 3, "concrete": 2, "personal": 3, "dynamic": 2},
+                "average_score": 2.5,
+                "tier": "good",
+                "themes": {"scripture": "emphasized"},
+                "quality_cot": "",
+                "theme_cot": "",
+            }
+        ],
+    }
+    record.update(overrides)
+    return record
+
+
+class TestIsOldScheme:
+    def test_list_themes_identify_the_old_scheme(self):
+        assert is_old_scheme(_old_record()) is True
+
+    def test_empty_list_themes_still_identify_it(self):
+        # The old grader stored [] for a story with no themes; the new one stores
+        # {}. The list *shape* is the marker, not its contents.
+        r = _old_record()
+        r["stories"][0]["themes"] = []
+        r["stories"][0]["scores"] = {"simple": 2, "concrete": 2, "personal": 2, "dynamic": 2}
+        assert is_old_scheme(r) is True
+
+    def test_out_of_range_scores_identify_it_even_with_dict_themes(self):
+        r = _new_record()
+        r["stories"][0]["scores"] = {"simple": 5, "concrete": 4, "personal": 3, "dynamic": 2}
+        assert is_old_scheme(r) is True
+
+    def test_new_scheme_record_is_not_flagged(self):
+        assert is_old_scheme(_new_record()) is False
+
+    def test_record_with_no_stories_is_not_flagged(self):
+        # A no-stories newsletter has nothing scheme-specific in it, so there is
+        # nothing to convert and no way (or need) to tell which scheme wrote it.
+        assert is_old_scheme(_new_record(stories=[])) is False
+
+
+class TestMigrateRecord:
+    def test_list_themes_become_present_grades(self):
+        out, changed = migrate_record(_old_record())
+        assert changed is True
+        assert out["stories"][0]["themes"] == {
+            "vocation_family": "present", "scripture": "present",
+        }
+
+    def test_empty_list_themes_become_an_empty_dict(self):
+        r = _old_record()
+        r["stories"][0]["themes"] = []
+        out, _ = migrate_record(r)
+        assert out["stories"][0]["themes"] == {}
+
+    def test_scores_are_bucketed_into_the_three_value_rubric(self):
+        r = _old_record()
+        r["stories"][0]["scores"] = {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
+        out, _ = migrate_record(r)
+        # 1-2 -> Poor(1), 3 -> OK(2), 4-5 -> Good(3).
+        assert out["stories"][0]["scores"] == {"a": 1, "b": 1, "c": 2, "d": 3, "e": 3}
+
+    def test_average_score_is_recomputed_from_the_bucketed_scores(self):
+        out, _ = migrate_record(_old_record())
+        # {4,3,5,2} -> {3,2,3,1} -> mean 2.25
+        assert out["stories"][0]["average_score"] == pytest.approx(2.25)
+
+    def test_recorded_tiers_are_preserved_not_recomputed(self):
+        """The tier is what the grader concluded under the old rubric, and it is
+        what got applied to the email as a Gmail label. Recomputing it from
+        lossily re-bucketed dimensions would put a grade in the record that
+        disagrees with the label actually on the message."""
+        out, _ = migrate_record(_old_record(overall_tier="excellent"))
+        assert out["overall_tier"] == "excellent"
+        assert out["stories"][0]["tier"] == "good"
+
+    def test_missing_scores_are_left_alone(self):
+        r = _old_record()
+        r["stories"][0]["scores"] = None
+        r["stories"][0]["average_score"] = None
+        out, changed = migrate_record(r)
+        assert changed is True  # themes still migrated
+        assert out["stories"][0]["scores"] is None
+        assert out["stories"][0]["average_score"] is None
+
+    def test_provenance_is_recorded(self):
+        """A migrated record's Poor/OK/Good labels are re-bucketed 5-point
+        judgments, not what the grader actually emitted — the record has to say
+        so, or the detail view silently overstates its own precision."""
+        out, _ = migrate_record(_old_record())
+        assert out["migrated_from"] == "pre-#53"
+
+    def test_other_fields_are_untouched(self):
+        out, _ = migrate_record(_old_record())
+        for key in ("timestamp", "message_id", "thread_id", "from", "subject"):
+            assert out[key] == _old_record()[key]
+        assert out["stories"][0]["quality_cot"] == "reasoning"
+
+    def test_new_scheme_record_passes_through_unchanged(self):
+        out, changed = migrate_record(_new_record())
+        assert changed is False
+        assert out == _new_record()
+        assert "migrated_from" not in out
+
+    def test_input_record_is_not_mutated(self):
+        r = _old_record()
+        migrate_record(r)
+        assert r["stories"][0]["themes"] == ["vocation_family", "scripture"]
+
+
+class TestMigrateFile:
+    def _write(self, path, records):
+        path.write_text("".join(json.dumps(r) + "\n" for r in records))
+
+    def test_reports_counts_without_touching_the_file_by_default(self, tmp_path):
+        f = tmp_path / "a.jsonl"
+        self._write(f, [_old_record(), _new_record(), _old_record()])
+        before = f.read_text()
+
+        stats = migrate_file(f)
+
+        assert (stats.total, stats.migrated) == (3, 2)
+        assert f.read_text() == before
+
+    def test_in_place_rewrites_the_file_and_keeps_a_backup(self, tmp_path):
+        f = tmp_path / "a.jsonl"
+        self._write(f, [_old_record(), _new_record()])
+        before = f.read_text()
+
+        migrate_file(f, in_place=True)
+
+        assert json.loads(f.read_text().splitlines()[0])["stories"][0]["themes"] == {
+            "vocation_family": "present", "scripture": "present",
+        }
+        assert (tmp_path / "a.jsonl.bak").read_text() == before
+
+    def test_record_order_is_preserved(self, tmp_path):
+        f = tmp_path / "a.jsonl"
+        self._write(f, [_old_record(thread_id="t1"), _new_record(thread_id="t2"),
+                        _old_record(thread_id="t3")])
+        migrate_file(f, in_place=True)
+        ids = [json.loads(line)["thread_id"] for line in f.read_text().splitlines()]
+        assert ids == ["t1", "t2", "t3"]
+
+    def test_blank_lines_are_dropped(self, tmp_path):
+        f = tmp_path / "a.jsonl"
+        f.write_text(json.dumps(_old_record()) + "\n\n\n")
+        stats = migrate_file(f, in_place=True)
+        assert stats.total == 1
+        assert len(f.read_text().splitlines()) == 1
+
+    def test_migrated_file_loads_through_the_review_tui(self, tmp_path):
+        """The point of the exercise: the file the reader rejected must open."""
+        f = tmp_path / "a.jsonl"
+        self._write(f, [_old_record(), _new_record()])
+        with pytest.raises(ValueError, match="old-scheme"):
+            load_assessments(f)
+
+        migrate_file(f, in_place=True)
+
+        records = load_assessments(f)
+        assert len(records) == 2
+
+    def test_a_malformed_line_aborts_before_anything_is_written(self, tmp_path):
+        """Half-migrating the only copy of the grading history is not an option."""
+        f = tmp_path / "a.jsonl"
+        f.write_text(json.dumps(_old_record()) + "\nnot json\n")
+        before = f.read_text()
+
+        with pytest.raises(ValueError, match="line 2"):
+            migrate_file(f, in_place=True)
+
+        assert f.read_text() == before
+        assert not (tmp_path / "a.jsonl.bak").exists()
+
+    def test_out_writes_a_separate_file_and_leaves_the_input_alone(self, tmp_path):
+        f = tmp_path / "a.jsonl"
+        out = tmp_path / "migrated.jsonl"
+        self._write(f, [_old_record()])
+        before = f.read_text()
+
+        migrate_file(f, out=out)
+
+        assert f.read_text() == before
+        assert load_assessments(out)

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -810,10 +810,19 @@ _MOUNTINFO_WITH_BIND = _MOUNTINFO_NO_BIND + (
 
 
 class TestParseMounts:
-    def test_maps_mount_point_to_its_source(self):
+    def test_maps_mount_point_to_its_source_and_fstype(self):
         assert parse_mounts(_MOUNTINFO_WITH_BIND)["/app/data"] == (
-            "/Users/brian/email-labeler/data"
+            "/Users/brian/email-labeler/data", "ext4",
         )
+
+    def test_fstype_is_found_past_the_optional_fields(self):
+        """``master:N`` / ``propagate_from:N`` sit between field 7 and the ``-``,
+        so the fstype's index varies — it must be located by the separator."""
+        line = (
+            "1470 1450 259:2 /src /app/data rw,relatime shared:12 master:7 "
+            "- xfs /dev/sda1 rw\n"
+        )
+        assert parse_mounts(line)["/app/data"] == ("/src", "xfs")
 
     def test_parses_every_mount_point(self):
         assert set(parse_mounts(_MOUNTINFO_WITH_BIND)) == {
@@ -833,7 +842,7 @@ class TestCoveringMount:
 
     def test_returns_the_nearest_enclosing_mount(self):
         mount = covering_mount(Path("/app/data/a.jsonl"), _MOUNTINFO_WITH_BIND)
-        assert mount == ("/app/data", "/Users/brian/email-labeler/data")
+        assert mount == ("/app/data", "/Users/brian/email-labeler/data", "ext4")
 
     def test_falls_back_to_the_root_mount(self):
         mount = covering_mount(Path("/app/data/a.jsonl"), _MOUNTINFO_NO_BIND)
@@ -881,6 +890,23 @@ class TestSinkPersistenceWarning:
         # No evidence either way — never cry wolf.
         assert sink_persistence_warning(Path("/app/data/a.jsonl"), None) is None
 
+    def test_warns_when_the_covering_mount_is_a_tmpfs(self):
+        """A mount over the directory is not automatically persistence: a tmpfs
+        lives in RAM and dies with the container just like the writable layer,
+        while looking to a mount-point check exactly like a bind mount."""
+        mountinfo = _MOUNTINFO_NO_BIND + (
+            "1470 1450 0:99 / /app/data rw,relatime - tmpfs tmpfs rw,size=65536k\n"
+        )
+        warning = sink_persistence_warning(Path("/app/data/a.jsonl"), mountinfo)
+        assert warning is not None
+        assert "tmpfs" in warning
+
+    def test_warns_when_the_covering_mount_is_another_overlay(self):
+        mountinfo = _MOUNTINFO_NO_BIND + (
+            "1470 1450 0:200 / /app/data rw,relatime - overlay overlay rw,lowerdir=/l/B\n"
+        )
+        assert sink_persistence_warning(Path("/app/data/a.jsonl"), mountinfo) is not None
+
 
 class TestSinkWritabilityWarning:
     """A sink that cannot be appended to now blocks labeling (the record is
@@ -911,6 +937,17 @@ class TestSinkWritabilityWarning:
         warning = sink_writability_warning(path)
         assert warning is not None
         assert str(path) in warning
+
+    def test_warns_when_the_configured_sink_is_a_directory(self, tmp_path):
+        """``output_file`` pointing at a directory is fatal for every grading
+        (``open(dir, "a")`` raises ``IsADirectoryError``), but ``os.access`` says
+        the directory is perfectly writable — so the shape has to be checked too,
+        or the one guaranteed-fatal misconfiguration passes preflight silently."""
+        sink = tmp_path / "assessments.jsonl"
+        sink.mkdir()
+        warning = sink_writability_warning(sink)
+        assert warning is not None
+        assert str(sink) in warning
 
     def test_warns_when_the_nearest_existing_directory_is_not_writable(self, tmp_path, monkeypatch):
         # The file (and an intermediate dir) don't exist yet: the check falls back

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -1,10 +1,12 @@
 """Tests for newsletter classifier — parsing functions and data models."""
 
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 
+import newsletter
 from llm_client import LLMBalanceError, LLMContentError, LLMUnavailableError
 from newsletter import (
     NewsletterClassifier,
@@ -13,11 +15,15 @@ from newsletter import (
     aggregate_theme_grades,
     classify_theme_line,
     compute_tier,
+    count_records,
     is_newsletter,
+    mount_points,
     parse_quality_scores,
     parse_send_date,
     parse_stories,
     parse_themes,
+    sink_persistence_warning,
+    sink_writability_warning,
     write_assessment,
 )
 
@@ -785,3 +791,127 @@ class TestIsNewsletter:
 
     def test_empty_messages(self):
         assert is_newsletter([], "newsletters@dm.org") is False
+
+
+# Real /proc/self/mountinfo excerpts (fields: id parent major:minor root
+# mount-point ...). The container-layer case has only the overlay root; the
+# mounted case adds the bind mount the operator configured.
+_MOUNTINFO_NO_BIND = """\
+1450 1449 0:118 / / rw,relatime - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/AAA
+1451 1450 0:121 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+1465 1450 259:2 /var/lib/docker/containers/abc/hosts /etc/hosts rw,relatime - ext4 /dev/nvme0n1p2 rw
+"""
+
+_MOUNTINFO_WITH_BIND = _MOUNTINFO_NO_BIND + (
+    "1470 1450 259:2 /Users/brian/email-labeler/data /app/data rw,relatime "
+    "- ext4 /dev/nvme0n1p2 rw\n"
+)
+
+
+class TestMountPoints:
+    def test_parses_mount_points_from_mountinfo(self):
+        assert mount_points(_MOUNTINFO_WITH_BIND) == {"/", "/proc", "/etc/hosts", "/app/data"}
+
+    def test_octal_escaped_space_is_decoded(self):
+        line = "1470 1450 259:2 /src /app/my\\040data rw,relatime - ext4 /dev/sda1 rw\n"
+        assert "/app/my data" in mount_points(line)
+
+    def test_ignores_malformed_lines(self):
+        assert mount_points("garbage\n\n1 2 3\n") == set()
+
+
+class TestSinkPersistenceWarning:
+    """The failure that silently stopped assessment storage: in Docker the
+    daemon's default output path (``data/...`` relative to WORKDIR ``/app``)
+    lands in the container's writable layer unless a volume covers it. Writes
+    keep succeeding, so nothing fails — the records are just destroyed the next
+    time the container is recreated."""
+
+    def test_warns_when_path_is_only_covered_by_the_container_root(self):
+        warning = sink_persistence_warning(
+            Path("/app/data/newsletter_assessments.jsonl"), _MOUNTINFO_NO_BIND
+        )
+        assert warning is not None
+        # Actionable: names the path and the fix.
+        assert "/app/data/newsletter_assessments.jsonl" in warning
+        assert "volume" in warning.lower() or "mount" in warning.lower()
+
+    def test_silent_when_a_bind_mount_covers_the_directory(self):
+        assert sink_persistence_warning(
+            Path("/app/data/newsletter_assessments.jsonl"), _MOUNTINFO_WITH_BIND
+        ) is None
+
+    def test_silent_when_the_file_itself_is_bind_mounted(self):
+        mountinfo = _MOUNTINFO_NO_BIND + (
+            "1470 1450 259:2 /host/a.jsonl /app/data/a.jsonl rw,relatime - ext4 /dev/sda1 rw\n"
+        )
+        assert sink_persistence_warning(Path("/app/data/a.jsonl"), mountinfo) is None
+
+    def test_a_sibling_mount_does_not_count_as_coverage(self):
+        # /app/dataset must not be read as covering /app/data* by string prefix.
+        mountinfo = _MOUNTINFO_NO_BIND + (
+            "1470 1450 259:2 /host /app/dataset rw,relatime - ext4 /dev/sda1 rw\n"
+        )
+        assert sink_persistence_warning(Path("/app/data/a.jsonl"), mountinfo) is not None
+
+    def test_unreadable_mountinfo_yields_no_warning(self):
+        # No evidence either way — never cry wolf.
+        assert sink_persistence_warning(Path("/app/data/a.jsonl"), None) is None
+
+
+class TestSinkWritabilityWarning:
+    """A sink that cannot be appended to now blocks labeling (the record is
+    written before the labels commit), so the operator must learn about it at
+    startup rather than through a give-up storm.
+
+    The unwritable cases drive ``os.access`` directly instead of chmod-ing a
+    fixture: the daemon runs as root in its container, and root bypasses
+    permission bits — a chmod-based test would assert behavior the daemon can
+    never actually hit. What must be proven is that an OS "no" (a read-only
+    mount is the realistic one) becomes a warning naming the location.
+    """
+
+    def test_silent_for_a_writable_existing_file(self, tmp_path):
+        path = tmp_path / "assessments.jsonl"
+        path.write_text("")
+        assert sink_writability_warning(path) is None
+
+    def test_silent_when_the_file_does_not_exist_yet_but_a_parent_is_writable(self, tmp_path):
+        # write_assessment creates missing parents, so an absent file/dir is fine
+        # as long as the nearest existing ancestor can be written to.
+        assert sink_writability_warning(tmp_path / "data" / "sub" / "a.jsonl") is None
+
+    def test_warns_when_the_existing_file_is_not_writable(self, tmp_path, monkeypatch):
+        path = tmp_path / "assessments.jsonl"
+        path.write_text("")
+        monkeypatch.setattr(newsletter.os, "access", lambda *_args, **_kw: False)
+        warning = sink_writability_warning(path)
+        assert warning is not None
+        assert str(path) in warning
+
+    def test_warns_when_the_nearest_existing_directory_is_not_writable(self, tmp_path, monkeypatch):
+        # The file (and an intermediate dir) don't exist yet: the check falls back
+        # to the nearest ancestor that does, and must name THAT in the warning.
+        monkeypatch.setattr(newsletter.os, "access", lambda *_args, **_kw: False)
+        warning = sink_writability_warning(tmp_path / "data" / "a.jsonl")
+        assert warning is not None
+        assert str(tmp_path) in warning
+
+
+class TestCountRecords:
+    """The startup line reports how many records the resolved path already holds:
+    a daemon that has been grading for weeks but reports 0 existing records is
+    writing somewhere other than the file the operator reviews."""
+
+    def test_counts_non_blank_lines(self, tmp_path):
+        path = tmp_path / "a.jsonl"
+        path.write_text('{"a": 1}\n\n{"a": 2}\n')
+        assert count_records(path) == 2
+
+    def test_missing_file_counts_zero(self, tmp_path):
+        assert count_records(tmp_path / "missing.jsonl") == 0
+
+    def test_unreadable_file_counts_none(self, tmp_path):
+        # A directory where the file should be: report "unknown", not a crash.
+        (tmp_path / "a.jsonl").mkdir()
+        assert count_records(tmp_path / "a.jsonl") is None

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -16,8 +16,9 @@ from newsletter import (
     classify_theme_line,
     compute_tier,
     count_records,
+    covering_mount,
     is_newsletter,
-    mount_points,
+    parse_mounts,
     parse_quality_scores,
     parse_send_date,
     parse_stories,
@@ -808,16 +809,38 @@ _MOUNTINFO_WITH_BIND = _MOUNTINFO_NO_BIND + (
 )
 
 
-class TestMountPoints:
-    def test_parses_mount_points_from_mountinfo(self):
-        assert mount_points(_MOUNTINFO_WITH_BIND) == {"/", "/proc", "/etc/hosts", "/app/data"}
+class TestParseMounts:
+    def test_maps_mount_point_to_its_source(self):
+        assert parse_mounts(_MOUNTINFO_WITH_BIND)["/app/data"] == (
+            "/Users/brian/email-labeler/data"
+        )
+
+    def test_parses_every_mount_point(self):
+        assert set(parse_mounts(_MOUNTINFO_WITH_BIND)) == {
+            "/", "/proc", "/etc/hosts", "/app/data",
+        }
 
     def test_octal_escaped_space_is_decoded(self):
         line = "1470 1450 259:2 /src /app/my\\040data rw,relatime - ext4 /dev/sda1 rw\n"
-        assert "/app/my data" in mount_points(line)
+        assert "/app/my data" in parse_mounts(line)
 
     def test_ignores_malformed_lines(self):
-        assert mount_points("garbage\n\n1 2 3\n") == set()
+        assert parse_mounts("garbage\n\n1 2 3\n") == {}
+
+
+class TestCoveringMount:
+    """Which mount actually holds the sink — the nearest one enclosing it."""
+
+    def test_returns_the_nearest_enclosing_mount(self):
+        mount = covering_mount(Path("/app/data/a.jsonl"), _MOUNTINFO_WITH_BIND)
+        assert mount == ("/app/data", "/Users/brian/email-labeler/data")
+
+    def test_falls_back_to_the_root_mount(self):
+        mount = covering_mount(Path("/app/data/a.jsonl"), _MOUNTINFO_NO_BIND)
+        assert mount[0] == "/"
+
+    def test_none_when_mountinfo_is_unreadable(self):
+        assert covering_mount(Path("/app/data/a.jsonl"), None) is None
 
 
 class TestSinkPersistenceWarning:

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -121,6 +121,32 @@ class TestLoadAssessments:
         records = load_assessments(f)
         assert records == []
 
+    def test_keeps_only_the_newest_record_per_thread(self, tmp_path):
+        """A newsletter can be written twice: the assessment is persisted before
+        the labels commit, so a label failure leaves the thread unprocessed and
+        the retry re-grades and re-writes it. The reader shows one row per
+        newsletter — the newest grading, i.e. the last one appended."""
+        f = tmp_path / "assessments.jsonl"
+        first = _make_record(thread_id="t1", overall_tier="fair")
+        retry = _make_record(thread_id="t1", overall_tier="good")
+        other = _make_record(thread_id="t2")
+        f.write_text("\n".join(json.dumps(r) for r in (first, other, retry)) + "\n")
+
+        records = load_assessments(f)
+        assert [r["thread_id"] for r in records] == ["t1", "t2"]
+        assert records[0]["overall_tier"] == "good"
+
+    def test_records_without_a_thread_id_are_all_kept(self, tmp_path):
+        """No thread_id, no identity — deduping them would silently merge
+        unrelated newsletters."""
+        f = tmp_path / "assessments.jsonl"
+        a, b = _make_record(), _make_record()
+        a.pop("thread_id")
+        b.pop("thread_id")
+        f.write_text(json.dumps(a) + "\n" + json.dumps(b) + "\n")
+
+        assert len(load_assessments(f)) == 2
+
     def test_rejects_old_scheme_list_themes(self, tmp_path):
         # A pre-#53 record stores story themes as a LIST; build_detail_lines
         # later does themes.items() and would crash mid-render. Fail fast at

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -600,6 +600,21 @@ def _title(app) -> str:
     return str(app.query_one("#title", Static).render())
 
 
+class TestMigratedProvenanceInDetail:
+    """A migrated pre-#53 record's Poor/OK/Good values are re-bucketed 5-point
+    judgments. The detail view must say so, or it presents a precision the
+    grader never expressed."""
+
+    def test_detail_notes_a_migrated_record(self):
+        r = _make_record()
+        r["migrated_from"] = "pre-#53"
+        assert any("pre-#53" in line for line in build_detail_lines(r, width=80))
+
+    def test_detail_says_nothing_for_an_unmigrated_record(self):
+        lines = build_detail_lines(_make_record(), width=80)
+        assert not any("pre-#53" in line for line in lines)
+
+
 class TestFormatSourceLine:
     """The reader must say what it read. The whole July-11 incident was a stale
     copy of the assessments file: the daemon was recording newsletters through

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -18,6 +18,7 @@ from newsletter_review.tui import (
     build_detail_lines,
     format_filter_summary,
     format_list_row,
+    format_source_line,
     load_assessments,
     run_review_tui,
     sort_by_send_date,
@@ -597,6 +598,57 @@ def _ui_records():
 
 def _title(app) -> str:
     return str(app.query_one("#title", Static).render())
+
+
+class TestFormatSourceLine:
+    """The reader must say what it read. The whole July-11 incident was a stale
+    copy of the assessments file: the daemon was recording newsletters through
+    today into its mounted path while the TUI was browsing an older file
+    somewhere else, and nothing on screen distinguished the two."""
+
+    def test_names_the_resolved_path_and_newest_send_date(self, tmp_path):
+        f = tmp_path / "data" / "newsletter_assessments.jsonl"
+        line = format_source_line(f, [
+            _make_record(thread_id="a", send_date="2026-07-11T09:00:00+00:00"),
+            _make_record(thread_id="b", send_date="2026-07-29T09:00:00+00:00"),
+        ])
+        assert str(f.resolve()) in line
+        assert "2 newsletters" in line
+        assert "2026-07-29" in line
+
+    def test_reports_an_empty_file(self, tmp_path):
+        line = format_source_line(tmp_path / "a.jsonl", [])
+        assert "0 newsletters" in line
+
+    def test_dash_when_no_record_carries_a_send_date(self, tmp_path):
+        r = _make_record(send_date=None)
+        line = format_source_line(tmp_path / "a.jsonl", [r])
+        assert "1 newsletter" in line
+        assert "—" in line
+
+    def test_newest_send_date_is_the_local_calendar_date(self, tmp_path):
+        # Same off-by-one care as the list column: a UTC-stored evening send must
+        # display as the local date, not the UTC one.
+        with _use_tz("America/New_York"):
+            line = format_source_line(
+                tmp_path / "a.jsonl",
+                [_make_record(send_date="2026-07-30T01:30:00+00:00")],
+            )
+        assert "2026-07-29" in line
+
+
+class TestReviewAppSourceLine:
+    async def test_source_line_is_displayed_when_a_path_is_known(self, tmp_path):
+        f = tmp_path / "newsletter_assessments.jsonl"
+        app = ReviewApp(_ui_records(), source=f)
+        async with app.run_test(size=SIZE):
+            shown = str(app.query_one("#source", Static).render())
+        assert str(f.resolve()) in shown
+
+    async def test_no_source_line_without_a_path(self):
+        app = ReviewApp(_ui_records())
+        async with app.run_test(size=SIZE):
+            assert not app.query("#source")
 
 
 class TestReviewAppList:

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -137,6 +137,32 @@ class TestLoadAssessments:
         assert [r["thread_id"] for r in records] == ["t1", "t2"]
         assert records[0]["overall_tier"] == "good"
 
+    def test_newest_wins_by_timestamp_not_by_file_position(self, tmp_path):
+        """Dedup must pick the newest GRADING, not the last line. README.md tells
+        operators to concatenate a rescued copy of the assessments file onto their
+        host file and calls overlapping entries harmless — which only holds if the
+        record's own ``timestamp`` decides, not the order the files were joined."""
+        f = tmp_path / "assessments.jsonl"
+        newer = _make_record(thread_id="t1", overall_tier="good",
+                             timestamp="2026-07-29T12:00:00+00:00")
+        older = _make_record(thread_id="t1", overall_tier="fair",
+                             timestamp="2026-07-01T12:00:00+00:00")
+        f.write_text(json.dumps(newer) + "\n" + json.dumps(older) + "\n")
+
+        records = load_assessments(f)
+        assert len(records) == 1
+        assert records[0]["overall_tier"] == "good"
+
+    def test_falls_back_to_last_wins_without_usable_timestamps(self, tmp_path):
+        """No comparable timestamp on either side → the appended-later record is
+        the best available guess at "newest"."""
+        f = tmp_path / "assessments.jsonl"
+        first = _make_record(thread_id="t1", overall_tier="fair", timestamp="")
+        second = _make_record(thread_id="t1", overall_tier="good", timestamp="")
+        f.write_text(json.dumps(first) + "\n" + json.dumps(second) + "\n")
+
+        assert load_assessments(f)[0]["overall_tier"] == "good"
+
     def test_records_without_a_thread_id_are_all_kept(self, tmp_path):
         """No thread_id, no identity — deduping them would silently merge
         unrelated newsletters."""
@@ -851,6 +877,14 @@ class TestRunReviewTui:
     def test_empty_records_prints_and_returns(self, capsys):
         run_review_tui([])
         assert "No assessment records" in capsys.readouterr().out
+
+    def test_empty_records_still_name_the_file_that_was_read(self, capsys, tmp_path):
+        """An empty listing is the case the source line matters MOST for — a wrong
+        or stale path looks identical to a genuinely idle daemon. Bailing out
+        before the header renders withholds the one fact that distinguishes them."""
+        f = tmp_path / "data" / "newsletter_assessments.jsonl"
+        run_review_tui([], source=f)
+        assert str(f.resolve()) in capsys.readouterr().out
 
 
 class TestCli:


### PR DESCRIPTION
## Why

Reported symptom: newly classified newsletters were not appearing in the review results — the daemon logged `Newsletter thread …: 3 stories, tier=poor …` for a newsletter that never showed up.

Investigation found the reported symptom had a different cause than expected, plus a real latent defect on the way. Both are fixed here.

**The reported symptom** was the review TUI being locked out of the live file. #53 changed story themes from a list to a theme→grade dict and dimension scores from 1-5 to Poor/OK/Good, and `70c1a02` then made the readers *reject* the old shapes — on the premise recorded in `0fa12eb` that *"the golden set / assessment JSONL are regenerated under the new scheme."* That premise holds for the eval golden set. It cannot hold for the production assessments JSONL: the file is append-only and is the only copy of every grading ever made. Nobody migrated it, so one pre-#53 record at line 1 has made the whole file unopenable since July 9, while the daemon went on appending correctly. The file being reviewed was a stale copy; nothing on screen distinguished it from a live one.

**The latent defect** was found while chasing that: labels committed *before* the record was written, and the write error was swallowed.

```python
apply_newsletter_classification(...)   # tier + theme labels + agent/processed, INBOX removed
try:
    write_assessment(...)
except Exception:
    log.exception(...)                 # ...and still return True
```

`agent/processed` is excluded from `gmail_query`, so once the labels commit the thread leaves the daemon's view permanently. Any sink fault — a read-only mount, a full disk, an unmounted container path — meant labels applied, grading lost, thread never re-graded, and the only trace was one easily-missed line. The per-thread INFO summary prints identically whether or not the record was saved.

## What changed

**Durability — write the record before the labels commit** (`f9d0489`). The JSONL is the only durable copy; Gmail keeps just the coarse labels. A sink fault now leaves the thread unprocessed and retried instead of labeled-but-lost, with an `OSError` logged at ERROR naming the resolved path rather than swallowed; a persistent fault ends at the existing give-up path's findable `agent/attempted`.

| Fault | Outcome |
|---|---|
| Sink write fails | ERROR naming the resolved path, thread left unprocessed → retried next cycle → persistent fault → `agent/attempted` |
| Labels fail after a successful write | Thread unprocessed → re-graded next cycle → a second record for that `thread_id`; `load_assessments` keeps the newest per thread, so the reader still shows one row |

**Startup preflight of the sink** (`f9d0489`, `15330ba`, `85c3b7d`). Every way this sink fails is silent in normal operation, so each gets a line before a single newsletter is graded:

```
INFO  Newsletter assessments append to: /app/data/newsletter_assessments.jsonl (412 existing record(s))
INFO  Assessments are persisted by the mount at /app/data (source /home/you/stack/data on the host)
      — confirm that is the directory you review
ERROR Newsletter assessments resolve to …, which no volume covers — it is inside the container's
      writable layer. Writes will appear to succeed, but the records are invisible on the host and
      are DESTROYED when the container is recreated. Mount the directory you review, e.g.
      '- ./data:/app/data' under the service's volumes.
ERROR Newsletter assessments sink is not writable: /app/data. …
ERROR Newsletter classification is enabled but [newsletter] output_file is not set in config.toml
      — newsletters will be graded and labeled, but no assessment records will be written
```

- The **record count** is the tell for a misdirected sink: a daemon grading for weeks against a path holding `0 existing record(s)` is not appending to the reviewed file.
- The **persistence check** compares the resolved path against `/proc/self/mountinfo`, firing only inside a container (`/.dockerenv`, `/run/.containerenv`) and only when the nearest enclosing mount is the container root. An unreadable `mountinfo` means no evidence, so no warning.
- The **mount source** is logged when a real mount does hold the sink, because no check can know which host directory was intended — a volume aimed at the wrong one fails as silently as no volume.

**The reader now says what it read** (`797605f`). The daemon logs where it writes; the TUI said nothing, which is how a stale copy stayed indistinguishable from a live one:

```
Newsletter Assessments — 253 records
/srv/stack/data/newsletter_assessments.jsonl — 253 newsletters, newest sent 2026-07-29
```

**Migration for pre-#53 records** (`f61d2a5`) — `scripts/migrate_assessments.py`. Dry-run by default; `--in-place` keeps a `.bak`. Every line is parsed and converted before anything is written, so a malformed file aborts with the original untouched, and the rewrite goes through a temp file + `os.replace` — half-migrating the only copy of the grading history is not a recoverable state.

| Field | Treatment |
|---|---|
| `stories[].themes` | List → `{theme: "present"}`. Exact in meaning: the old list asserted presence with no emphasis judgment. Nothing becomes `emphasized`, so no migrated record implies a theme label — matching the labels those emails carry. |
| `stories[].scores` | Bucketed 1-2 → Poor(1), 3 → OK(2), 4-5 → Good(3). Lossy by construction: 5 values onto 3. |
| `stories[].average_score` | Recomputed from the bucketed scores so it agrees with the labels the detail view renders. |
| `overall_tier`, `stories[].tier` | **Preserved verbatim, never recomputed.** The tier is what the grader concluded under the old rubric and what was applied to the email as a Gmail label; deriving a new one from re-bucketed dimensions would leave the record disagreeing with the message. |
| `migrated_from` | Added (`"pre-#53"`), surfaced in the detail view so re-bucketed scores are never read as what the grader emitted. |

**Dedup on read** (`f9d0489`). `load_assessments` keeps the newest record per `thread_id`. This covers the new duplicate mode the reorder introduces, and also a pre-existing one: a real production file was found holding 94 duplicate lines across 253 threads.

## Testing

1251 tests pass, ruff clean. Built red/green throughout; the migration's guarantees were additionally proven by mutation — breaking the bucket map, the theme grade, the parse-before-write ordering, and the no-mutate-input guarantee each failed the intended test.

New coverage: sink preflight wiring and write-before-label durability (`test_daemon.py`), mount parsing and persistence/writability diagnostics (`test_newsletter.py`), source line and migrated-record note (`test_newsletter_review.py`), and the migration end to end including a round-trip back through `load_assessments` (`test_migrate_assessments.py`).

Three existing newsletter tests were passing an `AsyncMock` model into a real write to `/tmp/test.jsonl` and relying on the swallow to hide the resulting `TypeError`; the reorder surfaced that, and they now use `tmp_path` with a real model string.

## After merging

The assessments file needs migrating once before the review TUI can open it, with the daemon stopped (it appends there):

```bash
python -m scripts.migrate_assessments path/to/newsletter_assessments.jsonl             # counts only
python -m scripts.migrate_assessments path/to/newsletter_assessments.jsonl --in-place  # apply
```

No new Gmail labels are required by this change, so startup validation is unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JBRveuqn4XkVpN2oycojNo)_