### PR TITLE
Fix #64: disable Ollama native thinking on the local tier, make budget exhaustion loud, repair eval CoT capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Background daemon that continuously polls Gmail for unclassified emails and appl
 - `README-technical.md` — Agent/reference: project structure, config.toml reference, environment variables, test coverage
 - `evals/README.md` — Human-oriented eval suite guide: pipeline stages, common workflows, key commands
 - `evals/README-technical.md` — Agent/reference: complete CLI flags for all eval tools, LLM cache internals, chain-of-thought capture format
+- `docs/runbook-agent-attempted-recovery.md` — Owner-run manual sweep of threads dropped to `agent/attempted` by the issue-#64 bug; time-sensitive (cleanest before the first post-#65 image is deployed), and not to be executed by an agent with Gmail write access
 
 ## Privacy Invariant
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -137,23 +137,34 @@ timeout = 180       # Local LLM gets more time (runs on consumer hardware)
 
 Each `[llm.*]` section supports an optional `extra_body` table. Any key-value pairs defined here are merged into every API request body sent to that endpoint. This is useful for provider-specific parameters that aren't part of the standard OpenAI chat completion format.
 
-**Disabling thinking for reasoning models** — Models like Qwen3, DeepSeek-R1, and GLM-4.5 generate chain-of-thought reasoning in `<think>` tags before answering. While the daemon already strips these tags from responses, you can disable thinking entirely to save tokens and reduce latency.
+**Disabling thinking for reasoning models** — Models like Qwen3, DeepSeek-R1, and GLM-4.5 generate chain-of-thought reasoning before answering — inline in `<think>` tags or in a separate response field, depending on the backend. While the daemon strips inline tags from responses, you can disable thinking entirely to save tokens and reduce latency.
 
-The shipped `config.toml` **disables native thinking on the local person-email classifier** (`[llm.local.extra_body.chat_template_kwargs]` → `enable_thinking = false`). A paired `stage2_only --sender-type person` eval (n=20) found native thinking strictly worse here: the model spent its `max_tokens` budget reasoning in the `<think>` channel and emitted no label on some threads (a `KeyError: 'content'` failure), while think-off was ≥ think-on on every thread (85% vs 78% accuracy, 0 vs 2 errors). The classification prompt already drives step-by-step reasoning into the *content* channel, so disabling native thinking preserves reasoning quality without the budget-split failure. `mlx_lm.server` honors this request-level `chat_template_kwargs` form; a top-level `enable_thinking` is ignored by that server.
+The shipped `config.toml` **disables native thinking on the local person-email classifier**. A paired `stage2_only --sender-type person` eval (n=20) found native thinking strictly worse here: the model spent its `max_tokens` budget reasoning in its thinking channel and emitted no label on some threads, while think-off was ≥ think-on on every thread (85% vs 78% accuracy, 0 vs 2 errors). Issue #64 later reproduced exactly that failure in production under Ollama. The classification prompt already drives step-by-step reasoning into the *content* channel, so disabling native thinking preserves reasoning quality without the budget-split failure.
 
-For providers that accept a top-level `enable_thinking` flag instead (Novita.ai, many OpenAI-compatible APIs):
+**The disable dialect is backend-specific, and a backend silently ignores dialects it doesn't understand** — a wrong-dialect disable is indistinguishable from a working one until the errors start (that was issue #64). The shipped config sends both known forms:
+
+For **Ollama** (verified on 0.32.5), the only working field on its OpenAI-compatible endpoint is a top-level `reasoning_effort = "none"`. Only `"none"` disables — `"low"` is a silent no-op, and `think = false` / `chat_template_kwargs` are ignored there:
+
+```toml
+[llm.local.extra_body]
+reasoning_effort = "none"
+```
+
+For **LM Studio and `mlx_lm.server`** with models that use `chat_template_kwargs` (e.g. Qwen3) — where a top-level `enable_thinking` is ignored:
+
+```toml
+[llm.local.extra_body.chat_template_kwargs]
+enable_thinking = false
+```
+
+Some providers accept a top-level `enable_thinking` flag instead (Novita.ai, various OpenAI-compatible APIs):
 
 ```toml
 [llm.local.extra_body]
 enable_thinking = false
 ```
 
-For LM Studio and `mlx_lm.server` with models that use `chat_template_kwargs` (e.g. Qwen3) — the shipped default:
-
-```toml
-[llm.local.extra_body.chat_template_kwargs]
-enable_thinking = false
-```
+Do **not** reach for Qwen's `/no_think` prompt switch: under Ollama it emitted a stray closing think-tag into content with no opening tag, which the tag-stripping regex cannot remove (issue #64).
 
 You can put any provider-specific fields in `extra_body` — it is not limited to thinking controls. For example:
 

--- a/README-technical.md
+++ b/README-technical.md
@@ -34,6 +34,10 @@ email-labeler/
 ├── newsletter_review/  Textual TUI for browsing newsletter assessments
 │   ├── __main__.py     CLI entry point (python -m newsletter_review)
 │   └── tui.py          Pure data helpers + Textual app
+├── docs/
+│   └── runbook-agent-attempted-recovery.md  Owner-run manual sweep of threads
+│                       dropped to agent/attempted by issue #64 (time-sensitive:
+│                       cleanest before the first post-#65 image is deployed)
 ├── scripts/
 │   ├── eval_model.py           One-command-per-model eval wrapper
 │   ├── migrate_assessments.py  Convert pre-#53 records in an assessments JSONL
@@ -342,7 +346,7 @@ Apple Silicon caps the GPU's Metal working set at roughly **75% of unified memor
   (kIOGPUCommandBufferCallbackErrorOutOfMemory)  ... SIGABRT
 ```
 
-A 27B model at 8-bit is ~34 GB, leaving only ~14 GB of headroom. Long transcripts have multi-GB KV caches, so a few concurrent long-transcript requests (or a large retained prompt cache) blow the ceiling. Mitigations, in order of preference:
+A 27B model at 8-bit is ~34 GB, leaving only ~14 GB of headroom. Long transcripts have multi-GB KV caches, so a few concurrent long-transcript requests (or a large retained prompt cache) blow the ceiling. Note that `[llm.local] max_tokens` was raised 1024 → 4096 (issue #64), so each in-flight request's KV cache can now grow up to 3,072 tokens further during decode than when the `local_parallel` ≤ 8 guidance was calibrated — re-confirm the model + N KV caches fit under the ceiling before raising `LOCAL_PARALLEL`. Mitigations, in order of preference:
 
 1. **Free system RAM** — leaked/idle processes shrink what the GPU can wire.
 2. **`local_parallel = 1`** (the default) — one live KV cache at a time.

--- a/README-technical.md
+++ b/README-technical.md
@@ -427,7 +427,7 @@ Conventions shared by every TUI:
 
 | Test file | Module | What's covered |
 |---|---|---|
-| `test_llm_client.py` | `llm_client.py` | Request format, auth headers, `<think>` tag stripping, error handling, out-of-funds (`LLMBalanceError`) detection, availability checks |
+| `test_llm_client.py` | `llm_client.py` | Request format, auth headers, `<think>` tag stripping, separate reasoning-field capture (`reasoning`/`reasoning_content`), `finish_reason: length` handling, error handling, out-of-funds (`LLMBalanceError`) detection, availability checks |
 | `test_classifier.py` | `classifier.py` | `parse_sender` formats, `parse_sender_type` edge cases and defaults, `parse_email_label` edge cases and defaults, cloud/local routing, full pipeline |
 | `test_labeler.py` | `labeler.py` | Label verification (all present, partial, none), label ID mapping, inbox/archive actions, single API call per email |
 | `test_daemon.py` | `daemon.py` | Service email path, person email path, MLX-unavailable skip, error isolation, out-of-funds halt, config loading, assessment-sink preflight + write-before-label durability |

--- a/config.toml
+++ b/config.toml
@@ -67,10 +67,12 @@ model = "{env.MLX_MODEL}"
 # 4096, not 1024: with native thinking disabled, the model still emits the full
 # step-by-step scaffold the prompt asks for — as untagged prose in content,
 # label last — and observed demand ran to ~1,300 completion tokens on hard
-# threads (issue #64). An over-budget decode with thinking off does NOT fail
-# loudly: content arrives truncated before any label and would parse to the
-# default LOW_PRIORITY → archive. This raise is therefore coupled to the
-# thinking disable below, not independent tuning.
+# threads (issue #64). An over-budget decode truncates content before the label
+# is emitted; llm_client raises LLMContentError on finish_reason "length" (so
+# it can no longer silently parse to the default LOW_PRIORITY → archive), but
+# that backstop turns every over-budget thread into an eventual give-up
+# (agent/attempted) — the budget must fit the honest demand. This raise is
+# therefore coupled to the thinking disable below, not independent tuning.
 max_tokens = 4096
 temperature = 0
 timeout = 180
@@ -152,7 +154,14 @@ output_file = "data/newsletter_assessments.jsonl"
 
 [newsletter.llm]
 model = "claude-sonnet-4-6"
-max_tokens = 1024
+# 4096, not 1024: story_extraction re-emits the FULL text of every story in a
+# single response, so output scales with newsletter size — 1024 truncated
+# multi-story newsletters mid-story. llm_client now raises LLMContentError on
+# finish_reason "length" (issue #64) instead of silently parsing a truncated
+# story list, so an undersized budget here would abandon long newsletters to
+# agent/attempted rather than mis-grade them. Sized by that reasoning (issue
+# #64's Fix 4); this tier has not been live-probed.
+max_tokens = 4096
 temperature = 0
 timeout = 60
 

--- a/config.toml
+++ b/config.toml
@@ -53,10 +53,12 @@ model = "zai-org/glm-5"
 # entirely on the native reasoning channel — and issue #64's probes showed
 # disabling it changes labels. Disable only behind an eval gate (issue #13).
 # Unlike the local tier, the budget is not squeezed: the same fixtures that
-# exhausted qwen's 1024 finished in 204-486 completion tokens here. 2048 is
-# cheap insurance on top of that headroom (measured on 5 probe fixtures, not
-# proof under service-heavy traffic).
-max_tokens = 2048
+# exhausted qwen's 1024 finished in 204-486 completion tokens here (2-5x
+# headroom — measured on 5 probe fixtures, so monitoring-grade evidence, not
+# proof under service-heavy traffic). If a squeeze ever develops, it now fails
+# loudly: llm_client raises on finish_reason "length" with the real
+# diagnostics, so watch the logs for LLMContentError naming this model.
+max_tokens = 1024
 temperature = 0
 timeout = 60
 

--- a/config.toml
+++ b/config.toml
@@ -73,6 +73,11 @@ model = "{env.MLX_MODEL}"
 # that backstop turns every over-budget thread into an eventual give-up
 # (agent/attempted) — the budget must fit the honest demand. This raise is
 # therefore coupled to the thinking disable below, not independent tuning.
+# NOTE: this also quadruples the per-request decode budget each concurrent
+# local request's KV cache can grow into. The documented LOCAL_PARALLEL
+# ceiling ("keep ≤ 8", README-technical "Local Model Serving & Memory") was
+# calibrated under the old 1024-token decode — re-confirm the model + N KV
+# caches fit the GPU's Metal budget before raising LOCAL_PARALLEL above 1.
 max_tokens = 4096
 temperature = 0
 timeout = 180
@@ -161,9 +166,19 @@ model = "claude-sonnet-4-6"
 # story list, so an undersized budget here would abandon long newsletters to
 # agent/attempted rather than mis-grade them. Sized by that reasoning (issue
 # #64's Fix 4); this tier has not been live-probed.
+# NOTE: max_tokens is part of the eval cache key (evals/llm_cache.py), so
+# changing it invalidates every cached newsletter response and the next
+# newsletter_run re-bills the whole golden set — while prompt_hash (prompts
+# only) stays identical, so pre/post-change runs are NOT distinguishable by
+# hash. Budget changes deserve a note alongside the A/B comparison.
 max_tokens = 4096
 temperature = 0
-timeout = 60
+# 180, not 60: a full-budget 4096-token Sonnet decode at typical non-streaming
+# throughput (~50-80 tok/s) runs 50-80+ seconds — the old 60s bound only fit
+# responses capped at 1024 tokens. A timeout here is give-up-eligible
+# (agent/attempted after repeated strikes), so the timeout must contain the
+# decode the max_tokens budget above allows.
+timeout = 180
 
 
 [newsletter.labels]

--- a/config.toml
+++ b/config.toml
@@ -53,17 +53,34 @@ timeout = 60
 
 [llm.local]
 model = "{env.MLX_MODEL}"
-max_tokens = 1024
+# 4096, not 1024: with native thinking disabled, the model still emits the full
+# step-by-step scaffold the prompt asks for — as untagged prose in content,
+# label last — and observed demand ran to ~1,300 completion tokens on hard
+# threads (issue #64). An over-budget decode with thinking off does NOT fail
+# loudly: content arrives truncated before any label and would parse to the
+# default LOW_PRIORITY → archive. This raise is therefore coupled to the
+# thinking disable below, not independent tuning.
+max_tokens = 4096
 temperature = 0
 timeout = 180
-# Extra fields merged into every API request body.
-# Disable native thinking on the local person-email classifier (issue #10): the
-# eval showed native thinking is strictly worse here — reasoning overruns the
-# max_tokens budget in the <think> channel and no label is emitted. The
-# classification prompt already drives step-by-step reasoning into the content
-# channel, so this keeps reasoning quality without the budget-split failure.
-# mlx_lm.server honors this request-level chat_template_kwargs form; a top-level
-# enable_thinking is ignored by that server.
+# Extra fields merged verbatim into the top level of every API request body.
+# Native thinking must be OFF on the local person-email classifier: the #10
+# eval showed it strictly worse (reasoning overruns the max_tokens budget in
+# the separate channel and no label is emitted), and issue #64 reproduced that
+# exact failure in production under Ollama. The disable dialect is
+# backend-specific, so BOTH known forms are sent:
+#   - reasoning_effort = "none" is the form Ollama (verified on 0.32.5) honors
+#     on its OpenAI-compatible endpoint. Only "none" disables — "low" is a
+#     silent no-op there, and think=false / chat_template_kwargs are ignored.
+#   - chat_template_kwargs.enable_thinking = false is the form mlx_lm.server
+#     and LM Studio honor (Ollama ignores it). Kept for portability back to
+#     those backends; issue #64's probes sent both fields together against
+#     Ollama without harm.
+# Never use Qwen's /no_think prompt switch instead: it emitted a stray closing
+# think-tag into content that _strip_thinking cannot remove (issue #64).
+[llm.local.extra_body]
+reasoning_effort = "none"
+
 [llm.local.extra_body.chat_template_kwargs]
 enable_thinking = false
 

--- a/config.toml
+++ b/config.toml
@@ -47,7 +47,16 @@ low_priority = "archive"
 
 [llm.cloud]
 model = "zai-org/glm-5"
-max_tokens = 1024
+# Native thinking stays ENABLED here — deliberately asymmetric with
+# [llm.local]. glm-5 emits no in-content chain-of-thought at all (the <think>
+# instruction in the prompts is dead weight for it), so its accuracy rides
+# entirely on the native reasoning channel — and issue #64's probes showed
+# disabling it changes labels. Disable only behind an eval gate (issue #13).
+# Unlike the local tier, the budget is not squeezed: the same fixtures that
+# exhausted qwen's 1024 finished in 204-486 completion tokens here. 2048 is
+# cheap insurance on top of that headroom (measured on 5 probe fixtures, not
+# proof under service-heavy traffic).
+max_tokens = 2048
 temperature = 0
 timeout = 60
 

--- a/docs/runbook-agent-attempted-recovery.md
+++ b/docs/runbook-agent-attempted-recovery.md
@@ -1,0 +1,74 @@
+# Runbook: recover threads dropped to `agent/attempted` (issue #64)
+
+Owner-run, manual. Nothing in this runbook is automated by the daemon, and no
+step should be run by an agent with Gmail write access — the whole point is a
+human deciding which threads re-enter the queue.
+
+## Why these threads are lost
+
+Under Ollama, the local tier's thinking-disable was silently inert (issue
+#64): hard person threads spent the entire `max_tokens` budget in the native
+reasoning channel, returned empty content (`LLMContentError`), took
+`FailureTracker`'s 5 strikes, and were labeled `agent/attempted`. That label
+is excluded from `gmail_query` (`config.toml`), so those threads dropped out
+of the poll permanently — never classified, never retried. Production logs did
+not survive the container teardown, so the affected-thread count cannot be
+reconstructed from logs; **the label itself is the only durable trace**, and
+sweeping it is the only recovery path.
+
+## What's in the backlog besides #64 casualties
+
+Not everything under `label:agent/attempted` was dropped by this bug:
+
+- **Proxy-flap give-ups (~2026-07-09 era):** threads abandoned during Gmail
+  API proxy outages, unrelated to #64.
+- **Newsletter sink faults (post-#65 images only):** since PR #65, a
+  persistent newsletter assessment-sink fault also routes to
+  `agent/attempted`. The image deployed as of 2026-07-30 (built 2026-07-28)
+  predates #65, so today the label still means only "classification
+  give-ups" — **the sweep is cleanest before the next image is deployed.**
+  After a post-#65 deploy, check a thread's To/Cc against the newsletter
+  recipient before assuming it was a #64 casualty.
+
+Also note: `FailureTracker` is in-memory. Every daemon restart wiped the
+failure counts and the original error logs, so there is no per-thread record
+of *why* a given thread was given up on — only the label.
+
+## Recovery steps
+
+1. **Enumerate, while the daemon is stopped and before the next deploy.**
+   Search Gmail for `label:agent/attempted`. Expect three populations: #64
+   person-thread casualties (roughly, threads from real people since the
+   Ollama cutover), older proxy-flap give-ups, and — only after a post-#65
+   deploy — newsletter sink faults.
+
+2. **Re-queue by removing the label.** The mechanism that has worked before:
+   remove the `agent/attempted` label — via the Gmail proxy's modify endpoint
+   (`modify_message` with `removeLabelIds`), or simply in the Gmail UI (it is
+   an ordinary label). Once removed, the thread matches `gmail_query` again
+   and re-enters the poll. Removing it from *everything* is safe if in doubt:
+   threads that fail for unrelated permanent reasons will take their 5 strikes
+   and return to `agent/attempted`.
+
+3. **Deploy the fix, then restart the daemon.** `config.toml` is baked into
+   the image at build time — the #64 fix is not live until the image is
+   rebuilt and the daemon restarted. (The daemon is currently stopped on
+   purpose; re-queued threads are inert until it runs again.) Re-queueing
+   before the fixed image is up would just re-drop the hard threads.
+
+4. **Watch the drain.** Re-queued threads flow through at
+   `max_emails_per_cycle` (default 10) per poll cycle. Watch for
+   `LLMContentError` in the logs — with the fix deployed there should be none
+   from the local tier; any new ones now carry the response's real
+   `finish_reason` and which reasoning field was populated.
+
+## Expectations
+
+- **Labels may differ on reprocess.** Temperature-0 decoding is not stable
+  across server states (issue #64, finding 6): a borderline thread can
+  legitimately come back `FYI` one cycle and `LOW_PRIORITY` another. A
+  re-queued thread getting a different label than it would have in June is
+  expected, not a regression.
+- **Old threads get labeled late.** `agent/needs-response` on a month-old
+  thread from `someone@example.com` may no longer be actionable; the sweep
+  restores classification, not timeliness.

--- a/docs/runbook-agent-attempted-recovery.md
+++ b/docs/runbook-agent-attempted-recovery.md
@@ -45,10 +45,13 @@ of *why* a given thread was given up on — only the label.
 2. **Re-queue by removing the label.** The mechanism that has worked before:
    remove the `agent/attempted` label — via the Gmail proxy's modify endpoint
    (`modify_message` with `removeLabelIds`), or simply in the Gmail UI (it is
-   an ordinary label). Once removed, the thread matches `gmail_query` again
-   and re-enters the poll. Removing it from *everything* is safe if in doubt:
-   threads that fail for unrelated permanent reasons will take their 5 strikes
-   and return to `agent/attempted`.
+   an ordinary label). One more condition: `gmail_query` is
+   `in:inbox -label:agent/processed -label:agent/attempted`, so the thread
+   must also still be **in the inbox**. The give-up path never archives, but
+   any thread you archived by hand in the meantime needs moving back to the
+   inbox as well or it will not re-enter the poll. Removing the label from
+   *everything* is safe if in doubt: threads that fail for unrelated permanent
+   reasons will take their 5 strikes and return to `agent/attempted`.
 
 3. **Deploy the fix, then restart the daemon.** `config.toml` is baked into
    the image at build time — the #64 fix is not live until the image is

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -98,7 +98,12 @@ dialects: `chat_template_kwargs.enable_thinking = false` (mlx_lm.server /
 LM Studio) and top-level `reasoning_effort = "none"` (Ollama, verified on
 0.32.5 — `"low"` is a silent no-op and `think: false` is ignored on its
 OpenAI-compat endpoint). If your server expects something else, pass it
-explicitly via `--local-extra-body`.
+explicitly via `--local-extra-body`. Caveat: a strictly-validating provider
+(e.g. OpenAI for non-reasoning models, or one that enforces the
+low/medium/high enum) may reject the top-level `reasoning_effort = "none"`
+with a 400 rather than ignoring it — every row then errors instead of
+producing a think-off arm. Against such a backend, skip the flag and pass only
+the dialect it accepts via `--extra-body`/`--local-extra-body`.
 
 ### report
 
@@ -426,24 +431,32 @@ The eval suite includes a disk-backed LLM response cache that avoids redundant L
 [model, temperature, max_tokens, extra_body, system_prompt, user_content]
 ```
 
-Changing any of these — the model name, temperature, inference parameters, `extra_body` config, or the prompt content — produces a different cache key, ensuring stale hits don't occur across configurations.
+Changing any of these — the model name, temperature, inference parameters, `extra_body` config, or the prompt content — produces a different cache key, ensuring stale hits don't occur across configurations. The flip side: a config-only change (e.g. raising a tier's `max_tokens`) invalidates every cached entry for that tier and re-bills the next run, **without changing `prompt_hash`** — the hash covers prompts only, so two runs that differ only in inference parameters are not distinguishable by hash. Note such changes alongside any A/B comparison they straddle.
 
 **Behavior:**
 
 - On startup, the entire cache file is loaded into memory.
 - Cache hits return instantly without contacting the LLM. An entry whose stored
-  `thinking` is `""` means the response carried no separately-capturable
-  reasoning — no separate reasoning field (`reasoning_content` / `reasoning`)
-  and no inline `<think>` block. It is a normal hit, not re-fetched.
+  `thinking` is `""` **and** which carries the `thinking_complete` marker was
+  written by post-#64 any-model capture: the response carried no
+  separately-capturable reasoning — no separate reasoning field
+  (`reasoning_content` / `reasoning`) and no inline `<think>` block. It is a
+  normal hit, not re-fetched.
   **`""` is NOT proof the model didn't reason** (issue #64): with native
   thinking disabled, the model reasons as untagged prose in the content
   channel, which is preserved in the result's `label_raw`, not in `thinking`.
-  (Entries written before issue #64 have a second blind spot: capture was
-  GLM-only, so reasoning a backend routed to a separate non-GLM field — e.g.
-  Ollama's `reasoning` — was dropped as `""` even though the model reasoned.)
-- Legacy entries written before thinking capture (no `thinking` key at all) are
-  backfilled with one LLM call the first time chain-of-thought is requested for
-  them, then cached permanently.
+- Entries with unknown thinking are backfilled with one LLM call the first time
+  chain-of-thought is requested for them, then re-written with the
+  `thinking_complete` marker and cached permanently. "Unknown" covers both
+  legacy entries (no `thinking` key at all) and entries whose `""` predates the
+  any-model capture fix (no `thinking_complete` marker): those were written
+  when capture was GLM-only, so reasoning a backend routed to a separate
+  non-GLM field — e.g. Ollama's `reasoning` — was dropped as `""` even though
+  the model reasoned. If the backfill call itself returns no usable answer
+  (`LLMContentError`, e.g. the re-decode truncates at the `max_tokens` budget),
+  the cached response is still served — never discarded over a thinking
+  backfill — and `""` is frozen with the marker so the doomed re-fetch isn't
+  re-billed every run.
 - Cache misses call the real LLM, then store the response in memory.
 - New entries are appended to disk when `flush()` is called (at the end of each run).
 - Hit/miss statistics are printed at the end of every evaluation run.

--- a/evals/README-technical.md
+++ b/evals/README-technical.md
@@ -63,31 +63,42 @@ Review hotkeys: `p`/`s` sender (person/service); `r`/`f`/`l` label (needs_respon
 | `--local-timeout` | Override local LLM request timeout in seconds (for slow prefills on long inputs) |
 | `--cloud-extra-body` | JSON object merged into every cloud LLM request body (e.g. `'{"top_p": 0.9}'`) |
 | `--local-extra-body` | JSON object merged into every local LLM request body (e.g. `'{"chat_template_kwargs": {"enable_thinking": false}}'`) |
-| `--cloud-no-think` | Disable thinking for the cloud LLM (shortcut for `--cloud-extra-body '{"chat_template_kwargs": {"enable_thinking": false}}'`) |
-| `--local-no-think` | Disable thinking for the local LLM (shortcut for `--local-extra-body '{"chat_template_kwargs": {"enable_thinking": false}}'`) |
+| `--cloud-no-think` | Disable thinking for the cloud LLM (sets both `chat_template_kwargs.enable_thinking=false` and `reasoning_effort="none"`; see below) |
+| `--local-no-think` | Disable thinking for the local LLM (sets both `chat_template_kwargs.enable_thinking=false` and `reasoning_effort="none"`; see below) |
 
 #### A/B testing thinking on vs. off
 
-The local model (person-body label classification) is a reasoning model by
-default. To measure the accuracy impact of disabling thinking before changing
-`config.toml`, run two evaluations and compare:
+The shipped `config.toml` already disables native thinking on the local tier
+(issues #10, #64), so a plain run **is** the thinking-off arm. To measure the
+accuracy impact of thinking ON (e.g. re-validating the #10 result on a new
+backend), re-enable it explicitly for one run and compare:
 
 ```bash
-# Baseline (thinking on, from config) — person threads only
-uv run python -m evals.run_eval --stages stage2_only --sender-type person --tag think-on
+# Thinking off — the shipped config; person threads only
+uv run python -m evals.run_eval --stages stage2_only --sender-type person --tag think-off
 
-# Thinking off
+# Thinking on: override both disable dialects that config.toml carries.
+# reasoning_effort "low" maps to the model default on Ollama — i.e. thinking
+# back on (only "none" disables there); enable_thinking=true re-enables under
+# mlx_lm.server / LM Studio.
 uv run python -m evals.run_eval --stages stage2_only --sender-type person \
-    --local-no-think --tag think-off
+    --local-extra-body '{"reasoning_effort": "low", "chat_template_kwargs": {"enable_thinking": true}}' \
+    --tag think-on
 
-uv run python -m evals.report --compare evals/results/<think-on>.jsonl evals/results/<think-off>.jsonl
+uv run python -m evals.report --compare evals/results/<think-off>.jsonl evals/results/<think-on>.jsonl
 ```
 
 Because `extra_body` is part of the cache key, the two runs are cached
 independently — no `--no-cache` needed. The exact disable payload is
-server-specific; `--local-no-think` uses the `chat_template_kwargs` form
-(Qwen3 / LM Studio). If your server expects a top-level flag instead, pass it
-explicitly, e.g. `--local-extra-body '{"enable_thinking": false}'`.
+server-specific and **a server silently ignores dialects it doesn't know** —
+which is how an A/B can quietly compare think-on to think-on (issue #64:
+the flags used to emit only the `chat_template_kwargs` form, which Ollama
+ignores). `--local-no-think` / `--cloud-no-think` therefore emit BOTH known
+dialects: `chat_template_kwargs.enable_thinking = false` (mlx_lm.server /
+LM Studio) and top-level `reasoning_effort = "none"` (Ollama, verified on
+0.32.5 — `"low"` is a silent no-op and `think: false` is ignored on its
+OpenAI-compat endpoint). If your server expects something else, pass it
+explicitly via `--local-extra-body`.
 
 ### report
 
@@ -421,8 +432,15 @@ Changing any of these — the model name, temperature, inference parameters, `ex
 
 - On startup, the entire cache file is loaded into memory.
 - Cache hits return instantly without contacting the LLM. An entry whose stored
-  `thinking` is `""` means the model was called and emitted no `<think>` block —
-  it is a normal hit, not re-fetched.
+  `thinking` is `""` means the response carried no separately-capturable
+  reasoning — no separate reasoning field (`reasoning_content` / `reasoning`)
+  and no inline `<think>` block. It is a normal hit, not re-fetched.
+  **`""` is NOT proof the model didn't reason** (issue #64): with native
+  thinking disabled, the model reasons as untagged prose in the content
+  channel, which is preserved in the result's `label_raw`, not in `thinking`.
+  (Entries written before issue #64 have a second blind spot: capture was
+  GLM-only, so reasoning a backend routed to a separate non-GLM field — e.g.
+  Ollama's `reasoning` — was dropped as `""` even though the model reasoned.)
 - Legacy entries written before thinking capture (no `thinking` key at all) are
   backfilled with one LLM call the first time chain-of-thought is requested for
   them, then cached permanently.
@@ -440,7 +458,7 @@ uv run python -m evals.run_eval --no-cache
 
 ## Chain-of-Thought Capture
 
-When running evaluations with the LLM cache enabled (the default), chain-of-thought content from `<think>...</think>` blocks is automatically captured and stored in sidecar files alongside results.
+When running evaluations with the LLM cache enabled (the default), chain-of-thought content is automatically captured and stored in sidecar files alongside results. Capture reads, in order: the response's separate reasoning field for any model (`reasoning_content` — GLM; `reasoning` — Ollama), then inline `<think>...</think>` blocks in content. With native thinking disabled (the shipped local config), neither exists — the model's step-by-step reasoning is the untagged content itself, preserved in `label_raw`; that's where to look when inspecting a thinking-off run's reasoning (e.g. issue #14).
 
 **Sidecar format:** `evals/results/<run>.cot.jsonl` — one JSON line per thread with `stage1_thinking` and `stage2_thinking` fields.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -298,20 +298,23 @@ uv run python -m evals.report --compare evals/results/*baseline*.jsonl evals/res
 
 **Thinking on/off A/B (reasoning models):**
 
-The local model reasons in `<think>` tags by default; that costs tokens and
-latency. To measure what disabling it does to accuracy *before* changing
-`config.toml`, run the same person-thread evaluation both ways and compare:
+The shipped `config.toml` disables the local model's native thinking (issues
+#10, #64), so a plain run is already the thinking-off arm. To measure what
+thinking ON does to accuracy, re-enable it explicitly for one run and compare:
 
 ```bash
-uv run python -m evals.run_eval --stages stage2_only --sender-type person --tag think-on
+uv run python -m evals.run_eval --stages stage2_only --sender-type person --tag think-off
 uv run python -m evals.run_eval --stages stage2_only --sender-type person \
-    --local-no-think --tag think-off
-uv run python -m evals.report --compare evals/results/*think-on*.jsonl evals/results/*think-off*.jsonl
+    --local-extra-body '{"reasoning_effort": "low", "chat_template_kwargs": {"enable_thinking": true}}' \
+    --tag think-on
+uv run python -m evals.report --compare evals/results/*think-off*.jsonl evals/results/*think-on*.jsonl
 ```
 
-`--local-no-think` / `--cloud-no-think` emit the `chat_template_kwargs` disable
-form (Qwen / LM Studio) and also natively disable thinking on GLM-style cloud
-models. If your server expects a different flag, pass it explicitly via
+`--local-no-think` / `--cloud-no-think` emit both known disable dialects —
+`chat_template_kwargs.enable_thinking=false` (mlx_lm.server / LM Studio) and
+`reasoning_effort="none"` (Ollama; the only form its OpenAI-compat endpoint
+honors) — and also natively disable thinking on GLM-style cloud models. If
+your server expects a different flag, pass it explicitly via
 `--local-extra-body` / `--cloud-extra-body`. The extra body is part of the LLM
 cache key, so the two runs cache independently — no `--no-cache` needed.
 

--- a/evals/llm_cache.py
+++ b/evals/llm_cache.py
@@ -25,7 +25,11 @@ class CachedLLMClient:
         self.cache_path = cache_path
         # key -> (response, thinking). thinking is None for legacy entries
         # written before thinking capture (unknown, backfillable); "" means the
-        # model was called and legitimately emitted no thinking (do NOT re-fetch).
+        # model was called and no separately-capturable reasoning arrived — no
+        # separate reasoning field, no <think> block (do NOT re-fetch). NOT
+        # proof the model didn't reason (issue #64): with thinking off the CoT
+        # is the untagged response itself, and entries cached before #64 could
+        # also have had reasoning sitting unread in a non-GLM separate field.
         self._cache: dict[str, tuple[str, str | None]] = {}
         self._pending: list[dict] = []  # new entries to flush to disk
         self.hits = 0
@@ -49,9 +53,10 @@ class CachedLLMClient:
                     entry = json.loads(line)
                     response = entry["response"]
                     # A present "thinking" key (even "") means the entry was
-                    # written by thinking-aware code: "" is a real "no thinking
-                    # emitted", not a gap to backfill. Only entries missing the
-                    # key entirely are legacy (thinking unknown -> None).
+                    # written by thinking-aware code: "" is a real "nothing was
+                    # separately capturable", not a gap to backfill. Only entries
+                    # missing the key entirely are legacy (thinking unknown ->
+                    # None).
                     thinking = entry["thinking"] if "thinking" in entry else None
                     # Normalize old entries that may contain unstripped think tags
                     extra_thinking = LLMClient._extract_thinking(response)
@@ -86,7 +91,8 @@ class CachedLLMClient:
         if key in self._cache:
             response, thinking = self._cache[key]
             # Backfill thinking only for legacy entries where it is unknown
-            # (None). An empty string means the model emitted no thinking —
+            # (None). An empty string means nothing was separately capturable
+            # (e.g. thinking-off runs, where the CoT is the response itself) —
             # re-fetching those would re-bill every terse response forever.
             if include_thinking and thinking is None:
                 self.misses += 1

--- a/evals/llm_cache.py
+++ b/evals/llm_cache.py
@@ -10,7 +10,7 @@ import json
 import time
 from pathlib import Path
 
-from llm_client import LLMClient
+from llm_client import LLMClient, LLMContentError
 
 
 class CachedLLMClient:
@@ -23,13 +23,15 @@ class CachedLLMClient:
     def __init__(self, inner: LLMClient, cache_path: Path):
         self.inner = inner
         self.cache_path = cache_path
-        # key -> (response, thinking). thinking is None for legacy entries
-        # written before thinking capture (unknown, backfillable); "" means the
-        # model was called and no separately-capturable reasoning arrived — no
-        # separate reasoning field, no <think> block (do NOT re-fetch). NOT
-        # proof the model didn't reason (issue #64): with thinking off the CoT
-        # is the untagged response itself, and entries cached before #64 could
-        # also have had reasoning sitting unread in a non-GLM separate field.
+        # key -> (response, thinking). thinking is None when unknown and
+        # backfillable: legacy entries written before thinking capture, AND
+        # entries whose stored "" predates the any-model capture fix (issue
+        # #64 — their reasoning may have sat unread in a non-GLM separate
+        # field). A trusted "" — written by post-fix code, marked
+        # thinking_complete on disk — means the model was called and no
+        # separately-capturable reasoning arrived: no separate reasoning
+        # field, no <think> block (do NOT re-fetch; with thinking off the CoT
+        # is the untagged response itself).
         self._cache: dict[str, tuple[str, str | None]] = {}
         self._pending: list[dict] = []  # new entries to flush to disk
         self.hits = 0
@@ -52,12 +54,20 @@ class CachedLLMClient:
                 try:
                     entry = json.loads(line)
                     response = entry["response"]
-                    # A present "thinking" key (even "") means the entry was
-                    # written by thinking-aware code: "" is a real "nothing was
-                    # separately capturable", not a gap to backfill. Only entries
-                    # missing the key entirely are legacy (thinking unknown ->
-                    # None).
-                    thinking = entry["thinking"] if "thinking" in entry else None
+                    # A present "thinking" key alone does NOT make "" trusted:
+                    # entries written before the any-model capture fix (issue
+                    # #64) stored "" while reasoning sat unread in a non-GLM
+                    # separate field (e.g. Ollama's `reasoning`). Only entries
+                    # carrying the thinking_complete marker (written by
+                    # post-fix code) may freeze "" as "nothing separately
+                    # capturable"; an unmarked "" is treated like a legacy
+                    # entry (thinking unknown -> None, backfillable — one
+                    # re-fetch, then re-written with the marker).
+                    raw_thinking = entry.get("thinking")
+                    if raw_thinking or entry.get("thinking_complete"):
+                        thinking = raw_thinking
+                    else:
+                        thinking = None
                     # Normalize old entries that may contain unstripped think tags
                     extra_thinking = LLMClient._extract_thinking(response)
                     response = LLMClient._strip_thinking(response)
@@ -90,16 +100,29 @@ class CachedLLMClient:
 
         if key in self._cache:
             response, thinking = self._cache[key]
-            # Backfill thinking only for legacy entries where it is unknown
-            # (None). An empty string means nothing was separately capturable
-            # (e.g. thinking-off runs, where the CoT is the response itself) —
-            # re-fetching those would re-bill every terse response forever.
+            # Backfill thinking only where it is unknown (None): legacy
+            # entries and pre-#64 "" entries (see _load). A trusted "" means
+            # nothing was separately capturable (e.g. thinking-off runs, where
+            # the CoT is the response itself) — re-fetching those would
+            # re-bill every terse response forever.
             if include_thinking and thinking is None:
                 self.misses += 1
                 start = time.monotonic()
-                _, thinking = await self.inner.complete(
-                    system_prompt, user_content, include_thinking=True,
-                )
+                try:
+                    _, thinking = await self.inner.complete(
+                        system_prompt, user_content, include_thinking=True,
+                    )
+                except LLMContentError:
+                    # The metadata-only re-fetch produced no usable answer
+                    # (e.g. the re-decode truncated at the max_tokens budget
+                    # under the post-#64 guard). The cached response is still
+                    # perfectly usable — never discard it over a thinking
+                    # backfill. Freeze "" rather than leaving None: under this
+                    # cache key the model/budget are fixed, so the re-fetch
+                    # would fail identically (and re-bill) on every run, and
+                    # any config change that could succeed also changes the
+                    # key.
+                    thinking = ""
                 self._llm_seconds[tk] = (
                     self._llm_seconds.get(tk, 0.0) + time.monotonic() - start
                 )
@@ -109,6 +132,7 @@ class CachedLLMClient:
                     "model": self.inner.model,
                     "response": response,
                     "thinking": thinking,
+                    "thinking_complete": True,
                 })
             else:
                 self.hits += 1
@@ -129,11 +153,14 @@ class CachedLLMClient:
             self._thinking_buffers.setdefault(tk, []).append(thinking)
 
         self._cache[key] = (response, thinking)
+        # thinking_complete marks the thinking value as written by post-#64
+        # any-model capture, so a "" is trusted emptiness on reload — see _load.
         self._pending.append({
             "key": key,
             "model": self.inner.model,
             "response": response,
             "thinking": thinking,
+            "thinking_complete": True,
         })
         if include_thinking:
             return response, thinking

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -174,7 +174,11 @@ def resolve_extra_body(base: dict | None, no_think: bool, override_json: str | N
 
     Precedence (later wins):
       1. config's existing extra_body (*base*)
-      2. --no-think -> sets chat_template_kwargs.enable_thinking = False
+      2. --no-think -> sets BOTH disable dialects: chat_template_kwargs.
+         enable_thinking = False (mlx_lm.server / LM Studio) and top-level
+         reasoning_effort = "none" (Ollama — the only field its OpenAI-compat
+         endpoint honors; issue #64). A backend ignores the dialect it doesn't
+         know, so emitting both keeps the flag meaningful across backends.
       3. --extra-body JSON object (its keys override the above)
 
     Returns the merged dict, or None when nothing is set (so the LLMClient keeps
@@ -189,6 +193,7 @@ def resolve_extra_body(base: dict | None, no_think: bool, override_json: str | N
         ctk = dict(result.get("chat_template_kwargs") or {})
         ctk["enable_thinking"] = False
         result["chat_template_kwargs"] = ctk
+        result["reasoning_effort"] = "none"
     if override_json:
         try:
             override = json.loads(override_json)
@@ -741,11 +746,13 @@ def cli():
                         help='JSON object merged into every local LLM request body '
                              '(e.g. \'{"chat_template_kwargs": {"enable_thinking": false}}\')')
     parser.add_argument("--cloud-no-think", action="store_true",
-                        help="Disable thinking for the cloud LLM "
-                             "(sets chat_template_kwargs.enable_thinking=false)")
+                        help="Disable thinking for the cloud LLM (sets "
+                             "chat_template_kwargs.enable_thinking=false and "
+                             "reasoning_effort=none)")
     parser.add_argument("--local-no-think", action="store_true",
-                        help="Disable thinking for the local LLM "
-                             "(sets chat_template_kwargs.enable_thinking=false)")
+                        help="Disable thinking for the local LLM (sets "
+                             "chat_template_kwargs.enable_thinking=false and "
+                             "reasoning_effort=none)")
     args = parser.parse_args()
 
     if args.stages not in VALID_STAGES:

--- a/llm_client.py
+++ b/llm_client.py
@@ -159,13 +159,17 @@ class LLMClient:
     def _extra_body_disables_thinking(self) -> bool:
         """True if extra_body asks to turn thinking off.
 
-        Recognizes both the chat_template_kwargs.enable_thinking form (Qwen / LM
-        Studio, what --no-think emits) and a top-level enable_thinking flag. GLM
-        ignores those fields, so complete() uses this to set GLM's native thinking
-        field to disabled rather than contradicting the request with enabled.
+        Recognizes the chat_template_kwargs.enable_thinking form (Qwen / LM
+        Studio), a top-level enable_thinking flag, and reasoning_effort="none"
+        (the Ollama dialect — only "none" disables there; "low" etc. are model
+        defaults, not a disable). GLM ignores all of those fields, so complete()
+        uses this to set GLM's native thinking field to disabled rather than
+        contradicting the request with enabled.
         """
         ctk = self.extra_body.get("chat_template_kwargs")
         if isinstance(ctk, dict) and ctk.get("enable_thinking") is False:
+            return True
+        if self.extra_body.get("reasoning_effort") == "none":
             return True
         return self.extra_body.get("enable_thinking") is False
 
@@ -312,12 +316,18 @@ class LLMClient:
             )
 
         if include_thinking:
-            # GLM models return reasoning in a separate field
-            if self._is_glm_model() and msg.get("reasoning_content"):
-                thinking = msg["reasoning_content"]
-            else:
-                # DeepSeek/Qwen models use inline <think> tags
-                thinking = self._extract_thinking(content)
+            # Separate-channel reasoning is read for ANY model — the field name
+            # is backend-specific (GLM: reasoning_content; Ollama: reasoning).
+            # This used to be GLM-gated, so Ollama-served local models silently
+            # yielded thinking="" (issue #64). Fall back to inline <think> tags
+            # (DeepSeek/Qwen under mlx_lm.server). With thinking disabled there
+            # is no separate field and no tags: the reasoning is the untagged
+            # content itself, so "" here just means "read the content".
+            thinking = (
+                msg.get("reasoning_content")
+                or msg.get("reasoning")
+                or self._extract_thinking(content)
+            )
             return self._strip_thinking(content), thinking
         return self._strip_thinking(content)
 

--- a/llm_client.py
+++ b/llm_client.py
@@ -319,15 +319,16 @@ class LLMClient:
             # Separate-channel reasoning is read for ANY model — the field name
             # is backend-specific (GLM: reasoning_content; Ollama: reasoning).
             # This used to be GLM-gated, so Ollama-served local models silently
-            # yielded thinking="" (issue #64). Fall back to inline <think> tags
-            # (DeepSeek/Qwen under mlx_lm.server). With thinking disabled there
-            # is no separate field and no tags: the reasoning is the untagged
-            # content itself, so "" here just means "read the content".
-            thinking = (
-                msg.get("reasoning_content")
-                or msg.get("reasoning")
-                or self._extract_thinking(content)
-            )
+            # yielded thinking="" (issue #64). Inline <think> tags are captured
+            # TOO, not as a mere fallback: with thinking on and budget to spare
+            # the model emitted both channels at once, and the inline block is
+            # stripped from the returned content — dropping it here would lose
+            # it entirely. With thinking disabled there is no separate field and
+            # no tags: the reasoning is the untagged content itself, so "" here
+            # just means "read the content".
+            separate = msg.get("reasoning_content") or msg.get("reasoning") or ""
+            inline = self._extract_thinking(content)
+            thinking = "\n\n".join(part for part in (separate, inline) if part)
             return self._strip_thinking(content), thinking
         return self._strip_thinking(content)
 

--- a/llm_client.py
+++ b/llm_client.py
@@ -72,15 +72,18 @@ class LLMUnavailableError(Exception):
 
 
 class LLMContentError(RuntimeError):
-    """The model returned no usable ``content`` (issue #30).
+    """The model returned no usable ``content`` (issues #30, #64).
 
     A reasoning model that exhausts max_tokens mid-<think>, a GLM reply carrying
     only ``reasoning_content``, or an empty string all yield an unusable response.
-    Retrying as-is won't help, so it is request-specific/permanent and
-    give-up-eligible. It subclasses ``RuntimeError`` so the email pipeline's
-    ``except RuntimeError`` give-up handler catches it unchanged, while giving the
-    newsletter pipeline a dedicated type to re-raise (a *bare* per-story
-    RuntimeError stays isolated; a content-less one propagates to give-up).
+    So does a response whose ``finish_reason`` is ``"length"`` even when content
+    is non-empty: the answer was cut at the max_tokens budget, and parsing a
+    truncated answer silently defaults the label (issue #64). Retrying as-is
+    won't help, so it is request-specific/permanent and give-up-eligible. It
+    subclasses ``RuntimeError`` so the email pipeline's ``except RuntimeError``
+    give-up handler catches it unchanged, while giving the newsletter pipeline a
+    dedicated type to re-raise (a *bare* per-story RuntimeError stays isolated;
+    a content-less one propagates to give-up).
     """
 
 
@@ -190,6 +193,9 @@ class LLMClient:
                 out of funds (402, or a 400/403 whose body carries a balance
                 signature) — account-wide; the daemon halts rather than giving
                 up per-thread.
+            LLMContentError: If the response carries no usable answer — empty/
+                missing content, or finish_reason "length" (answer truncated at
+                the max_tokens budget) — request-specific and give-up-eligible.
             RuntimeError: If the LLM returns any other non-200 response.
         """
         headers = {"Content-Type": "application/json"}
@@ -266,22 +272,43 @@ class LLMClient:
                 f"(prompt ~{prompt_chars // 4} tokens, {prompt_chars} chars): {resp_body}"
             )
 
-        msg = response.json()["choices"][0]["message"]
+        choice = response.json()["choices"][0]
+        msg = choice["message"]
+        finish_reason = choice.get("finish_reason")
         content = msg.get("content")
-        if not content:
-            # A reasoning model that exhausts max_tokens mid-<think> (or a GLM reply
-            # that returns only reasoning_content) yields a message with no usable
-            # `content` — whether that arrives as null, a missing key, or an empty
-            # string. Retrying as-is won't help, so this is request-specific/
-            # permanent: surface a clear RuntimeError (give-up-eligible via the daemon),
-            # never LLMUnavailableError (would retry forever) or a raw KeyError.
-            # (An empty string must be caught too: it would otherwise parse to a
-            # default SERVICE / LOW_PRIORITY label and silently mislabel the email.)
-            has_reasoning = bool(msg.get("reasoning_content") or msg.get("reasoning"))
+        if not content or finish_reason == "length":
+            # Two unusable-response shapes, both request-specific/permanent
+            # (retrying as-is won't help), so both raise LLMContentError —
+            # give-up-eligible via the daemon, never LLMUnavailableError (would
+            # retry forever) or a raw KeyError (issue #64):
+            #   - No `content` (null, missing key, or empty string): a reasoning
+            #     model exhausted max_tokens in its thinking channel, or GLM
+            #     returned only reasoning_content. An empty string must be caught
+            #     too — it would otherwise parse to a default SERVICE /
+            #     LOW_PRIORITY label and silently mislabel the email.
+            #   - finish_reason "length" with non-empty content: the answer was
+            #     cut at the max_tokens budget, usually mid-reasoning before any
+            #     label. Parsing it would silently default to LOW_PRIORITY and
+            #     archive the email, so a truncated answer is never returned.
+            # The diagnostics report the response's actual finish_reason and
+            # which reasoning field was populated (Ollama uses `reasoning`, GLM
+            # uses `reasoning_content`) — the old message hardcoded a guess,
+            # which masked the real failure pattern in production logs.
+            populated = [f for f in ("reasoning_content", "reasoning") if msg.get(f)]
+            prompt_chars = len(system_prompt) + len(user_content)
+            diagnostics = (
+                f"finish_reason={finish_reason!r}, max_tokens={self.max_tokens}, "
+                f"prompt ~{prompt_chars // 4} tokens ({prompt_chars} chars); "
+                + (f"reasoning in {' + '.join(populated)}" if populated else "no reasoning field")
+            )
+            if not content:
+                raise LLMContentError(
+                    f"LLM {self.model} returned no content ({diagnostics})"
+                )
             raise LLMContentError(
-                f"LLM {self.model} returned no content "
-                f"(max_tokens={self.max_tokens} likely exhausted before a final answer; "
-                f"reasoning_content {'present' if has_reasoning else 'absent'})"
+                f"LLM {self.model} answer truncated at the max_tokens budget — "
+                f"{len(content)} chars of content but no trustworthy final answer "
+                f"({diagnostics})"
             )
 
         if include_thinking:

--- a/llm_client.py
+++ b/llm_client.py
@@ -162,14 +162,18 @@ class LLMClient:
         Recognizes the chat_template_kwargs.enable_thinking form (Qwen / LM
         Studio), a top-level enable_thinking flag, and reasoning_effort="none"
         (the Ollama dialect — only "none" disables there; "low" etc. are model
-        defaults, not a disable). GLM ignores all of those fields, so complete()
-        uses this to set GLM's native thinking field to disabled rather than
+        defaults, not a disable). Matched case-insensitively: a hand-edited
+        config or --extra-body JSON spelling it "None" still carries disable
+        intent, and missing it would silently flip a think-off A/B arm back to
+        thinking-on. GLM ignores all of those fields, so complete() uses this
+        to set GLM's native thinking field to disabled rather than
         contradicting the request with enabled.
         """
         ctk = self.extra_body.get("chat_template_kwargs")
         if isinstance(ctk, dict) and ctk.get("enable_thinking") is False:
             return True
-        if self.extra_body.get("reasoning_effort") == "none":
+        effort = self.extra_body.get("reasoning_effort")
+        if isinstance(effort, str) and effort.lower() == "none":
             return True
         return self.extra_body.get("enable_thinking") is False
 
@@ -280,25 +284,33 @@ class LLMClient:
         msg = choice["message"]
         finish_reason = choice.get("finish_reason")
         content = msg.get("content")
-        if not content or finish_reason == "length":
-            # Two unusable-response shapes, both request-specific/permanent
-            # (retrying as-is won't help), so both raise LLMContentError —
+        stripped = self._strip_thinking(content) if content else ""
+        if not stripped or finish_reason == "length":
+            # Three unusable-response shapes, all request-specific/permanent
+            # (retrying as-is won't help), so all raise LLMContentError —
             # give-up-eligible via the daemon, never LLMUnavailableError (would
             # retry forever) or a raw KeyError (issue #64):
             #   - No `content` (null, missing key, or empty string): a reasoning
             #     model exhausted max_tokens in its thinking channel, or GLM
-            #     returned only reasoning_content. An empty string must be caught
-            #     too — it would otherwise parse to a default SERVICE /
-            #     LOW_PRIORITY label and silently mislabel the email.
+            #     returned only reasoning_content.
+            #   - Content that strips to nothing: a fully-closed think-only
+            #     response — the model spent its whole turn inside <think> and
+            #     never answered. Both empty shapes would otherwise parse to a
+            #     default SERVICE / LOW_PRIORITY label and silently mislabel
+            #     the email.
             #   - finish_reason "length" with non-empty content: the answer was
             #     cut at the max_tokens budget, usually mid-reasoning before any
             #     label. Parsing it would silently default to LOW_PRIORITY and
             #     archive the email, so a truncated answer is never returned.
             # The diagnostics report the response's actual finish_reason and
-            # which reasoning field was populated (Ollama uses `reasoning`, GLM
-            # uses `reasoning_content`) — the old message hardcoded a guess,
-            # which masked the real failure pattern in production logs.
+            # where the reasoning actually sat — a separate field (Ollama uses
+            # `reasoning`, GLM uses `reasoning_content`) or inline <think>
+            # prose in content (the mlx_lm.server / LM Studio think-on shape) —
+            # the old message hardcoded a guess, which masked the real failure
+            # pattern in production logs.
             populated = [f for f in ("reasoning_content", "reasoning") if msg.get(f)]
+            if content and "<think>" in content:
+                populated.append("inline <think> tags")
             prompt_chars = len(system_prompt) + len(user_content)
             diagnostics = (
                 f"finish_reason={finish_reason!r}, max_tokens={self.max_tokens}, "
@@ -309,16 +321,26 @@ class LLMClient:
                 raise LLMContentError(
                     f"LLM {self.model} returned no content ({diagnostics})"
                 )
+            if finish_reason == "length":
+                raise LLMContentError(
+                    f"LLM {self.model} answer truncated at the max_tokens budget — "
+                    f"{len(content)} chars of content but no trustworthy final answer "
+                    f"({diagnostics})"
+                )
             raise LLMContentError(
-                f"LLM {self.model} answer truncated at the max_tokens budget — "
-                f"{len(content)} chars of content but no trustworthy final answer "
-                f"({diagnostics})"
+                f"LLM {self.model} returned only reasoning, no final answer — "
+                f"{len(content)} chars of content strip to nothing ({diagnostics})"
             )
 
         if include_thinking:
             # Separate-channel reasoning is read for ANY model — the field name
-            # is backend-specific (GLM: reasoning_content; Ollama: reasoning).
-            # This used to be GLM-gated, so Ollama-served local models silently
+            # is backend-specific (GLM: reasoning_content; Ollama: reasoning),
+            # and a proxy may populate both at once, so every string-valued
+            # field is captured (mirrored duplicates collapsed) — the error
+            # diagnostics above already treat the fields as simultaneously
+            # reportable. Non-string values (structured reasoning blocks from
+            # some proxies) are ignored rather than crashing the join. This
+            # used to be GLM-gated, so Ollama-served local models silently
             # yielded thinking="" (issue #64). Inline <think> tags are captured
             # TOO, not as a mere fallback: with thinking on and budget to spare
             # the model emitted both channels at once, and the inline block is
@@ -326,11 +348,16 @@ class LLMClient:
             # it entirely. With thinking disabled there is no separate field and
             # no tags: the reasoning is the untagged content itself, so "" here
             # just means "read the content".
-            separate = msg.get("reasoning_content") or msg.get("reasoning") or ""
+            separate = [
+                v for v in (msg.get("reasoning_content"), msg.get("reasoning"))
+                if isinstance(v, str) and v
+            ]
+            if len(separate) == 2 and separate[0] == separate[1]:
+                separate = separate[:1]
             inline = self._extract_thinking(content)
-            thinking = "\n\n".join(part for part in (separate, inline) if part)
-            return self._strip_thinking(content), thinking
-        return self._strip_thinking(content)
+            thinking = "\n\n".join(part for part in (*separate, inline) if part)
+            return stripped, thinking
+        return stripped
 
     async def probe(self, timeout: float | None = None) -> "AvailabilityResult":
         """Probe the endpoint, returning status detail (issue #41 item 7).

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1465,17 +1465,19 @@ class TestLoadConfig:
     def test_config_disables_native_thinking_on_local_classifier(self):
         # Issue #10: the eval showed native thinking on the local person-email
         # classifier is strictly worse (budget-split failures where reasoning
-        # overruns max_tokens and no label is emitted). The classification prompt
-        # already drives reasoning into the content channel, so native thinking is
-        # disabled via request-level chat_template_kwargs (the form mlx_lm.server
-        # honors). The cloud classifier is unaffected.
+        # overruns max_tokens and no label is emitted). The disable dialect is
+        # backend-specific: this test guards the chat_template_kwargs form
+        # (honored by mlx_lm.server / LM Studio, ignored by Ollama); the Ollama
+        # form is reasoning_effort = "none", guarded by
+        # test_config_local_extra_body_disables_thinking_on_ollama (issue #64).
+        # The cloud classifier is unaffected.
         config = load_config()
         local = config["llm"]["local"]
         # Layout guard: the flag must be in the nested chat_template_kwargs form.
-        # mlx_lm.server (the real local server) honors this form and ignores a
-        # top-level enable_thinking, so this specific nesting is load-bearing — a
-        # refactor to the top-level form would silently re-enable thinking on the
-        # local server even though llm_client treats both as no-think.
+        # mlx_lm.server honors this form and ignores a top-level enable_thinking,
+        # so this specific nesting is load-bearing — a refactor to the top-level
+        # form would silently stop disabling thinking on mlx_lm.server even
+        # though llm_client treats both as no-think.
         ctk = local["extra_body"]["chat_template_kwargs"]
         assert ctk["enable_thinking"] is False
         # Behavior guard: the LLMClient the daemon builds from this config must
@@ -1485,6 +1487,31 @@ class TestLoadConfig:
             extra_body=local.get("extra_body"),
         )
         assert client._extra_body_disables_thinking() is True
+
+    def test_config_local_extra_body_disables_thinking_on_ollama(self):
+        # Issue #64: Ollama's OpenAI-compat endpoint ignores the
+        # chat_template_kwargs.enable_thinking form entirely (measured on
+        # 0.32.5), so native thinking was silently re-enabled and reasoning
+        # consumed the whole max_tokens budget before any content was emitted.
+        # The one field that Ollama honors is a top-level
+        # reasoning_effort = "none" ("low" is a silent no-op — only "none"
+        # disables). llm_client merges extra_body at the top level of the
+        # request body, so this is pure config data.
+        config = load_config()
+        extra_body = config["llm"]["local"]["extra_body"]
+        assert extra_body["reasoning_effort"] == "none"
+
+    def test_config_local_max_tokens_covers_thinking_off_decode(self):
+        # Issue #64: with thinking off, the prompts still elicit the full
+        # step-by-step scaffold as untagged content, and observed demand ran up
+        # to 1,293 completion tokens — beyond the old 1024 budget. Worse, an
+        # over-budget decode with thinking off does NOT raise LLMContentError:
+        # content arrives truncated before any label and parse_email_label
+        # silently defaults to LOW_PRIORITY (whose action is ARCHIVE). The
+        # budget raise is therefore coupled to the thinking disable, not
+        # optional insurance. 2048 is the measured floor; shipped value 4096.
+        config = load_config()
+        assert config["llm"]["local"]["max_tokens"] >= 2048
 
     def test_config_has_newsletter_section(self):
         config = load_config()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1504,14 +1504,27 @@ class TestLoadConfig:
     def test_config_local_max_tokens_covers_thinking_off_decode(self):
         # Issue #64: with thinking off, the prompts still elicit the full
         # step-by-step scaffold as untagged content, and observed demand ran up
-        # to 1,293 completion tokens — beyond the old 1024 budget. Worse, an
-        # over-budget decode with thinking off does NOT raise LLMContentError:
-        # content arrives truncated before any label and parse_email_label
-        # silently defaults to LOW_PRIORITY (whose action is ARCHIVE). The
-        # budget raise is therefore coupled to the thinking disable, not
-        # optional insurance. 2048 is the measured floor; shipped value 4096.
+        # to 1,293 completion tokens — beyond the old 1024 budget. An
+        # over-budget decode truncates content before any label; llm_client now
+        # raises LLMContentError on finish_reason "length" (it used to parse to
+        # a silent LOW_PRIORITY default), so an undersized budget means loud
+        # give-ups rather than mislabels — still lost mail. The budget raise is
+        # therefore coupled to the thinking disable, not optional insurance.
+        # 2048 is the measured floor; shipped value 4096.
         config = load_config()
         assert config["llm"]["local"]["max_tokens"] >= 2048
+
+    def test_config_newsletter_max_tokens_covers_multi_story_extraction(self):
+        # Issue #64 collateral: story_extraction re-emits the FULL text of every
+        # story in one response, so its output scales with newsletter size — the
+        # one call whose demand 1024 demonstrably cannot bound. With llm_client
+        # now raising on finish_reason "length" (instead of silently truncating
+        # mid-story), an undersized budget would turn every long newsletter into
+        # a deterministic give-up (agent/attempted). Sized by that reasoning
+        # (issue #64's Fix 4), not by live measurement — the newsletter tier was
+        # never probed.
+        config = load_config()
+        assert config["newsletter"]["llm"]["max_tokens"] >= 2048
 
     def test_config_has_newsletter_section(self):
         config = load_config()

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -123,7 +123,8 @@ class TestApplyConfigOverrides:
         cfg = _override_config()
         apply_config_overrides(cfg, _override_args(local_no_think=True))
         assert cfg["llm"]["local"]["extra_body"] == {
-            "chat_template_kwargs": {"enable_thinking": False}
+            "chat_template_kwargs": {"enable_thinking": False},
+            "reasoning_effort": "none",
         }
         assert "extra_body" not in cfg["llm"]["cloud"]  # cloud untouched
 
@@ -177,22 +178,43 @@ class TestResolveExtraBody:
     def test_passes_through_base_when_no_overrides(self):
         assert resolve_extra_body({"top_p": 0.9}, False, None) == {"top_p": 0.9}
 
-    def test_no_think_sets_chat_template_kwargs(self):
+    def test_no_think_sets_both_disable_dialects(self):
+        # Issue #64: --no-think used to emit only the chat_template_kwargs form,
+        # which Ollama silently ignores — so a think-on/think-off A/B against an
+        # Ollama backend compared think-on to think-on. The flag must emit BOTH
+        # known dialects: chat_template_kwargs.enable_thinking=false (mlx_lm /
+        # LM Studio) and top-level reasoning_effort="none" (Ollama; only "none"
+        # disables there).
         assert resolve_extra_body(None, True, None) == {
-            "chat_template_kwargs": {"enable_thinking": False}
+            "chat_template_kwargs": {"enable_thinking": False},
+            "reasoning_effort": "none",
         }
 
     def test_no_think_preserves_existing_chat_template_kwargs(self):
         out = resolve_extra_body({"chat_template_kwargs": {"foo": 1}}, True, None)
-        assert out == {"chat_template_kwargs": {"foo": 1, "enable_thinking": False}}
+        assert out == {
+            "chat_template_kwargs": {"foo": 1, "enable_thinking": False},
+            "reasoning_effort": "none",
+        }
 
     def test_explicit_json_merges_and_wins(self):
         out = resolve_extra_body({"top_p": 0.9}, False, '{"top_p": 0.5, "min_p": 0.1}')
         assert out == {"top_p": 0.5, "min_p": 0.1}
 
     def test_explicit_json_overrides_no_think(self):
+        # JSON overrides the keys it names; --no-think keys it doesn't name stay.
         out = resolve_extra_body(None, True, '{"chat_template_kwargs": {"enable_thinking": true}}')
-        assert out == {"chat_template_kwargs": {"enable_thinking": True}}
+        assert out == {
+            "chat_template_kwargs": {"enable_thinking": True},
+            "reasoning_effort": "none",
+        }
+
+    def test_explicit_json_overrides_no_think_reasoning_effort(self):
+        out = resolve_extra_body(None, True, '{"reasoning_effort": "high"}')
+        assert out == {
+            "chat_template_kwargs": {"enable_thinking": False},
+            "reasoning_effort": "high",
+        }
 
     def test_invalid_json_raises(self):
         with pytest.raises(ValueError):

--- a/tests/test_eval_run.py
+++ b/tests/test_eval_run.py
@@ -128,6 +128,18 @@ class TestApplyConfigOverrides:
         }
         assert "extra_body" not in cfg["llm"]["cloud"]  # cloud untouched
 
+    def test_cloud_no_think_applies_both_dialects_to_cloud(self):
+        # The cloud flag's wiring is separate from the local flag's — a
+        # disconnected --cloud-no-think would be a silently-inert no-op, the
+        # exact failure shape issue #64 is about.
+        cfg = _override_config()
+        apply_config_overrides(cfg, _override_args(cloud_no_think=True))
+        assert cfg["llm"]["cloud"]["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": False},
+            "reasoning_effort": "none",
+        }
+        assert "extra_body" not in cfg["llm"]["local"]  # local untouched
+
     def test_extra_body_json_is_merged(self):
         cfg = _override_config()
         apply_config_overrides(cfg, _override_args(cloud_extra_body='{"top_p": 0.9}'))
@@ -215,6 +227,15 @@ class TestResolveExtraBody:
             "chat_template_kwargs": {"enable_thinking": False},
             "reasoning_effort": "high",
         }
+
+    def test_no_think_overrides_base_config_reasoning_effort(self):
+        # Precedence: --no-think must OVERRIDE a base config's reasoning_effort,
+        # not merely fill it in when absent. A base carrying "low" is plausible
+        # Ollama tuning — and "low" is a silent no-op there (thinking stays ON),
+        # so preserving it would make --no-think inert against exactly the
+        # backend it was fixed for.
+        out = resolve_extra_body({"reasoning_effort": "low"}, True, None)
+        assert out["reasoning_effort"] == "none"
 
     def test_invalid_json_raises(self):
         with pytest.raises(ValueError):

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from evals.llm_cache import CachedLLMClient
-from llm_client import LLMClient
+from llm_client import LLMClient, LLMContentError
 
 
 def _make_inner(**overrides) -> LLMClient:
@@ -291,6 +291,81 @@ class TestCorruptCacheFile:
         assert thinking == "reasoning about sender type"
         assert cached2.hits == 1
         inner2.complete.assert_not_awaited()
+
+    async def test_pre_capture_fix_empty_thinking_entry_is_backfilled(self, tmp_path: Path):
+        """A disk entry with thinking="" but NO thinking_complete marker predates
+        the any-model capture fix (issue #64): its "" may hide reasoning that sat
+        unread in a non-GLM separate field (e.g. Ollama's `reasoning`), so it is
+        backfillable — not authoritative emptiness."""
+        cache_path = tmp_path / "cache.jsonl"
+        inner = _make_inner()
+        valid_key = CachedLLMClient(inner, cache_path)._cache_key("sys", "usr")
+        cache_path.write_text(
+            json.dumps({
+                "key": valid_key, "model": "test-model",
+                "response": "SERVICE", "thinking": "",
+            }) + "\n"
+        )
+
+        _set_return(inner, "SERVICE", "reasoning captured post-fix")
+        cached = CachedLLMClient(inner, cache_path)
+        response, thinking = await cached.complete("sys", "usr", include_thinking=True)
+
+        assert response == "SERVICE"  # cached response preserved
+        assert thinking == "reasoning captured post-fix"
+        inner.complete.assert_awaited_once()
+
+    async def test_backfilled_empty_thinking_is_frozen_with_marker(self, tmp_path: Path):
+        """When the backfill of a pre-fix "" entry again captures nothing, the
+        re-written entry must be authoritative — one re-fetch total, not one
+        per run forever."""
+        cache_path = tmp_path / "cache.jsonl"
+        inner = _make_inner()
+        valid_key = CachedLLMClient(inner, cache_path)._cache_key("sys", "usr")
+        cache_path.write_text(
+            json.dumps({
+                "key": valid_key, "model": "test-model",
+                "response": "SERVICE", "thinking": "",
+            }) + "\n"
+        )
+
+        _set_return(inner, "SERVICE", "")  # still nothing capturable post-fix
+        cached = CachedLLMClient(inner, cache_path)
+        await cached.complete("sys", "usr", include_thinking=True)
+        cached.flush()
+
+        inner2 = _make_inner()
+        cached2 = CachedLLMClient(inner2, cache_path)
+        response, thinking = await cached2.complete("sys", "usr", include_thinking=True)
+
+        assert response == "SERVICE"
+        assert thinking == ""
+        assert cached2.hits == 1
+        inner2.complete.assert_not_awaited()
+
+    async def test_backfill_content_error_falls_back_to_cached_response(self, tmp_path: Path):
+        """A backfill re-fetch that raises LLMContentError (e.g. the re-decode
+        truncates at the max_tokens budget under the post-#64 guard) must not
+        discard the perfectly usable cached response: return it with thinking
+        "", and remember the failure instead of re-firing a doomed request."""
+        cache_path = tmp_path / "cache.jsonl"
+        inner = _make_inner()
+        valid_key = CachedLLMClient(inner, cache_path)._cache_key("sys", "usr")
+        cache_path.write_text(
+            json.dumps({"key": valid_key, "model": "test-model", "response": "SERVICE"}) + "\n"
+        )
+
+        inner.complete.side_effect = LLMContentError(
+            "LLM test-model answer truncated at the max_tokens budget"
+        )
+        cached = CachedLLMClient(inner, cache_path)
+        response, thinking = await cached.complete("sys", "usr", include_thinking=True)
+
+        assert response == "SERVICE"
+        assert thinking == ""
+        # Same session: the failure is remembered, no second doomed re-fetch
+        await cached.complete("sys", "usr", include_thinking=True)
+        assert inner.complete.await_count == 1
 
 
     async def test_current_entry_with_empty_thinking_is_a_hit(self, tmp_path: Path):

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -294,14 +294,16 @@ class TestCorruptCacheFile:
 
 
     async def test_current_entry_with_empty_thinking_is_a_hit(self, tmp_path: Path):
-        """An entry written by current code with thinking='' (model emitted no
-        <think> block) must be a cache hit under include_thinking=True — not a
-        legacy entry to re-fetch. Otherwise every terse response (NO_STORIES,
-        'NONE' themes) is re-billed on every run and re-appended to disk."""
+        """An entry written by current code with thinking='' (nothing separately
+        capturable: no reasoning field, no <think> block — e.g. a thinking-off
+        run, where the CoT is the response itself) must be a cache hit under
+        include_thinking=True — not a legacy entry to re-fetch. Otherwise every
+        terse response (NO_STORIES, 'NONE' themes) is re-billed on every run
+        and re-appended to disk."""
         cache_path = tmp_path / "cache.jsonl"
 
         inner1 = _make_inner()
-        _set_return(inner1, "NO_STORIES", "")  # legitimately no thinking
+        _set_return(inner1, "NO_STORIES", "")  # nothing separately capturable
         cached1 = CachedLLMClient(inner1, cache_path)
         await cached1.complete("sys", "usr", include_thinking=True)
         cached1.flush()

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -605,9 +605,11 @@ class TestFinishReasonLength:
         assert "max_tokens" in msg
         assert "prompt ~" in msg  # prompt token estimate, not a hardcoded guess
         # Names the field that actually held the reasoning (`reasoning`), not
-        # the hardcoded `reasoning_content` guess.
-        assert "reasoning" in msg
+        # the hardcoded `reasoning_content` guess — and not the absent-field
+        # text, which is what a diagnostics regression would fall back to.
+        assert "reasoning in reasoning" in msg
         assert "reasoning_content" not in msg
+        assert "no reasoning field" not in msg
 
     async def test_length_with_truncated_content_raises_not_parses(self, local_client):
         """finish_reason "length" with NON-empty content is a truncated answer:
@@ -659,7 +661,10 @@ class TestFinishReasonLength:
 
     async def test_empty_content_without_finish_reason_names_absent_reasoning(self, cloud_client):
         """Empty content stays loud even without finish_reason, and the error
-        says no reasoning field was populated rather than guessing one was."""
+        says no reasoning field was populated rather than guessing one was.
+        The reported finish_reason must be the response's REAL (absent) value —
+        this is the case that distinguishes real reporting from a hardcoded
+        'length'."""
         resp = _mock_response(json_data={
             "choices": [{"message": {"role": "assistant", "content": ""}}]
         })
@@ -668,6 +673,7 @@ class TestFinishReasonLength:
         msg = str(exc_info.value)
         assert "no content" in msg
         assert "no reasoning field" in msg
+        assert "finish_reason=None" in msg
 
 
 class TestProbe:
@@ -1166,6 +1172,35 @@ class TestSeparateReasoningFieldCapture:
             )
             assert thinking == ""
             assert "LOW_PRIORITY" in response
+
+    async def test_both_channels_captured_when_model_emits_both(self):
+        """Issue #64 finding: with thinking ON and budget to spare, the model
+        emitted BOTH native reasoning AND <think>-tagged content CoT. Both must
+        land in thinking — the inline block is stripped from the returned
+        content, so capture that takes only the separate field would lose the
+        inline channel entirely (in neither thinking nor label_raw)."""
+        mock_response = _mock_response(json_data={
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "content": "<think>inline channel</think>\nFYI",
+                    "reasoning": "native channel",
+                },
+            }]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            response, thinking = await self._qwen_ollama_client().complete(
+                "sys", "user", include_thinking=True,
+            )
+            assert response == "FYI"
+            assert "native channel" in thinking
+            assert "inline channel" in thinking
 
     async def test_reasoning_effort_none_recognized_as_thinking_disable(self):
         """reasoning_effort="none" (the Ollama disable dialect, now in the

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -571,6 +571,105 @@ class TestContentlessResponse:
                 await glm_client.complete("sys", "user", include_thinking=True)
 
 
+class TestFinishReasonLength:
+    """A finish_reason of "length" must be loud, never silently parsed (issue #64).
+
+    Measured hazard: with thinking off, an over-budget decode returns non-empty
+    but truncated content, cut before any label — parse_email_label would
+    silently default to LOW_PRIORITY (action: ARCHIVE) with only a parse
+    WARNING. And the empty-content variant's old error message hardcoded a
+    guess ("max_tokens likely exhausted; reasoning_content ...") instead of
+    reporting the response's actual finish_reason and which reasoning field was
+    populated (Ollama's is `reasoning`, not `reasoning_content`).
+    """
+
+    async def test_length_with_empty_content_reports_real_diagnostics(self, local_client):
+        """The exact production signature (issue #64): HTTP 200, finish_reason
+        "length", content == "", reasoning in Ollama's `reasoning` field. The
+        error must carry the REAL finish_reason, a prompt-size estimate, and
+        name the actual populated reasoning field."""
+        resp = _mock_response(json_data={
+            "choices": [{
+                "finish_reason": "length",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning": "Step 1: the sender appears to be a colleague...",
+                },
+            }]
+        })
+        with pytest.raises(LLMContentError) as exc_info:
+            await _post_canned(local_client, resp)
+        msg = str(exc_info.value)
+        assert "finish_reason='length'" in msg
+        assert "max_tokens" in msg
+        assert "prompt ~" in msg  # prompt token estimate, not a hardcoded guess
+        # Names the field that actually held the reasoning (`reasoning`), not
+        # the hardcoded `reasoning_content` guess.
+        assert "reasoning" in msg
+        assert "reasoning_content" not in msg
+
+    async def test_length_with_truncated_content_raises_not_parses(self, local_client):
+        """finish_reason "length" with NON-empty content is a truncated answer:
+        it must raise (give-up-eligible), never return for parsing — the
+        truncation lands mid-scaffold before any label, and a parsed default
+        would silently archive person mail."""
+        resp = _mock_response(json_data={
+            "choices": [{
+                "finish_reason": "length",
+                "message": {
+                    "role": "assistant",
+                    "content": "1. Who is this from? The sender appears to be",
+                },
+            }]
+        })
+        with pytest.raises(LLMContentError, match="truncated"):
+            await _post_canned(local_client, resp)
+
+    async def test_length_with_truncated_content_raises_in_include_thinking_mode(self, local_client):
+        """The truncation guard must also cover the include_thinking path (evals)."""
+        resp = _mock_response(json_data={
+            "choices": [{
+                "finish_reason": "length",
+                "message": {"role": "assistant", "content": "1. Who is this"},
+            }]
+        })
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = resp
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(LLMContentError, match="truncated"):
+                await local_client.complete("sys", "user", include_thinking=True)
+
+    async def test_stop_with_content_returns_normally(self, local_client):
+        """A normal completion (finish_reason "stop") is unaffected."""
+        resp = _mock_response(json_data={
+            "choices": [{"finish_reason": "stop", "message": {"content": "FYI"}}]
+        })
+        assert await _post_canned(local_client, resp) == "FYI"
+
+    async def test_missing_finish_reason_with_content_returns_normally(self, local_client):
+        """Responses that omit finish_reason entirely (many mocks, some servers)
+        keep working — absence is not "length"."""
+        resp = _mock_response(json_data={
+            "choices": [{"message": {"content": "NEEDS_RESPONSE"}}]
+        })
+        assert await _post_canned(local_client, resp) == "NEEDS_RESPONSE"
+
+    async def test_empty_content_without_finish_reason_names_absent_reasoning(self, cloud_client):
+        """Empty content stays loud even without finish_reason, and the error
+        says no reasoning field was populated rather than guessing one was."""
+        resp = _mock_response(json_data={
+            "choices": [{"message": {"role": "assistant", "content": ""}}]
+        })
+        with pytest.raises(LLMContentError) as exc_info:
+            await _post_canned(cloud_client, resp)
+        msg = str(exc_info.value)
+        assert "no content" in msg
+        assert "no reasoning field" in msg
+
+
 class TestProbe:
     """probe() carries status detail so preflight can distinguish a 404
     (model-name mismatch) from an unreachable endpoint (issue #41 item 7)."""

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1033,8 +1033,10 @@ class TestGLMReasoningContent:
             assert response == "SERVICE"
             assert "some reasoning" in thinking
 
-    async def test_non_glm_ignores_reasoning_content(self):
-        """Non-GLM models use inline tags even if reasoning_content is present."""
+    async def test_separate_reasoning_field_wins_over_inline_tags_for_non_glm(self):
+        """A populated separate reasoning field is preferred over inline tags for
+        ANY model, not just GLM (issue #64: capture used to be GLM-gated, so
+        Ollama-served local models silently yielded thinking="")."""
         client = LLMClient(
             base_url="https://api.example.com/v1/chat/completions",
             api_key="sk-test",
@@ -1043,7 +1045,7 @@ class TestGLMReasoningContent:
         mock_response = _mock_response(json_data={
             "choices": [{"message": {
                 "content": "<think>inline reasoning</think>\nSERVICE",
-                "reasoning_content": "should be ignored",
+                "reasoning_content": "separate-channel reasoning",
             }}]
         })
 
@@ -1054,9 +1056,8 @@ class TestGLMReasoningContent:
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
             response, thinking = await client.complete("sys", "user", include_thinking=True)
-            assert response == "SERVICE"
-            assert "inline reasoning" in thinking
-            assert "should be ignored" not in thinking
+            assert response == "SERVICE"  # inline tags still stripped from content
+            assert "separate-channel reasoning" in thinking
 
     async def test_glm_empty_reasoning_content_falls_back(self, glm_client):
         """GLM with empty reasoning_content falls back to inline tags."""
@@ -1076,3 +1077,127 @@ class TestGLMReasoningContent:
             response, thinking = await glm_client.complete("sys", "user", include_thinking=True)
             assert response == "SERVICE"
             assert "inline thought" in thinking
+
+
+class TestSeparateReasoningFieldCapture:
+    """include_thinking must read the separate reasoning field for ANY model
+    (issue #64). It was GLM-gated, so under Ollama — which routes Qwen's
+    reasoning to `msg.reasoning`, not `reasoning_content` — every local call
+    returned thinking="" and the eval .cot.jsonl sidecar was silently empty,
+    documented as if the model had emitted no reasoning.
+    """
+
+    def _qwen_ollama_client(self):
+        return LLMClient(
+            base_url="http://ollama.example.com/v1/chat/completions",
+            api_key="",
+            model="qwen3.6:35b-mlx",
+        )
+
+    async def test_ollama_reasoning_field_yields_thinking(self):
+        """The Ollama response shape (reasoning in `msg.reasoning`, bare-prose
+        content) must yield non-empty thinking for a non-GLM model."""
+        mock_response = _mock_response(json_data={
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "1. The sender is a colleague.\n\nFYI",
+                    "reasoning": "Okay, let me work through the three questions...",
+                },
+            }]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            response, thinking = await self._qwen_ollama_client().complete(
+                "sys", "user", include_thinking=True,
+            )
+            assert "FYI" in response
+            assert "three questions" in thinking
+
+    async def test_no_separate_field_falls_back_to_inline_tags(self):
+        """Without a separate field, inline <think> extraction still works
+        (DeepSeek/Qwen served by mlx_lm.server with thinking on)."""
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {
+                "content": "<think>inline path</think>\nLOW_PRIORITY",
+            }}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            response, thinking = await self._qwen_ollama_client().complete(
+                "sys", "user", include_thinking=True,
+            )
+            assert response == "LOW_PRIORITY"
+            assert "inline path" in thinking
+
+    async def test_untagged_content_with_no_reasoning_yields_empty_thinking(self):
+        """Thinking-off Ollama shape: no separate field, no tags — the CoT is
+        the untagged content itself (preserved in the response / label_raw), so
+        thinking is legitimately ""."""
+        mock_response = _mock_response(json_data={
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "1. A vendor.\n2. No action.\n\nLOW_PRIORITY",
+                },
+            }]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            response, thinking = await self._qwen_ollama_client().complete(
+                "sys", "user", include_thinking=True,
+            )
+            assert thinking == ""
+            assert "LOW_PRIORITY" in response
+
+    async def test_reasoning_effort_none_recognized_as_thinking_disable(self):
+        """reasoning_effort="none" (the Ollama disable dialect, now in the
+        shipped local config) must read as thinking-disabled intent — so a GLM
+        client carrying it injects thinking=disabled instead of contradicting
+        it with enabled."""
+        client = LLMClient(
+            base_url="https://api.example.com/v1/chat/completions",
+            api_key="sk-test",
+            model="zai-org/glm-5",
+            extra_body={"reasoning_effort": "none"},
+        )
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {"content": "SERVICE"}}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await client.complete("sys", "user", include_thinking=True)
+
+            body = mock_client.post.call_args.kwargs["json"]
+            assert body["thinking"] == {"type": "disabled"}
+
+    async def test_reasoning_effort_other_values_do_not_read_as_disable(self):
+        """Only "none" disables (Ollama treats "low" as a silent no-op), so only
+        "none" may read as disable intent."""
+        client = LLMClient(
+            base_url="", api_key="", model="qwen3",
+            extra_body={"reasoning_effort": "low"},
+        )
+        assert client._extra_body_disables_thinking() is False

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -675,6 +675,69 @@ class TestFinishReasonLength:
         assert "no reasoning field" in msg
         assert "finish_reason=None" in msg
 
+    async def test_length_with_inline_think_content_names_inline_channel(self, local_client):
+        """When the reasoning that ate the budget sits inline in content as an
+        (unclosed) <think> block — the mlx_lm.server / LM Studio think-on
+        truncation shape, the original #10/#30 failure — the diagnostics must
+        say so instead of claiming "no reasoning field": an operator triaging
+        logs would otherwise conclude the model emitted no reasoning at all."""
+        resp = _mock_response(json_data={
+            "choices": [{
+                "finish_reason": "length",
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>step 1: the sender appears to be... step 2:",
+                },
+            }]
+        })
+        with pytest.raises(LLMContentError) as exc_info:
+            await _post_canned(local_client, resp)
+        msg = str(exc_info.value)
+        assert "inline <think>" in msg
+        assert "no reasoning field" not in msg
+
+
+class TestThinkOnlyResponse:
+    """Non-empty content that strips to NOTHING — a fully-closed think-only
+    response (finish_reason "stop") — is as unusable as no content: returning
+    "" would let parse_email_label default to LOW_PRIORITY and silently archive
+    the email, the exact silent-default shape issue #64 eliminates. Reachable
+    whenever a backend leaves thinking effectively on (e.g. mlx_lm.server
+    ignoring reasoning_effort) and the model closes its think block without an
+    answer."""
+
+    async def test_closed_think_only_content_raises(self, local_client):
+        resp = _mock_response(json_data={
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>the sender is a colleague... FYI probably</think>",
+                },
+            }]
+        })
+        with pytest.raises(LLMContentError, match="only reasoning"):
+            await _post_canned(local_client, resp)
+
+    async def test_closed_think_only_raises_in_include_thinking_mode(self, local_client):
+        """The guard must also cover the include_thinking path (evals)."""
+        resp = _mock_response(json_data={
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>reasoning without an answer</think>",
+                },
+            }]
+        })
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = resp
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(LLMContentError, match="only reasoning"):
+                await local_client.complete("sys", "user", include_thinking=True)
+
 
 class TestProbe:
     """probe() carries status detail so preflight can distinguish a 404
@@ -1039,10 +1102,12 @@ class TestGLMReasoningContent:
             assert response == "SERVICE"
             assert "some reasoning" in thinking
 
-    async def test_separate_reasoning_field_wins_over_inline_tags_for_non_glm(self):
-        """A populated separate reasoning field is preferred over inline tags for
-        ANY model, not just GLM (issue #64: capture used to be GLM-gated, so
-        Ollama-served local models silently yielded thinking="")."""
+    async def test_separate_and_inline_channels_both_captured_for_non_glm(self):
+        """A populated separate reasoning field is read for ANY model, not just
+        GLM (issue #64: capture used to be GLM-gated, so Ollama-served local
+        models silently yielded thinking=""). Nothing "wins": the inline
+        channel is captured alongside it — the inline block is stripped from
+        the returned content, so dropping it here would lose it entirely."""
         client = LLMClient(
             base_url="https://api.example.com/v1/chat/completions",
             api_key="sk-test",
@@ -1064,6 +1129,7 @@ class TestGLMReasoningContent:
             response, thinking = await client.complete("sys", "user", include_thinking=True)
             assert response == "SERVICE"  # inline tags still stripped from content
             assert "separate-channel reasoning" in thinking
+            assert "inline reasoning" in thinking
 
     async def test_glm_empty_reasoning_content_falls_back(self, glm_client):
         """GLM with empty reasoning_content falls back to inline tags."""
@@ -1236,3 +1302,98 @@ class TestSeparateReasoningFieldCapture:
             extra_body={"reasoning_effort": "low"},
         )
         assert client._extra_body_disables_thinking() is False
+
+    async def test_reasoning_effort_none_recognized_case_insensitively(self):
+        """A hand-edited config or --extra-body JSON may spell it "None"/"NONE";
+        case must not silently flip a think-off A/B arm back to thinking-on."""
+        client = LLMClient(
+            base_url="https://api.example.com/v1/chat/completions",
+            api_key="sk-test",
+            model="zai-org/glm-5",
+            extra_body={"reasoning_effort": "None"},
+        )
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {"content": "SERVICE"}}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await client.complete("sys", "user", include_thinking=True)
+
+            body = mock_client.post.call_args.kwargs["json"]
+            assert body["thinking"] == {"type": "disabled"}
+
+    async def test_non_string_reasoning_field_is_ignored(self):
+        """A backend/proxy may surface the reasoning channel as structured data
+        (e.g. an OpenRouter-style list of reasoning blocks). Non-string values
+        must not crash the thinking join — fall back to the inline channel, as
+        the old GLM-gated code did for fields it didn't read."""
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {
+                "content": "<think>inline fallback</think>\nFYI",
+                "reasoning": [{"type": "reasoning.text", "text": "structured"}],
+            }}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            response, thinking = await self._qwen_ollama_client().complete(
+                "sys", "user", include_thinking=True,
+            )
+            assert response == "FYI"
+            assert thinking == "inline fallback"
+
+    async def test_both_separate_fields_captured_when_populated(self):
+        """Some proxies populate BOTH reasoning_content and reasoning — the
+        error-path diagnostics already treat them as simultaneously reportable.
+        Neither channel may be silently dropped from the sidecar."""
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {
+                "content": "FYI",
+                "reasoning_content": "CHANNEL_A",
+                "reasoning": "CHANNEL_B",
+            }}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            response, thinking = await self._qwen_ollama_client().complete(
+                "sys", "user", include_thinking=True,
+            )
+            assert response == "FYI"
+            assert "CHANNEL_A" in thinking
+            assert "CHANNEL_B" in thinking
+
+    async def test_mirrored_separate_fields_not_duplicated(self):
+        """A proxy that mirrors the same text into both separate fields must
+        not double it in the captured thinking."""
+        mock_response = _mock_response(json_data={
+            "choices": [{"message": {
+                "content": "FYI",
+                "reasoning_content": "SAME TEXT",
+                "reasoning": "SAME TEXT",
+            }}]
+        })
+
+        with patch("llm_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            _, thinking = await self._qwen_ollama_client().complete(
+                "sys", "user", include_thinking=True,
+            )
+            assert thinking == "SAME TEXT"


### PR DESCRIPTION
Implements the fixes for #64, built directly on the live-probe evidence record ([2026-07-30 comment](https://github.com/brianroberg/email-labeler/issues/64#issuecomment-5125786210)). Every behavior change went red→green; after-the-fact test strengthenings were mutation-proved (break the code, watch the test fail, revert).

## The blocking bug (config-only fix)

`chat_template_kwargs.enable_thinking = false` is inert on Ollama, so native thinking was ON in production: hard person threads burned all 1024 tokens in the reasoning channel, returned empty content, took 5 strikes, and were dropped to `agent/attempted` — silently excluded from the poll query forever.

- **`[llm.local.extra_body]` gains `reasoning_effort = "none"`** — the one field Ollama (verified on 0.32.5) honors on its OpenAI-compat endpoint. Only `"none"` disables; `"low"` is a silent no-op. The `chat_template_kwargs` block stays for mlx_lm.server / LM Studio portability, with the comment rewritten to say which backend honors which dialect (it previously asserted the inert form works).
- **`[llm.local]` `max_tokens` 1024 → 4096.** Coupled to the disable, not independent tuning: with thinking off the model still emits the prompt's full scaffold as untagged content (observed demand up to ~1,300 tokens), and an over-budget decode used to truncate *silently* (see next section). Measured floor is >1,293; 4096 is the recommended margin. Config-as-data tests lock both settings.

## `finish_reason: "length"` is now loud

`complete()` never read `finish_reason`. Demonstrated hazard: with thinking off at a small budget, a truncated response parses to the default LOW_PRIORITY → the email is **archived silently**, with only a parse WARNING. Now any `"length"` finish raises `LLMContentError`, and the diagnostics report the response's real `finish_reason`, a prompt-size estimate, and which reasoning field was actually populated (Ollama's is `reasoning`, not the previously hardcoded `reasoning_content` guess).

**Design tradeoff flagged for review:** `length` + *non-empty* content also raises, even if a label happens to sit in the truncated text. The weaker alternative — parse, raise only when no label found — trusts an answer whose reasoning was cut mid-stream; measurement showed the cut usually lands before the label, so this errs loud. Give-up routing is unchanged (`LLMContentError` is still a `RuntimeError`).

**Consequence for the newsletter tier:** the raise applies to every tier, and `story_extraction` re-emits the full text of every story, so at 1024 a long newsletter would have become a deterministic give-up instead of the old silent mid-story truncation. `[newsletter.llm]` `max_tokens` therefore goes 1024 → 4096 — sized by #64 Fix 4's reasoning, **not** by measurement (that tier was never probed; the config comment says so).

## Eval CoT capture + no-think flags

- `complete(include_thinking=True)` read the separate reasoning field only for GLM models. Ollama routes Qwen's reasoning to `message.reasoning`, so every local call yielded `thinking=""` and the `.cot.jsonl` sidecar looked like the model never reasoned. The separate field is now read for **any** model, and inline `<think>` blocks are captured *in addition* (probes showed both channels populated at once under thinking-on with headroom; the inline block is stripped from content, so fallback-only capture would lose it).
- `--local-no-think` / `--cloud-no-think` emitted only the `chat_template_kwargs` form — inert on Ollama, so an A/B on that backend compared think-on to think-on. They now emit both dialects, `--no-think` provably *overrides* a base-config `reasoning_effort`, and the cloud flag's wiring is pinned by its own test (disconnecting it used to pass the whole suite).
- Docs no longer describe `""` in the sidecar as "the model emitted no `<think>` block": under thinking-off the reasoning is the untagged content itself, preserved in `label_raw` — which is what #14's investigation should read.

## Deliberate non-changes

- **Cloud thinking stays enabled.** glm-5 emits no in-content CoT, so disabling native thinking removes *all* of its reasoning — and a probe showed the disable changes labels. Eval-gated on #13; the config comment documents the asymmetry with the local tier.
- **Cloud `max_tokens` stays 1024.** Probes showed 2–5x headroom, and a squeeze now fails loudly (`LLMContentError` naming the model) instead of needing a preemptive bump — watch the logs.

## Deployment + recovery

⚠️ `config.toml` is **baked into the image at build time** — nothing here is live until the image is rebuilt and the daemon restarted (it is currently stopped on purpose). Threads already dropped by the bug carry `agent/attempted` as their only durable trace; `docs/runbook-agent-attempted-recovery.md` (new) covers the sweep: the unrelated populations sharing the label, why enumerating is cleanest *before* the first post-#65 deploy, and the `in:inbox` + label-removal re-queue conditions.

Verification: full suite green (1282 tests + 110 subtests), ruff clean. An adversarial multi-agent review of the diff ran before this PR; its confirmed findings (stale present-tense comments, the newsletter budget interaction, two-channel capture, four surviving test mutations, a runbook gap) are all fixed in the final commit.

Fixes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t96psce4etuLwTmyicUy4

---
_Generated by [Claude Code](https://claude.ai/code/session_016t96psce4etuLwTmyicUy4)_