### PR TITLE
Wave 1: Enforcement — D2 privacy negative-form tests, D13 CI, #67 fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.14"
+      - run: uv sync --locked --extra dev
+      - run: uv run --extra dev ruff check .
+      - run: uv run --extra dev pytest tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,21 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        # UTC plus both timezone extremes: the suite's timezone honesty
+        # (issue #67) is enforced on every run, not spot-checked manually.
+        tz: ["UTC", "Pacific/Pago_Pago", "Pacific/Kiritimati"]
+    env:
+      TZ: ${{ matrix.tz }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/README-technical.md
+++ b/README-technical.md
@@ -424,6 +424,8 @@ Conventions shared by every TUI:
 | `test_daemon.py` | `daemon.py` | Service email path, person email path, MLX-unavailable skip, error isolation, out-of-funds halt, config loading, assessment-sink preflight + write-before-label durability |
 | `test_privacy.py` | `classifier.py`, `daemon.py` | Negative-form privacy tests (registry D2/D3): person-classified bodies reach only the local tier (classifier and daemon level), Stage 1 whole-call payload discipline, unparseable-Stage-1 SERVICE-default pin, VIP short-circuit, newsletter ownership bypass, no cloud fallback on local failure, metadata-shape allowlist |
 | `test_config_utils.py` | `config_utils.py` | Config loading, `{env.VAR}` substitution |
+| `test_env_var_docs.py` | env-var docs (meta-test) | Every env var referenced by daemon sources or `config.toml` `{env.VAR}` is documented in this file's Environment Variables table |
+| `test_env_example_docs.py` | `.env.example` (meta-test) | Every var the example declares is documented in the env table; every Required var has an active line in the example |
 | `test_newsletter.py` | `newsletter.py` | Newsletter story extraction, quality scoring, theme classification, assessment record writing, sink persistence/writability diagnostics |
 | `test_eval_schemas.py` | `evals/schemas.py` | GoldenThread/PredictionResult/RunMeta serialization round-trips |
 | `test_eval_harvest.py` | `evals/harvest.py` | Ground truth inference from labels, deduplication |

--- a/README-technical.md
+++ b/README-technical.md
@@ -422,6 +422,7 @@ Conventions shared by every TUI:
 | `test_classifier.py` | `classifier.py` | `parse_sender` formats, `parse_sender_type` edge cases and defaults, `parse_email_label` edge cases and defaults, cloud/local routing, full pipeline |
 | `test_labeler.py` | `labeler.py` | Label verification (all present, partial, none), label ID mapping, inbox/archive actions, single API call per email |
 | `test_daemon.py` | `daemon.py` | Service email path, person email path, MLX-unavailable skip, error isolation, out-of-funds halt, config loading, assessment-sink preflight + write-before-label durability |
+| `test_privacy.py` | `classifier.py`, `daemon.py` | Negative-form privacy tests (registry D2/D3): person-classified bodies reach only the local tier (classifier and daemon level), Stage 1 whole-call payload discipline, unparseable-Stage-1 SERVICE-default pin, VIP short-circuit, newsletter ownership bypass, no cloud fallback on local failure, metadata-shape allowlist |
 | `test_config_utils.py` | `config_utils.py` | Config loading, `{env.VAR}` substitution |
 | `test_newsletter.py` | `newsletter.py` | Newsletter story extraction, quality scoring, theme classification, assessment record writing, sink persistence/writability diagnostics |
 | `test_eval_schemas.py` | `evals/schemas.py` | GoldenThread/PredictionResult/RunMeta serialization round-trips |

--- a/README-technical.md
+++ b/README-technical.md
@@ -435,3 +435,9 @@ Conventions shared by every TUI:
 | `test_eval_newsletter_report.py` | `evals/newsletter_report.py` | `match_stories`, tier/dimension/theme metrics, comparison deltas |
 | `test_newsletter_review.py` | `newsletter_review/tui.py` | Pure helpers (loading, per-thread dedup, filtering, formatting, source line, migrated-record note) + Pilot UI tests (navigation, drill-down, tier/theme/sender filters, source header, quit) |
 | `test_migrate_assessments.py` | `scripts/migrate_assessments.py` | Old-scheme detection, theme/score conversion, tier preservation, atomic in-place rewrite + abort-on-malformed, round-trip through `load_assessments` |
+
+## Continuous Integration
+
+GitHub Actions (`.github/workflows/ci.yml`, authoritative) runs dependency
+sync, lint, and the full mocked suite on every PR and push to main; no
+secrets are required (registry D13).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -180,7 +180,7 @@ so the next schema evolution is a version bump + migration, not shape-sniffing.
 
 ## D13 — Adopt CI (2026-07-30)
 
-**Status:** implementation pending (Wave 1).
+**Status:** implemented (Wave 1).
 
 A minimal GitHub Actions workflow (uv sync, pytest, ruff) on PRs and pushes to
 main. The suite is fully mocked; no secrets. Its absence was not deliberate.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -31,7 +31,7 @@ fixes that assume one function's values govern the other.
 
 ## D2 — Privacy posture: best-effort routing, stated honestly (2026-07-30)
 
-**Status:** implemented (docs, Wave 0); test enforcement pending (Wave 1).
+**Status:** implemented (docs, Wave 0; test enforcement, Wave 1).
 
 The email-triage privacy guarantee is: **bodies of threads classified as
 person are processed only by the local LLM**. This is best-effort routing, not

--- a/docs/plans/2026-07-30-wave1-enforcement.md
+++ b/docs/plans/2026-07-30-wave1-enforcement.md
@@ -309,3 +309,29 @@ incidental assertion; same reordering in the newsletter test for M6.
 
 CI evidence: recorded on the PR (pull_request run) and on main after merge
 (push run) — see the PR thread.
+
+### Post-execution review corrections (2026-07-30, xhigh review of PR #69)
+
+- **The P5 baseline and "green in every timezone" claims overstated.** They
+  held for the three zones P5 names, but three further tests in
+  tests/test_newsletter_review.py pinned UTC-morning instants and failed at
+  or west of UTC-10 (verified under `TZ=Pacific/Honolulu`; main under
+  `TZ=Pacific/Pago_Pago` had four west-of-UTC failures, not one). Fixed in
+  the review-fix commit with the same local-midday approach (shared
+  `_local_midday_utc_iso` helper), and CI now runs a three-zone TZ matrix
+  (UTC / Pacific/Pago_Pago / Pacific/Kiritimati) so the property is enforced
+  by the gate rather than spot-checked at acceptance.
+- **T2-table deviation not previously recorded:** the table says the
+  local-failure test's mock raises `httpx.ConnectError`; the shipped test
+  raises `LLMUnavailableError` (now with `tier="local"`, so it pins the
+  daemon's local-tier arm specifically).
+- **Review hardening applied in the same commit:** spec'd LLM mocks
+  (`AsyncMock(spec=LLMClient)`) with an all-method `mock_calls` leak sweep
+  and `mock_calls == []` zero-call pins; Stage 1 positional-arity pin
+  (`len(call.args) == 2`); a third fixture sender making the Stage 1
+  short-circuit observable (`call_count == 2`); env-guard regexes unified on
+  `[A-Z0-9_]+` with whitespace-tolerant prefixes/cells and direction (a)
+  parsing actual table rows; shared daemon fixtures promoted to
+  tests/conftest.py; env-section helper imported from test_env_var_docs; CI
+  concurrency group. Re-proof mutations for the changed assertions recorded
+  in the review-fix commit message.

--- a/docs/plans/2026-07-30-wave1-enforcement.md
+++ b/docs/plans/2026-07-30-wave1-enforcement.md
@@ -1,6 +1,7 @@
 # Wave 1 — Enforcement (privacy negative-form tests, CI, #67)
 
-> **Status: proposed 2026-07-30** (awaiting owner review; not executed).
+> **Status: executed 2026-07-30** (owner-approved with T4 included; see the
+> Execution record at the end for the mutation log).
 > Drafted after the Wave 0.5 issue triage; #67 is absorbed into this wave per
 > the triage disposition on issue #68.
 
@@ -276,3 +277,35 @@ the rest of the meta-test backfill stays with Wave 3.
    (home of the mutation log and any accepted deviations, per the Wave 0
    precedent) and flip this plan's status header `proposed → executed`
    (D8).
+
+## Execution record (2026-07-30)
+
+Executed T1–T4 in order (T4 included by owner decision), one commit each,
+full suite + ruff green after every task. Tri-timezone acceptance
+(`TZ=UTC` / `America/New_York` / `Asia/Tokyo`): 1302 passed + 123 subtests
+in each. `git diff main -- '*.py'` touches only `tests/` (P1 held).
+
+Mutation log (each applied transiently, observed red, reverted — the
+production tree was verified clean after the pass):
+
+| Mutation | Applied | Red observed on |
+|---|---|---|
+| M1 tier expression → always cloud | classifier.py `classify_email` | `test_person_thread_body_reaches_only_local_llm` (+ 3 route-dependent siblings) |
+| M2 snippet → full transcript | daemon.py metadata build | `test_person_thread_end_to_end_daemon` (whole-call equality) + local-failure leak sweep |
+| M3 tier expression → always local | classifier.py `classify_email` | both `TestServiceRouting` tests |
+| M4 unparseable default → PERSON | classifier.py `parse_sender_type` | `test_unparseable_stage1_defaults_to_service_route` |
+| M5 VIP short-circuit disabled | classifier.py `classify_sender` | `test_vip_sender_skips_cloud_entirely` |
+| M6 newsletter branch forced False | daemon.py newsletter check | `test_newsletter_thread_bypasses_stage1_and_local` (on the cloud-count assertion) |
+| M7a `body` field on ThreadMetadata | classifier.py | `test_metadata_shapes_cannot_carry_bodies` |
+| M7b `body` field on EmailMetadata | classifier.py | `test_metadata_shapes_cannot_carry_bodies` (other arm) |
+| M8 cloud fallback on local failure | classifier.py `classify_email` | `test_person_thread_local_failure_never_falls_back_to_cloud` (on the leak sweep) |
+| M9 bogus var in .env.example | .env.example | `test_env_example_vars_are_documented` (subtest `NOT_A_REAL_VAR`) |
+| M10 `PROXY_API_KEY` commented out | .env.example | `test_required_vars_present_and_active` (subtest `PROXY_API_KEY`) |
+
+Accepted implementation refinements (within plan scope): the local-failure
+test's leak assertion is ordered before the result assertion (and its cloud
+mock carries a spare tuple) so M8's red lands on the leak sweep, not on an
+incidental assertion; same reordering in the newsletter test for M6.
+
+CI evidence: recorded on the PR (pull_request run) and on main after merge
+(push run) — see the PR thread.

--- a/docs/plans/2026-07-30-wave1-enforcement.md
+++ b/docs/plans/2026-07-30-wave1-enforcement.md
@@ -1,0 +1,278 @@
+# Wave 1 — Enforcement (privacy negative-form tests, CI, #67)
+
+> **Status: proposed 2026-07-30** (awaiting owner review; not executed).
+> Drafted after the Wave 0.5 issue triage; #67 is absorbed into this wave per
+> the triage disposition on issue #68.
+
+Third step of the 2026-07-30 clarity effort, after Wave 0 (docs foundation,
+executed) and Wave 0.5 (issue triage, executed). Wave 1 adds **enforcement
+only**: the D2 privacy negative-form tests, the D13 CI gate, and the #67
+timezone fix the CI gate depends on for honesty. Behavior changes wait for
+Wave 2; the findings-catalog sweep for Wave 3.
+
+## Goal
+
+Make the guarantees the docs now state mechanically enforceable:
+
+1. **D2, tested.** The privacy posture — bodies of threads *classified as*
+   person are processed only by the local LLM; before routing, the cloud sees
+   only sender/subject/snippet — gets negative-form tests that fail if any
+   change widens what the cloud receives, plus a shape guard so the metadata
+   objects cannot quietly grow a body-carrying field.
+2. **D13, running.** Every PR and push to main runs lint plus the full mocked
+   suite — on a suite that is green in every timezone (#67), so a green
+   check on a UTC runner means the same thing on the owner's EDT machine.
+
+## Principles (binding on every task below)
+
+- **P1 — No production behavior changes.** No production `.py` is edited; the
+  only source edits are under `tests/`. `config.toml` is untouched. Mutations
+  used to prove tests are transient: applied, observed red, reverted, never
+  committed.
+- **P2 — After-the-fact tests are mutation-proven.** Every T2/T4 test targets
+  code that already exists, so per CLAUDE.md's testing rules each is proven
+  by a named mutation (matrix in T2/T4); the observed red runs are recorded
+  in the execution record.
+- **P3 — Honest phrasing.** Test names and docstrings state the D2 guarantee
+  in its best-effort form ("classified as person", "nothing beyond
+  sender/subject/snippet") — never the absolute form D2 forecloses. The
+  snippet is Gmail's body-derived preview of the latest message
+  (daemon.py:520), so no test asserts "no body text reaches the cloud"; the
+  assertions are scoped to text beyond the three metadata fields.
+- **P4 — One commit per task**, in task order; suite run after every task.
+- **P5 — Timezone honesty.** At T1 and at acceptance, the suite must be fully
+  green under `TZ=UTC`, `TZ=America/New_York`, and `TZ=Asia/Tokyo`
+  (single-TZ runs suffice in between). Baseline before T1: exactly one known
+  failure west of UTC — issue #67's test.
+- **P6 — Registry statuses flip in the implementing commit** (D2's in T2's
+  commit, D13's in T3's), per the Review Charter's same-change rule.
+
+## Task list
+
+| # | Task | Files touched |
+|---|---|---|
+| T1 | #67: timezone-proof the review-TUI date fixture | `tests/test_newsletter_review.py` |
+| T2 | D2 privacy negative-form tests + metadata-shape guard | `tests/test_privacy.py` (new), `README-technical.md` (coverage row), `docs/decisions.md` (D2 status) |
+| T3 | D13 CI workflow | `.github/workflows/ci.yml` (new), `README-technical.md` (CI note), `docs/decisions.md` (D13 status) |
+| T4 | `.env.example` ↔ env-table sync guard *(optional — strike in review if unwanted)* | `tests/test_env_example_docs.py` (new), `README-technical.md` (coverage row) |
+| T5 | Acceptance | — |
+
+---
+
+## T1 — #67: timezone-proof `_dated_records`
+
+The production behavior is intentional (`_local_date`,
+newsletter_review/tui.py:115, renders the viewer's local date); the fixture
+defeats it by pinning UTC-midnight instants and asserting the UTC date
+string. Fix the fixture, not the code and not the clock — issue #67's own
+analysis, adopted verbatim: replace the module-level `_dated_records()`
+helper (tests/test_newsletter_review.py:1031-1037) with local-midday instants
+converted to UTC:
+
+```python
+def _dated_records():
+    """Records with distinct fixed send-dates (all in 2024) for sort/date tests.
+
+    Instants are local midday converted to UTC; rendering converts back in
+    the same process timezone, an identity round-trip, so each record shows
+    the authored local date in every timezone (issue #67). Midday also keeps
+    the UTC calendar date within a day of the authored date, clear of the
+    date filter's mid-month cutoffs.
+    """
+    def utc_iso(y, m, d):
+        return datetime(y, m, d, 12, 0).astimezone(timezone.utc).isoformat()
+    return [
+        _make_record(subject="Jan", send_date=utc_iso(2024, 1, 10)),
+        _make_record(subject="Mar", send_date=utc_iso(2024, 3, 10)),
+        _make_record(subject="Feb", send_date=utc_iso(2024, 2, 10)),
+    ]
+```
+
+Constraints, from the issue and verified against current code:
+
+- **Do not** assert via `_local_date(...)` (re-implements the code under
+  test) and **do not** pin `TZ=UTC` (hides the west-of-UTC rendering path;
+  the file's `_use_tz` helper at :29-44 stays for the tests that genuinely
+  test TZ behavior). GitHub runners are UTC — pinning would make CI
+  permanently blind to exactly the class of bug this is.
+- `TestReviewAppDateFilter` shares the fixture (call sites :1054, :1063,
+  :1075, :1082, :1091); its mid-month cutoffs stay correct under midday
+  instants — by construction now, not by luck.
+- `datetime`/`timezone` are already imported (line 8); no new imports.
+
+**Proof (red/green on the fixture):** before the change,
+`TZ=America/New_York uv run --extra dev pytest tests/test_newsletter_review.py`
+fails exactly `test_default_sort_by_send_date_desc`; after it, the full suite
+is green under all three P5 timezones. On merge, close #67 citing this
+commit.
+
+## T2 — `tests/test_privacy.py`: D2 negative-form tests
+
+New module; docstring cites D2/D3 and states the guarantee in best-effort
+form. Uses the existing patterns only — no new test infrastructure:
+`AsyncMock` LLM clients injected into a **real** `EmailClassifier`
+(constructor DI as in tests/test_classifier.py:281-288), payload inspection
+via `complete.call_args` / `call_args_list` (idiom:
+test_classifier.py:299-301), and for the daemon-level tests the
+`process_single_thread` invocation shape of tests/test_daemon.py:167-176
+with thread dicts authored locally in the module, shaped like
+test_daemon.py's `mock_thread_response` fixture (:77-118) — conftest's
+fixtures are single-message resources, not thread payloads.
+
+**Mock contract.** Every `complete(...)` call is made with
+`include_thinking=True` and unpacked as a `(text, cot)` tuple
+(classifier.py:246-249, 263-265, 299), so **both** LLM mocks get an explicit
+2-tuple `return_value` (or `side_effect`) in **every** test — including the
+mock a test expects never to be called — so that a mutation's red lands on
+the named assertion, not on a tuple-unpack `ValueError` from an unconfigured
+`AsyncMock`.
+
+**Sentinel discipline.** Fixture bodies carry **two** distinctive markers:
+one within the first ~100 characters (catches truncated leaks, e.g. a future
+`body[:200]` interpolation) and one after several hundred characters of
+filler (catches anything a snippet-sized prefix would miss). The fixture's
+`snippet` field is a separate distinctive string containing neither marker —
+in tests we author the thread dict, so the snippet is whatever we set; the
+filler mirrors real Gmail, where a snippet is a short body prefix. "Leaked"
+means: either marker present in any argument or kwarg of any
+`cloud_llm.complete(...)` call.
+
+Tests and the mutation each is proven by (every mutation is applied
+transiently, the named test observed red, then reverted — P1/P2):
+
+| Test | Asserts | Proven by mutation |
+|---|---|---|
+| `test_person_thread_body_reaches_only_local_llm` (classifier-level) | Stage 1 cloud mock returns `PERSON`; `classify()` sends the marker to `local_llm.complete` and to no `cloud_llm.complete` call | **M1**: classifier.py:284 — make the tier expression always pick `self.cloud_llm` |
+| `test_person_thread_end_to_end_daemon` (daemon-level; the load-bearing one) | real `EmailClassifier` + AsyncMock LLMs through `process_single_thread`: markers in the local payload; absent from every cloud payload; each Stage 1 cloud call is checked by **whole-call equality** — `args[0]` equals the injected config's `sender_classification.system` string, `args[1]` equals the rendered `user_template`, kwargs exactly `{"include_thinking": True}` | **M2**: daemon.py:520-527 — pass the full transcript as `snippet` when building `ThreadMetadata` (hoist the daemon.py:530 `format_thread_transcript` call above the metadata build for the transient mutation; also caught: **M1**) |
+| `test_service_thread_body_goes_to_cloud_and_local_unused` | Stage 1 returns `SERVICE` → marker in cloud Stage 2a payload, `local_llm.complete` never called (pins the tier split's other arm — and documents, honestly, that service bodies go to the cloud) | **M3**: classifier.py:284 — always pick `self.local_llm` |
+| `test_unparseable_stage1_defaults_to_service_route` | Stage 1 returns keywordless prose → routed to cloud Stage 2a. Docstring pins the adjudicated D2 default: availability first; do **not** "fix" to PERSON | **M4**: classifier.py:110-111 — default to `PERSON` |
+| `test_vip_sender_skips_cloud_entirely` | sender in `VIP_SENDERS` → `cloud_llm.complete` never called at all; marker only in local payload | **M5**: classifier.py:239-240/252-253 — disable the VIP short-circuit |
+| `test_newsletter_thread_bypasses_stage1_and_local` (daemon-level) | thread whose To **exactly equals** the configured recipient → newsletter classifier receives the transcript (cloud by design, D3); the email classifier and `local_llm` are never invoked. Fixture uses an exact-match address so the test survives Wave 2's D3 exact-match change unchanged | **M6**: daemon.py:408-409 — force the newsletter branch **False** so the newsletter thread falls through to the email pipeline |
+| `test_person_thread_local_failure_never_falls_back_to_cloud` (daemon-level) | Stage 1 returns `PERSON`, then the local mock raises `httpx.ConnectError` → neither marker in any `cloud_llm.complete` call, and no labels applied (the failure defers per today's behavior). Pins the most plausible D2 regression: a well-meaning "resilience" fallback that routes person bodies to the cloud when the local tier is down | **M8**: classifier.py:284 area / daemon.py:537-542 — transiently wrap the local call in try/except that retries via `self.cloud_llm` |
+| `test_metadata_shapes_cannot_carry_bodies` | `dataclasses.fields` name-sets are exactly `{thread_id, senders, subject, snippet}` (`ThreadMetadata`, classifier.py:39-46) and `{message_id, sender, subject, snippet}` (`EmailMetadata`, classifier.py:31-36). Docstring: body text travels only as the explicit `body` argument (classifier.py:273/309); growing these classes is a privacy-review event, and a body-carrying field is foreclosed (D2) | **M7a**: add `body: str = ""` to `ThreadMetadata`; **M7b**: same on `EmailMetadata` (each arm proven separately) |
+
+Notes binding the implementation:
+
+- The Stage 1 assertion in the end-to-end test is a *whole-call equality*
+  check — system string, rendered `user_template`, and kwargs — for each
+  unique sender, not a substring blacklist, so a widening of the Stage 1
+  payload in any slot fails it, not just one carrying our sentinels. The
+  templates are rendered from **the config injected into the classifier
+  under test** (the DI fixture pattern carries its own copy);
+  config.toml:116-118 is cited as the production home of that template, not
+  as the test's data source.
+- The multi-sender loop (classifier.py:258-268) is covered by giving the
+  end-to-end fixture two senders: assert one Stage 1 cloud call per sender
+  until the first `PERSON` (short-circuit), each metadata-only.
+- No test asserts anything about the *content* of `snippet` reaching the
+  cloud (P3 — it is body-derived by design), and no test touches the
+  newsletter transcript's cloud path except to pin that it *is* the cloud
+  path (D3 forecloses privacy findings there).
+- Same commit: add the `tests/test_privacy.py` row to README-technical's
+  "Test Coverage by Module" table, and flip D2's status to
+  `implemented (docs, Wave 0; test enforcement, Wave 1)` (P6).
+
+## T3 — `.github/workflows/ci.yml`: the D13 gate
+
+Create with exactly this content (action versions confirmed current at
+execution time; bump majors then if needed):
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.14"
+      - run: uv sync --locked --extra dev
+      - run: uv run --extra dev ruff check .
+      - run: uv run --extra dev pytest tests/
+```
+
+Rationale (kept here, not restated elsewhere — the workflow file plus this
+plan section is the record):
+
+- Triggers per D13 and observed history: PRs *and* direct pushes to main
+  (Wave 0 merged to main without a PR; both routes must gate).
+- `--locked` strengthens D13's `uv sync`: CI fails if `uv.lock` is stale
+  rather than silently re-resolving — the Dockerfile's `--frozen`
+  no-silent-re-resolution discipline, plus a staleness check. Python pinned
+  to 3.14 matching `requires-python >= 3.14` (pyproject.toml:5) and the
+  Dockerfile's `python:3.14-slim`.
+- The suite is fully mocked and offline (1292 tests + 110 subtests, ~1 min
+  local); no secrets, no `.env` (gitignored and absent in CI; the
+  import-time `load_dotenv()` calls are no-ops there). `permissions:
+  contents: read` is least-privilege.
+- **No `TZ` pinning** — T1 made the suite timezone-honest; pinning UTC would
+  reintroduce the blindness #67 exposed.
+- Meta-test check (from recon): nothing parses YAML; `.github/` contains no
+  `.py`, so `test_tui_docs`'s rglob finds nothing; `test_env_var_docs` scans
+  root-level `.py` only. Adding the workflow file trips no test.
+
+Same commit: a new two-line `## Continuous Integration` section in
+README-technical (operational reference, D7), as a pointer, not a
+restatement: "GitHub Actions (`.github/workflows/ci.yml`, authoritative)
+runs dependency sync, lint, and the full mocked suite on every PR and push
+to main; no secrets are required." Flip D13's status to
+`implemented (Wave 1)` (P6).
+
+## T4 — `.env.example` sync guard *(optional)*
+
+Wave 0 T4 noted `.env.example` is guarded by nothing; the roadmap carries it
+as an optional Wave 1 candidate. Smallest useful guard, mirroring
+tests/test_env_var_docs.py's style — new `tests/test_env_example_docs.py`:
+
+- Parse `.env.example` lines matching `^#? ?([A-Z_]+)=`.
+- **(a)** Every parsed var must appear in README-technical's
+  "## Environment Variables" table (catches a stale or misspelled example).
+- **(b)** Every var that table marks Required (today: `PROXY_API_KEY`,
+  `CLOUD_LLM_URL`, `CLOUD_LLM_API_KEY`) must appear as an **active**
+  (uncommented) line in `.env.example` (catches the example losing a var the
+  daemon won't start without).
+
+Deliberately *not* asserted: that every optional/override knob appears in
+`.env.example` — whether the override knobs (`LOCAL_PARALLEL`,
+`MAX_EMAILS_PER_CYCLE`, …) belong in the example is an owner call this wave
+does not make.
+
+**Proof:** **M9** — add a bogus `NOT_A_REAL_VAR=x` line to `.env.example` →
+(a) red; **M10** — comment out the `PROXY_API_KEY=` line → (b) red; revert
+both. Same commit: add coverage-table rows for **both** env-doc guards
+(`test_env_var_docs.py`, today absent from the table, and the new
+`test_env_example_docs.py`) so the table is not selectively inconsistent —
+the rest of the meta-test backfill stays with Wave 3.
+
+## T5 — Acceptance
+
+1. Full suite green under all three P5 timezones; `ruff check .` clean.
+2. Mutation log complete in the execution record: M1–M8 including both M7
+   arms (and M9–M10 if T4 kept), each showing the named test red on the
+   named assertion, then reverted to green.
+3. `git diff main -- '*.py'` shows changes only under `tests/`  (P1).
+4. Push the branch, open the PR: the `pull_request` trigger runs and is
+   green — the workflow's first live run *is* the acceptance evidence for
+   T3. After merge, confirm one green `push` run on main.
+5. Registry coherent: D2 and D13 statuses flipped (P6); no other entry
+   touched. Close #67 (citing T1's commit) and comment on #68 that Wave 1 is
+   executed.
+6. Scope check against the roadmap: Wave 1 owes nothing else — D3
+   exact-match, D5 corollaries, D6, D10–D12 are Wave 2; the docstring/
+   altitude sweep is Wave 3. The #67-absorption and the optional
+   `.env.example` guard are the only triage-fed additions.
+7. In the final commit: append an **Execution record** section to this plan
+   (home of the mutation log and any accepted deviations, per the Wave 0
+   precedent) and flip this plan's status header `proposed → executed`
+   (D8).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,33 @@
 """Shared fixtures and sample Gmail data for tests."""
 
+import asyncio
 import base64
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+
+@pytest.fixture
+def mock_proxy():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_label_manager():
+    mgr = AsyncMock()
+    # get_existing_priority is synchronous — use MagicMock so it returns a value, not a coroutine
+    mgr.get_existing_priority = MagicMock(return_value=None)
+    return mgr
+
+
+@pytest.fixture
+def cloud_sem():
+    return asyncio.Semaphore(2)
+
+
+@pytest.fixture
+def local_sem():
+    return asyncio.Semaphore(1)
 
 
 @pytest.fixture

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -38,11 +38,6 @@ from proxy_client import ProxyAuthError, ProxyError, ProxyUnavailableError
 
 
 @pytest.fixture
-def mock_proxy():
-    return AsyncMock()
-
-
-@pytest.fixture
 def mock_classifier():
     classifier = AsyncMock()
     classifier.classify.return_value = ClassificationResult(
@@ -53,24 +48,6 @@ def mock_classifier():
     )
     classifier.classify_sender.return_value = (SenderType.PERSON, "PERSON", "")
     return classifier
-
-
-@pytest.fixture
-def mock_label_manager():
-    mgr = AsyncMock()
-    # get_existing_priority is synchronous — use MagicMock so it returns a value, not a coroutine
-    mgr.get_existing_priority = MagicMock(return_value=None)
-    return mgr
-
-
-@pytest.fixture
-def cloud_sem():
-    return asyncio.Semaphore(2)
-
-
-@pytest.fixture
-def local_sem():
-    return asyncio.Semaphore(1)
 
 
 @pytest.fixture

--- a/tests/test_env_example_docs.py
+++ b/tests/test_env_example_docs.py
@@ -1,0 +1,65 @@
+"""Keep .env.example in sync with README-technical's env-var table.
+
+Two decision-free directions (Wave 1 plan, T4):
+(a) every variable the example declares (active or commented) must be
+    documented in the README's Environment Variables table — catches a
+    stale or misspelled example;
+(b) every variable the table marks Required must appear as an *active*
+    (uncommented) line — catches the example losing a var the daemon
+    won't start without.
+
+Deliberately not asserted: that every documented optional/override knob
+appears in the example — what .env.example is *for* (minimal quickstart vs
+exhaustive catalog) is an owner call no test should pre-empt.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+ENV_EXAMPLE_PATH = ROOT / ".env.example"
+README_PATH = ROOT / "README-technical.md"
+
+# A declared var: optionally commented ("# "), then NAME= at line start.
+_DECLARED_VAR = re.compile(r"^#? ?([A-Z_]+)=", re.MULTILINE)
+# An active (uncommented) var line.
+_ACTIVE_VAR = re.compile(r"^([A-Z_]+)=", re.MULTILINE)
+# A table row marked Required: | `VAR` | Yes | ...
+_REQUIRED_ROW = re.compile(r"\| `(\w+)` \| Yes \|")
+
+
+def _env_vars_section(readme_text: str) -> str:
+    match = re.search(r"## Environment Variables.*?(?=\n## |\Z)", readme_text, re.DOTALL)
+    return match.group(0) if match else ""
+
+
+def test_env_example_vars_are_documented(subtests):
+    example_text = ENV_EXAMPLE_PATH.read_text()
+    env_section = _env_vars_section(README_PATH.read_text())
+    declared = set(_DECLARED_VAR.findall(example_text))
+
+    assert declared, "No variables found in .env.example — parse may be broken"
+    assert env_section, "No '## Environment Variables' section found in README"
+
+    for var in sorted(declared):
+        with subtests.test(var=var):
+            assert f"`{var}`" in env_section, (
+                f"`{var}` is declared in .env.example but not documented in "
+                f"README-technical's Environment Variables table"
+            )
+
+
+def test_required_vars_present_and_active(subtests):
+    example_text = ENV_EXAMPLE_PATH.read_text()
+    env_section = _env_vars_section(README_PATH.read_text())
+    required = set(_REQUIRED_ROW.findall(env_section))
+    active = set(_ACTIVE_VAR.findall(example_text))
+
+    assert required, "No Required rows found in the env table — parse may be broken"
+
+    for var in sorted(required):
+        with subtests.test(var=var):
+            assert var in active, (
+                f"`{var}` is marked Required in README-technical's env table "
+                f"but has no active (uncommented) line in .env.example"
+            )

--- a/tests/test_env_example_docs.py
+++ b/tests/test_env_example_docs.py
@@ -1,9 +1,9 @@
 """Keep .env.example in sync with README-technical's env-var table.
 
 Two decision-free directions (Wave 1 plan, T4):
-(a) every variable the example declares (active or commented) must be
-    documented in the README's Environment Variables table — catches a
-    stale or misspelled example;
+(a) every variable the example declares (active or commented) must have a
+    row in the README's Environment Variables table — catches a stale or
+    misspelled example;
 (b) every variable the table marks Required must appear as an *active*
     (uncommented) line — catches the example losing a var the daemon
     won't start without.
@@ -16,42 +16,45 @@ exhaustive catalog) is an owner call no test should pre-empt.
 import re
 from pathlib import Path
 
+from tests.test_env_var_docs import _get_env_vars_section
+
 ROOT = Path(__file__).parent.parent
 ENV_EXAMPLE_PATH = ROOT / ".env.example"
 README_PATH = ROOT / "README-technical.md"
 
-# A declared var: optionally commented ("# "), then NAME= at line start.
-_DECLARED_VAR = re.compile(r"^#? ?([A-Z_]+)=", re.MULTILINE)
+# A declared var: optional indentation, optionally commented, then NAME=.
+# [A-Z0-9_] (not \w) everywhere: env var names here are upper snake case,
+# and one character class across all four regexes keeps digit-bearing names
+# (OAUTH2_...) from being parsed inconsistently.
+_DECLARED_VAR = re.compile(r"^\s*#?\s*([A-Z0-9_]+)=", re.MULTILINE)
 # An active (uncommented) var line.
-_ACTIVE_VAR = re.compile(r"^([A-Z_]+)=", re.MULTILINE)
+_ACTIVE_VAR = re.compile(r"^\s*([A-Z0-9_]+)=", re.MULTILINE)
+# Any table row for a var: | `VAR` | ... (whitespace-tolerant cell padding).
+_TABLE_ROW = re.compile(r"^\|\s*`([A-Z0-9_]+)`\s*\|", re.MULTILINE)
 # A table row marked Required: | `VAR` | Yes | ...
-_REQUIRED_ROW = re.compile(r"\| `(\w+)` \| Yes \|")
-
-
-def _env_vars_section(readme_text: str) -> str:
-    match = re.search(r"## Environment Variables.*?(?=\n## |\Z)", readme_text, re.DOTALL)
-    return match.group(0) if match else ""
+_REQUIRED_ROW = re.compile(r"^\|\s*`([A-Z0-9_]+)`\s*\|\s*Yes\s*\|", re.MULTILINE)
 
 
 def test_env_example_vars_are_documented(subtests):
     example_text = ENV_EXAMPLE_PATH.read_text()
-    env_section = _env_vars_section(README_PATH.read_text())
+    env_section = _get_env_vars_section(README_PATH.read_text())
     declared = set(_DECLARED_VAR.findall(example_text))
+    documented = set(_TABLE_ROW.findall(env_section))
 
     assert declared, "No variables found in .env.example — parse may be broken"
-    assert env_section, "No '## Environment Variables' section found in README"
+    assert documented, "No table rows found in the env table — parse may be broken"
 
     for var in sorted(declared):
         with subtests.test(var=var):
-            assert f"`{var}`" in env_section, (
-                f"`{var}` is declared in .env.example but not documented in "
+            assert var in documented, (
+                f"`{var}` is declared in .env.example but has no row in "
                 f"README-technical's Environment Variables table"
             )
 
 
 def test_required_vars_present_and_active(subtests):
     example_text = ENV_EXAMPLE_PATH.read_text()
-    env_section = _env_vars_section(README_PATH.read_text())
+    env_section = _get_env_vars_section(README_PATH.read_text())
     required = set(_REQUIRED_ROW.findall(env_section))
     active = set(_ACTIVE_VAR.findall(example_text))
 

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -1029,11 +1029,22 @@ class TestReviewAppReviewFindings:
 
 
 def _dated_records():
-    """Records with distinct fixed send-dates (all in 2024) for sort/date tests."""
+    """Records with distinct fixed send-dates (all in 2024) for sort/date tests.
+
+    Instants are local midday converted to UTC; rendering converts back in
+    the same process timezone, an identity round-trip, so each record shows
+    the authored local date in every timezone (issue #67). Midday also keeps
+    the UTC calendar date within a day of the authored date, clear of the
+    date filter's mid-month cutoffs.
+    """
+
+    def utc_iso(y, m, d):
+        return datetime(y, m, d, 12, 0).astimezone(timezone.utc).isoformat()
+
     return [
-        _make_record(subject="Jan", send_date="2024-01-10T00:00:00+00:00"),
-        _make_record(subject="Mar", send_date="2024-03-10T00:00:00+00:00"),
-        _make_record(subject="Feb", send_date="2024-02-10T00:00:00+00:00"),
+        _make_record(subject="Jan", send_date=utc_iso(2024, 1, 10)),
+        _make_record(subject="Mar", send_date=utc_iso(2024, 3, 10)),
+        _make_record(subject="Feb", send_date=utc_iso(2024, 2, 10)),
     ]
 
 

--- a/tests/test_newsletter_review.py
+++ b/tests/test_newsletter_review.py
@@ -26,6 +26,13 @@ from newsletter_review.tui import (
 )
 
 
+def _local_midday_utc_iso(y, m, d):
+    """Local midday converted to UTC; rendering converts back in the same
+    process timezone, an identity round-trip, so the record shows the
+    authored local date in every timezone (issue #67)."""
+    return datetime(y, m, d, 12, 0).astimezone(timezone.utc).isoformat()
+
+
 @contextmanager
 def _use_tz(name: str):
     """Run the body under a fixed local timezone (Linux ``tzset``), restoring the
@@ -268,9 +275,9 @@ class TestApplyFilters:
     def test_since_filter_keeps_on_or_after_cutoff(self):
         # Issue #36: date filter on the send-date, inclusive of the boundary.
         records = [
-            _make_record(thread_id="old", send_date="2024-01-01T00:00:00+00:00"),
-            _make_record(thread_id="edge", send_date="2024-06-15T09:00:00+00:00"),
-            _make_record(thread_id="new", send_date="2024-12-31T00:00:00+00:00"),
+            _make_record(thread_id="old", send_date=_local_midday_utc_iso(2024, 1, 1)),
+            _make_record(thread_id="edge", send_date=_local_midday_utc_iso(2024, 6, 15)),
+            _make_record(thread_id="new", send_date=_local_midday_utc_iso(2024, 12, 31)),
         ]
         result = apply_filters(records, since="2024-06-15")
         assert {r["thread_id"] for r in result} == {"edge", "new"}
@@ -371,7 +378,7 @@ class TestFormatListRow:
 
     def test_includes_send_date(self):
         # Issue #36: the list date column shows the email SEND date (date part).
-        row = format_list_row(_make_record(send_date="2026-02-19T09:00:00+00:00"), 120)
+        row = format_list_row(_make_record(send_date=_local_midday_utc_iso(2026, 2, 19)), 120)
         assert "2026-02-19" in row
 
     def test_missing_send_date_shows_placeholder(self):
@@ -650,8 +657,8 @@ class TestFormatSourceLine:
     def test_names_the_resolved_path_and_newest_send_date(self, tmp_path):
         f = tmp_path / "data" / "newsletter_assessments.jsonl"
         line = format_source_line(f, [
-            _make_record(thread_id="a", send_date="2026-07-11T09:00:00+00:00"),
-            _make_record(thread_id="b", send_date="2026-07-29T09:00:00+00:00"),
+            _make_record(thread_id="a", send_date=_local_midday_utc_iso(2026, 7, 11)),
+            _make_record(thread_id="b", send_date=_local_midday_utc_iso(2026, 7, 29)),
         ])
         assert str(f.resolve()) in line
         assert "2 newsletters" in line
@@ -1031,20 +1038,14 @@ class TestReviewAppReviewFindings:
 def _dated_records():
     """Records with distinct fixed send-dates (all in 2024) for sort/date tests.
 
-    Instants are local midday converted to UTC; rendering converts back in
-    the same process timezone, an identity round-trip, so each record shows
-    the authored local date in every timezone (issue #67). Midday also keeps
-    the UTC calendar date within a day of the authored date, clear of the
-    date filter's mid-month cutoffs.
+    Local-midday instants (see _local_midday_utc_iso) keep each record's
+    rendered date equal to the authored date in every timezone, and clear of
+    the date filter's mid-month cutoffs.
     """
-
-    def utc_iso(y, m, d):
-        return datetime(y, m, d, 12, 0).astimezone(timezone.utc).isoformat()
-
     return [
-        _make_record(subject="Jan", send_date=utc_iso(2024, 1, 10)),
-        _make_record(subject="Mar", send_date=utc_iso(2024, 3, 10)),
-        _make_record(subject="Feb", send_date=utc_iso(2024, 2, 10)),
+        _make_record(subject="Jan", send_date=_local_midday_utc_iso(2024, 1, 10)),
+        _make_record(subject="Mar", send_date=_local_midday_utc_iso(2024, 3, 10)),
+        _make_record(subject="Feb", send_date=_local_midday_utc_iso(2024, 2, 10)),
     ]
 
 

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,384 @@
+"""Negative-form privacy tests (registry D2, D3 — docs/decisions.md).
+
+The guarantee under test, stated honestly (D2): bodies of threads
+*classified as* person are processed only by the local LLM; before routing,
+the cloud sees only sender/subject/snippet. Stage 1 routes on metadata and
+can be wrong, and unparseable Stage 1 output deliberately defaults to
+SERVICE (availability first) — that default is pinned here, not "fixed".
+
+The snippet is Gmail's body-derived preview of the latest message
+(daemon.py builds it from the message's own ``snippet`` field), so these
+tests never assert "no body text reaches the cloud"; they assert nothing
+*beyond* sender/subject/snippet does. Every fixture body carries two
+sentinel markers — one inside the first ~100 characters, one after several
+hundred characters of filler — so truncated leaks (a ``body[:200]``-style
+interpolation) and full-body leaks are both caught. The fixture snippet
+contains neither marker.
+"""
+
+import asyncio
+import base64
+from dataclasses import fields
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from classifier import EmailClassifier, EmailMetadata, SenderType, ThreadMetadata
+from daemon import process_single_thread
+from llm_client import LLMUnavailableError
+
+EARLY_MARKER = "EARLY-BODY-MARKER-3c9d"
+LATE_MARKER = "LATE-BODY-MARKER-7f3a"
+MARKERS = (EARLY_MARKER, LATE_MARKER)
+SNIPPET_TEXT = "Preview text containing neither marker"
+FILLER = "filler words to push the late marker well past snippet range " * 8
+
+
+def _body(salutation: str) -> str:
+    """A body with an early marker (first ~100 chars) and a late one."""
+    return f"{EARLY_MARKER} {salutation}\n{FILLER}\n{LATE_MARKER} regards"
+
+
+def _calls_leaking_markers(mock_llm: AsyncMock) -> list:
+    """Every complete() call on the mock whose args or kwargs carry a marker."""
+    leaks = []
+    for call in mock_llm.complete.call_args_list:
+        blob = " ".join(str(a) for a in call.args) + " " + " ".join(
+            str(v) for v in call.kwargs.values()
+        )
+        if any(marker in blob for marker in MARKERS):
+            leaks.append(call)
+    return leaks
+
+
+CONFIG = {
+    "prompts": {
+        "sender_classification": {
+            "system": "Classify as PERSON or SERVICE.",
+            "user_template": "From: {sender}\nSubject: {subject}\nPreview: {snippet}",
+        },
+        "email_classification": {
+            "preamble": "Classify the email into one category:",
+            "postamble": "Think carefully.",
+            "user_template": "From: {sender}\nSubject: {subject}\nThread transcript:\n{body}",
+            "categories": {
+                "NEEDS_RESPONSE": "Requires a reply.",
+                "FYI": "Informational, no action needed.",
+                "LOW_PRIORITY": "Low importance or unwanted.",
+            },
+        },
+    },
+    "vip_senders": {
+        "categories": ["NEEDS_RESPONSE", "FYI"],
+    },
+}
+
+
+@pytest.fixture
+def mock_cloud_llm():
+    llm = AsyncMock()
+    llm.complete.return_value = ("SERVICE", "")  # every mock configured (tuple contract)
+    return llm
+
+
+@pytest.fixture
+def mock_local_llm():
+    llm = AsyncMock()
+    llm.complete.return_value = ("FYI", "")  # every mock configured (tuple contract)
+    return llm
+
+
+@pytest.fixture
+def classifier(mock_cloud_llm, mock_local_llm):
+    with patch.dict("os.environ", {"VIP_SENDERS": "vip@example.com"}):
+        return EmailClassifier(cloud_llm=mock_cloud_llm, local_llm=mock_local_llm, config=CONFIG)
+
+
+@pytest.fixture
+def mock_proxy():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_label_manager():
+    mgr = AsyncMock()
+    mgr.get_existing_priority = MagicMock(return_value=None)
+    return mgr
+
+
+@pytest.fixture
+def cloud_sem():
+    return asyncio.Semaphore(2)
+
+
+@pytest.fixture
+def local_sem():
+    return asyncio.Semaphore(1)
+
+
+def _message(msg_id: str, sender: str, subject: str, body: str, date: str, to: str = "") -> dict:
+    headers = [
+        {"name": "From", "value": sender},
+        {"name": "Subject", "value": subject},
+        {"name": "Date", "value": date},
+    ]
+    if to:
+        headers.append({"name": "To", "value": to})
+    return {
+        "id": msg_id,
+        "threadId": "thread_privacy",
+        "internalDate": "1704067200000" if msg_id.endswith("1") else "1704070800000",
+        "labelIds": ["INBOX"],
+        "payload": {
+            "headers": headers,
+            "body": {"data": base64.urlsafe_b64encode(body.encode()).decode()},
+        },
+    }
+
+
+def _thread_dict(senders: list[str], to: str = "") -> dict:
+    """Two-message thread; marker-bearing bodies; snippet on the latest message."""
+    messages = [
+        _message("msg_1", senders[0], "Quarterly update", _body("hello"),
+                 "Mon, 1 Jan 2024 12:00:00 +0000", to=to),
+        _message("msg_2", senders[-1], "Re: Quarterly update", _body("thanks"),
+                 "Mon, 1 Jan 2024 13:00:00 +0000", to=to),
+    ]
+    messages[-1]["snippet"] = SNIPPET_TEXT  # daemon reads the latest message's snippet
+    return {"id": "thread_privacy", "messages": messages}
+
+
+# ── Person routing: bodies of threads classified as person stay local ────
+
+
+class TestPersonRouting:
+    async def test_person_thread_body_reaches_only_local_llm(
+        self, classifier, mock_cloud_llm, mock_local_llm
+    ):
+        """Classifier level: a person-classified body goes to the local tier only."""
+        metadata = ThreadMetadata(
+            thread_id="t1",
+            senders=["Alice Example <alice@example.com>"],
+            subject="Quarterly update",
+            snippet=SNIPPET_TEXT,
+        )
+        mock_cloud_llm.complete.side_effect = [("PERSON", "sender cot")]
+        mock_local_llm.complete.return_value = ("NEEDS_RESPONSE", "label cot")
+
+        result = await classifier.classify(metadata, _body("hello"))
+
+        assert result.sender_type == SenderType.PERSON
+        local_user = mock_local_llm.complete.call_args.args[1]
+        assert all(marker in local_user for marker in MARKERS)
+        assert _calls_leaking_markers(mock_cloud_llm) == []
+
+    async def test_person_thread_end_to_end_daemon(
+        self, mock_cloud_llm, mock_local_llm, classifier,
+        mock_proxy, mock_label_manager, cloud_sem, local_sem,
+    ):
+        """Daemon level: real classifier through process_single_thread.
+
+        Each Stage 1 cloud call is checked by whole-call equality — system
+        string, rendered user_template, kwargs — so a widening of the
+        pre-routing cloud payload in any slot fails, not just one carrying
+        the sentinels.
+        """
+        senders = ["Notification Bot <bot@example.com>", "Alice Example <alice@example.com>"]
+        mock_proxy.get_thread.return_value = _thread_dict(senders)
+        # First sender parses SERVICE, second PERSON (exercises the loop + short-circuit).
+        mock_cloud_llm.complete.side_effect = [("SERVICE", ""), ("PERSON", "cot")]
+        mock_local_llm.complete.return_value = ("NEEDS_RESPONSE", "")
+
+        result = await process_single_thread(
+            "thread_privacy",
+            ["msg_1", "msg_2"],
+            mock_proxy,
+            classifier,
+            mock_label_manager,
+            cloud_sem,
+            local_sem,
+            max_thread_chars=50000,
+        )
+
+        assert result is True
+        sender_cfg = CONFIG["prompts"]["sender_classification"]
+        assert mock_cloud_llm.complete.call_count == 2
+        for call, sender in zip(mock_cloud_llm.complete.call_args_list, senders):
+            assert call.args[0] == sender_cfg["system"]
+            assert call.args[1] == sender_cfg["user_template"].format(
+                sender=sender, subject="Quarterly update", snippet=SNIPPET_TEXT
+            )
+            assert call.kwargs == {"include_thinking": True}
+        local_user = mock_local_llm.complete.call_args.args[1]
+        assert all(marker in local_user for marker in MARKERS)
+        assert _calls_leaking_markers(mock_cloud_llm) == []
+        mock_label_manager.apply_classification.assert_called_once()
+
+    async def test_person_thread_local_failure_never_falls_back_to_cloud(
+        self, mock_cloud_llm, mock_local_llm, classifier,
+        mock_proxy, mock_label_manager, cloud_sem, local_sem,
+    ):
+        """A local-tier outage defers the thread; it must not reroute the body
+        to the cloud (the most plausible D2 regression: a well-meaning
+        resilience fallback)."""
+        mock_proxy.get_thread.return_value = _thread_dict(
+            ["Alice Example <alice@example.com>", "Alice Example <alice@example.com>"]
+        )
+        # Second element exists only so a mutated cloud-fallback path has
+        # something to consume — the unmutated flow never reaches it.
+        mock_cloud_llm.complete.side_effect = [("PERSON", "cot"), ("FYI", "")]
+        mock_local_llm.complete.side_effect = LLMUnavailableError("local LLM down")
+
+        result = await process_single_thread(
+            "thread_privacy",
+            ["msg_1", "msg_2"],
+            mock_proxy,
+            classifier,
+            mock_label_manager,
+            cloud_sem,
+            local_sem,
+            max_thread_chars=50000,
+        )
+
+        assert _calls_leaking_markers(mock_cloud_llm) == []
+        assert result is False
+        mock_label_manager.apply_classification.assert_not_called()
+        mock_label_manager.mark_processed.assert_not_called()
+
+
+# ── Service routing: the honest other arm of the tier split ──────────────
+
+
+class TestServiceRouting:
+    async def test_service_thread_body_goes_to_cloud_and_local_unused(
+        self, classifier, mock_cloud_llm, mock_local_llm
+    ):
+        """Service-classified bodies go to the cloud by design (D2 states the
+        guarantee for person-classified threads only); the local tier is not
+        involved."""
+        metadata = ThreadMetadata(
+            thread_id="t2",
+            senders=["Shop Notifications <noreply@shop.example>"],
+            subject="Your order",
+            snippet=SNIPPET_TEXT,
+        )
+        mock_cloud_llm.complete.side_effect = [("SERVICE", ""), ("LOW_PRIORITY", "")]
+        mock_local_llm.complete.return_value = ("FYI", "")  # configured, must stay unused
+
+        result = await classifier.classify(metadata, _body("your order"))
+
+        assert result.sender_type == SenderType.SERVICE
+        assert mock_local_llm.complete.call_count == 0
+        stage2_user = mock_cloud_llm.complete.call_args_list[1].args[1]
+        assert all(marker in stage2_user for marker in MARKERS)
+
+    async def test_unparseable_stage1_defaults_to_service_route(
+        self, classifier, mock_cloud_llm, mock_local_llm
+    ):
+        """Pins the adjudicated D2 default: keywordless Stage 1 output routes
+        as SERVICE (availability first). Do not "fix" this to PERSON — D2
+        forecloses that; the residual misroute risk is measured by the eval
+        suite's privacy-violation rate, not denied."""
+        metadata = ThreadMetadata(
+            thread_id="t3",
+            senders=["Ambiguous <someone@example.com>"],
+            subject="Hello",
+            snippet=SNIPPET_TEXT,
+        )
+        mock_cloud_llm.complete.side_effect = [
+            ("I think this may be a human being", ""),
+            ("FYI", ""),
+        ]
+        mock_local_llm.complete.return_value = ("FYI", "")  # configured, must stay unused
+
+        result = await classifier.classify(metadata, _body("hello"))
+
+        assert result.sender_type == SenderType.SERVICE
+        assert mock_local_llm.complete.call_count == 0
+
+
+# ── VIP short-circuit: no cloud involvement at all ───────────────────────
+
+
+class TestVipRouting:
+    async def test_vip_sender_skips_cloud_entirely(
+        self, classifier, mock_cloud_llm, mock_local_llm
+    ):
+        """A VIP sender is PERSON without a Stage 1 call: zero cloud calls,
+        body only on the local tier."""
+        metadata = ThreadMetadata(
+            thread_id="t4",
+            senders=["VIP Person <vip@example.com>"],
+            subject="Catching up",
+            snippet=SNIPPET_TEXT,
+        )
+        mock_cloud_llm.complete.return_value = ("SERVICE", "")  # configured, must stay unused
+        mock_local_llm.complete.return_value = ("NEEDS_RESPONSE", "")
+
+        result = await classifier.classify(metadata, _body("hi"))
+
+        assert result.sender_type == SenderType.PERSON
+        assert mock_cloud_llm.complete.call_count == 0
+        local_user = mock_local_llm.complete.call_args.args[1]
+        assert all(marker in local_user for marker in MARKERS)
+
+
+# ── Newsletter ownership (D3): cloud by design, before person/service ────
+
+
+class TestNewsletterOwnership:
+    async def test_newsletter_thread_bypasses_stage1_and_local(
+        self, mock_cloud_llm, mock_local_llm, classifier,
+        mock_proxy, mock_label_manager, cloud_sem, local_sem,
+    ):
+        """A thread To-addressed to the newsletter recipient is organizational
+        content (D3): its full transcript — person-written replies included —
+        goes to the newsletter pipeline's cloud client by design, and the
+        email pipeline (Stage 1, local tier) is never involved.
+
+        The fixture address exactly equals the recipient so this test is
+        unaffected by Wave 2's D3 exact-address matching change."""
+        recipient = "newsletters@example.org"
+        mock_proxy.get_thread.return_value = _thread_dict(
+            ["Alice Example <alice@example.com>", "Bob Staff <bob@example.org>"],
+            to=recipient,
+        )
+        newsletter_classifier = AsyncMock()
+        newsletter_classifier.classify_newsletter.return_value = []
+
+        result = await process_single_thread(
+            "thread_privacy",
+            ["msg_1", "msg_2"],
+            mock_proxy,
+            classifier,
+            mock_label_manager,
+            cloud_sem,
+            local_sem,
+            max_thread_chars=50000,
+            newsletter_classifier=newsletter_classifier,
+            newsletter_recipient=recipient,
+        )
+
+        assert result is True
+        assert mock_cloud_llm.complete.call_count == 0
+        assert mock_local_llm.complete.call_count == 0
+        transcript = newsletter_classifier.classify_newsletter.call_args.args[0]
+        assert all(marker in transcript for marker in MARKERS)
+
+
+# ── Metadata shape guard: the pre-routing cloud payload cannot grow ──────
+
+
+class TestMetadataShape:
+    def test_metadata_shapes_cannot_carry_bodies(self):
+        """Body text travels only as the explicit ``body`` argument of
+        classify()/classify_email(); the metadata objects Stage 1 sees hold
+        exactly sender/subject/snippet identity fields. Growing either class
+        is a privacy-review event, and a body-carrying field is foreclosed
+        (D2) — update this allowlist only with a registry-aware review."""
+        assert {f.name for f in fields(ThreadMetadata)} == {
+            "thread_id", "senders", "subject", "snippet",
+        }
+        assert {f.name for f in fields(EmailMetadata)} == {
+            "message_id", "sender", "subject", "snippet",
+        }

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -16,16 +16,15 @@ interpolation) and full-body leaks are both caught. The fixture snippet
 contains neither marker.
 """
 
-import asyncio
 import base64
 from dataclasses import fields
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from classifier import EmailClassifier, EmailMetadata, SenderType, ThreadMetadata
 from daemon import process_single_thread
-from llm_client import LLMUnavailableError
+from llm_client import LLMClient, LLMUnavailableError
 
 EARLY_MARKER = "EARLY-BODY-MARKER-3c9d"
 LATE_MARKER = "LATE-BODY-MARKER-7f3a"
@@ -40,11 +39,16 @@ def _body(salutation: str) -> str:
 
 
 def _calls_leaking_markers(mock_llm: AsyncMock) -> list:
-    """Every complete() call on the mock whose args or kwargs carry a marker."""
+    """Every call on the mock — any method — whose args or kwargs carry a marker.
+
+    Sweeps mock_calls rather than complete.call_args_list so content routed
+    through a renamed or added client method is still caught; the spec'd
+    fixtures reject methods LLMClient doesn't have."""
     leaks = []
-    for call in mock_llm.complete.call_args_list:
-        blob = " ".join(str(a) for a in call.args) + " " + " ".join(
-            str(v) for v in call.kwargs.values()
+    for call in mock_llm.mock_calls:
+        _name, args, kwargs = call
+        blob = " ".join(str(a) for a in args) + " " + " ".join(
+            str(v) for v in kwargs.values()
         )
         if any(marker in blob for marker in MARKERS):
             leaks.append(call)
@@ -76,14 +80,14 @@ CONFIG = {
 
 @pytest.fixture
 def mock_cloud_llm():
-    llm = AsyncMock()
+    llm = AsyncMock(spec=LLMClient)
     llm.complete.return_value = ("SERVICE", "")  # every mock configured (tuple contract)
     return llm
 
 
 @pytest.fixture
 def mock_local_llm():
-    llm = AsyncMock()
+    llm = AsyncMock(spec=LLMClient)
     llm.complete.return_value = ("FYI", "")  # every mock configured (tuple contract)
     return llm
 
@@ -94,40 +98,20 @@ def classifier(mock_cloud_llm, mock_local_llm):
         return EmailClassifier(cloud_llm=mock_cloud_llm, local_llm=mock_local_llm, config=CONFIG)
 
 
-@pytest.fixture
-def mock_proxy():
-    return AsyncMock()
-
-
-@pytest.fixture
-def mock_label_manager():
-    mgr = AsyncMock()
-    mgr.get_existing_priority = MagicMock(return_value=None)
-    return mgr
-
-
-@pytest.fixture
-def cloud_sem():
-    return asyncio.Semaphore(2)
-
-
-@pytest.fixture
-def local_sem():
-    return asyncio.Semaphore(1)
-
-
-def _message(msg_id: str, sender: str, subject: str, body: str, date: str, to: str = "") -> dict:
+def _message(
+    msg_id: str, sender: str, subject: str, body: str, internal_date: str, to: str = ""
+) -> dict:
     headers = [
         {"name": "From", "value": sender},
         {"name": "Subject", "value": subject},
-        {"name": "Date", "value": date},
+        {"name": "Date", "value": "Mon, 1 Jan 2024 12:00:00 +0000"},
     ]
     if to:
         headers.append({"name": "To", "value": to})
     return {
         "id": msg_id,
         "threadId": "thread_privacy",
-        "internalDate": "1704067200000" if msg_id.endswith("1") else "1704070800000",
+        "internalDate": internal_date,
         "labelIds": ["INBOX"],
         "payload": {
             "headers": headers,
@@ -137,12 +121,17 @@ def _message(msg_id: str, sender: str, subject: str, body: str, date: str, to: s
 
 
 def _thread_dict(senders: list[str], to: str = "") -> dict:
-    """Two-message thread; marker-bearing bodies; snippet on the latest message."""
+    """One marker-bearing message per sender; snippet on the latest message."""
     messages = [
-        _message("msg_1", senders[0], "Quarterly update", _body("hello"),
-                 "Mon, 1 Jan 2024 12:00:00 +0000", to=to),
-        _message("msg_2", senders[-1], "Re: Quarterly update", _body("thanks"),
-                 "Mon, 1 Jan 2024 13:00:00 +0000", to=to),
+        _message(
+            f"msg_{i}",
+            sender,
+            "Quarterly update" if i == 1 else "Re: Quarterly update",
+            _body("hello" if i == 1 else "thanks"),
+            internal_date=str(1704067200000 + i * 3_600_000),
+            to=to,
+        )
+        for i, sender in enumerate(senders, start=1)
     ]
     messages[-1]["snippet"] = SNIPPET_TEXT  # daemon reads the latest message's snippet
     return {"id": "thread_privacy", "messages": messages}
@@ -183,15 +172,21 @@ class TestPersonRouting:
         pre-routing cloud payload in any slot fails, not just one carrying
         the sentinels.
         """
-        senders = ["Notification Bot <bot@example.com>", "Alice Example <alice@example.com>"]
+        senders = [
+            "Notification Bot <bot@example.com>",
+            "Alice Example <alice@example.com>",
+            "Carol Example <carol@example.com>",
+        ]
         mock_proxy.get_thread.return_value = _thread_dict(senders)
-        # First sender parses SERVICE, second PERSON (exercises the loop + short-circuit).
+        # First sender parses SERVICE, second PERSON; the third sender existing
+        # makes the short-circuit observable — dropping the early return would
+        # issue a third Stage 1 call and fail the call_count pin below.
         mock_cloud_llm.complete.side_effect = [("SERVICE", ""), ("PERSON", "cot")]
         mock_local_llm.complete.return_value = ("NEEDS_RESPONSE", "")
 
         result = await process_single_thread(
             "thread_privacy",
-            ["msg_1", "msg_2"],
+            ["msg_1", "msg_2", "msg_3"],
             mock_proxy,
             classifier,
             mock_label_manager,
@@ -202,8 +197,9 @@ class TestPersonRouting:
 
         assert result is True
         sender_cfg = CONFIG["prompts"]["sender_classification"]
-        assert mock_cloud_llm.complete.call_count == 2
-        for call, sender in zip(mock_cloud_llm.complete.call_args_list, senders):
+        assert mock_cloud_llm.complete.call_count == 2  # short-circuit: carol never classified
+        for call, sender in zip(mock_cloud_llm.complete.call_args_list, senders[:2]):
+            assert len(call.args) == 2  # arity pin: no widening via new positional slots
             assert call.args[0] == sender_cfg["system"]
             assert call.args[1] == sender_cfg["user_template"].format(
                 sender=sender, subject="Quarterly update", snippet=SNIPPET_TEXT
@@ -227,7 +223,7 @@ class TestPersonRouting:
         # Second element exists only so a mutated cloud-fallback path has
         # something to consume — the unmutated flow never reaches it.
         mock_cloud_llm.complete.side_effect = [("PERSON", "cot"), ("FYI", "")]
-        mock_local_llm.complete.side_effect = LLMUnavailableError("local LLM down")
+        mock_local_llm.complete.side_effect = LLMUnavailableError("local LLM down", tier="local")
 
         result = await process_single_thread(
             "thread_privacy",
@@ -268,7 +264,7 @@ class TestServiceRouting:
         result = await classifier.classify(metadata, _body("your order"))
 
         assert result.sender_type == SenderType.SERVICE
-        assert mock_local_llm.complete.call_count == 0
+        assert mock_local_llm.mock_calls == []
         stage2_user = mock_cloud_llm.complete.call_args_list[1].args[1]
         assert all(marker in stage2_user for marker in MARKERS)
 
@@ -294,7 +290,7 @@ class TestServiceRouting:
         result = await classifier.classify(metadata, _body("hello"))
 
         assert result.sender_type == SenderType.SERVICE
-        assert mock_local_llm.complete.call_count == 0
+        assert mock_local_llm.mock_calls == []
 
 
 # ── VIP short-circuit: no cloud involvement at all ───────────────────────
@@ -318,7 +314,7 @@ class TestVipRouting:
         result = await classifier.classify(metadata, _body("hi"))
 
         assert result.sender_type == SenderType.PERSON
-        assert mock_cloud_llm.complete.call_count == 0
+        assert mock_cloud_llm.mock_calls == []
         local_user = mock_local_llm.complete.call_args.args[1]
         assert all(marker in local_user for marker in MARKERS)
 
@@ -360,8 +356,8 @@ class TestNewsletterOwnership:
         )
 
         assert result is True
-        assert mock_cloud_llm.complete.call_count == 0
-        assert mock_local_llm.complete.call_count == 0
+        assert mock_cloud_llm.mock_calls == []
+        assert mock_local_llm.mock_calls == []
         transcript = newsletter_classifier.classify_newsletter.call_args.args[0]
         assert all(marker in transcript for marker in MARKERS)
 


### PR DESCRIPTION
Executes the approved Wave 1 plan (`docs/plans/2026-07-30-wave1-enforcement.md`, status now `executed`; owner approved including the optional T4).

- **T1** — #67: timezone-proof `_dated_records` (local-midday instants); suite green under UTC, America/New_York, and Asia/Tokyo. Closes #67.
- **T2** — `tests/test_privacy.py`: eight D2/D3 negative-form tests, each mutation-proven (M1–M8, log in the plan's execution record); D2 status → test-enforced.
- **T3** — `.github/workflows/ci.yml`: uv `--locked` sync, ruff, full mocked suite on PRs and pushes to main; D13 status → implemented. This PR's check run is the acceptance evidence.
- **T4** — `.env.example` ↔ env-table sync guard (M9/M10-proven).
- **T5** — execution record + status flip.

No production `.py` is touched — the diff is tests, CI config, and docs. Mutations used for proofs were transient and verified reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01452zG87bvGs1SgQU13RGgS